### PR TITLE
Makefile cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Vireo_Xcode/VireoEggShell.xcodeproj/xcshareddata/xcschemes/EggShell.xcscheme
 make-it/esh
 target-support/
 dist/
+custom.mak
 
 # Visual Studio Ignores
 Vireo_VS/Debug/*

--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -54,10 +54,16 @@ help:
 #  Vireo has grown as well, so emscripten is getting better if the over all size has shrunk by about 20%
 
 EMCC= emcc
+EM_DBGFLAG = -g4
+EM_OPTFLAG = -Os # -Os -O3
 
-EM_OPTFLAG = -Os # -Os -g4 -O3
-EM_ANALYSIS_OPT_FLAG = -Os
-EM_OPT= $(EM_OPTFLAG) -s NO_EXIT_RUNTIME=1 -fno-exceptions --memory-init-file 0
+ifneq ($(wildcard custom.mak),)
+   include custom.mak
+endif
+
+EM_OPTFLAGS ?= $(EM_OPTFLAG)	# Can be overrided in custom.mak
+EM_ANALYSIS_OPT_FLAG = $(EM_OPTFLAG)
+EM_OPT = $(EM_OPTFLAGS) -s NO_EXIT_RUNTIME=1 -fno-exceptions --memory-init-file 0
 EMFLAGS= -I$(INCDIR) -DkVireoOS_emscripten -DVIREO_LEAN $(EM_OPT)
 EMLIBRARY= --js-library ../source/io/library_canvas2d.js --js-library ../source/io/library_httpClient.js
 EM_WRAP= --pre-js $(CORESOURCEDIR)/vireo.preamble.js --post-js $(CORESOURCEDIR)/vireo.postamble.js 
@@ -93,11 +99,11 @@ AAL_ONLY = 1
 endif
 
 $(OBJS)/%.Embind.bc: $(CORESOURCEDIR)/%.Embind.cpp
-	$(EMCC) $(EMFLAGS) --bind -MD -MF $(patsubst %.bc,%.d,$@) -c -o $@ $<
+	$(EMCC) $(EMFLAGS) --bind -MD -MF $(patsubst %.bc,%.bc.d,$@) -c -o $@ $<
 $(OBJS)/%.bc: $(CORESOURCEDIR)/%.cpp
-	$(EMCC) $(EMFLAGS) -MD -MF $(patsubst %.bc,%.d,$@) -c -o $@ $<
+	$(EMCC) $(EMFLAGS) -MD -MF $(patsubst %.bc,%.bc.d,$@) -c -o $@ $<
 $(OBJS)/%.bc: $(IOSOURCEDIR)/%.cpp
-	$(EMCC) $(EMFLAGS) -MD -MF $(patsubst %.bc,%.d,$@) -c -o $@ $<
+	$(EMCC) $(EMFLAGS) -MD -MF $(patsubst %.bc,%.bc.d,$@) -c -o $@ $<
 
 $(EM_BC_FILES): | $(OBJS)
 $(OBJS):
@@ -115,7 +121,7 @@ $(TARGETDIR)/vireo.js: $(EM_BC_FILES) $(ANALYSIS_LIBRARY) $(CORESOURCEDIR)/vireo
 #$(EMCC) $(EM_OPT) $(EM_BC_FILES) -o vireo.html --compression $(EM_DIR)third_party/lzma.js/lzma-native,$(EM_DIR)third_party/lzma.js/lzma-decoder.js,LZMA.decompress
 #$(EMCC) $(EM_OPT) $(EM_WRAP) $(EM_BC_FILES) -o vireo.js
 
-DEPS := $(EM_BC_FILES:.bc=.d)
+DEPS := $(EM_BC_FILES:.bc=.bc.d)
 
 
 -include $(DEPS)

--- a/make-it/EmMakefile-AAL
+++ b/make-it/EmMakefile-AAL
@@ -125,7 +125,6 @@ EM_BC_FILES = $(OBJS)/VireoMerged.bc\
 	$(OBJS)/Canvas2d.bc\
 	$(OBJS)/HttpClient.bc\
 	$(OBJS)/FileIO.bc\
-	$(OBJS)/Linx.bc\
 	$(OBJS)/Emscripten.bc\
 	$(OBJS)/CEntryPoints.bc\
 	$(OBJS)/AnalysisLibrary.bc
@@ -230,11 +229,11 @@ $(OBJS)/AnalysisLibrary.bc: $(AnalysisComponents)
 
 ifeq (,$(AAL_ONLY))
 $(OBJS)/%.Embind.bc: $(CORESOURCEDIR)/%.Embind.cpp
-	$(EMCC) $(EMFLAGS) --bind -MD -MF $(patsubst %.bc,%.d,$@) -c -o $@ $<
+	$(EMCC) $(EMFLAGS) --bind -MD -MF $(patsubst %.bc,%.bc.d,$@) -c -o $@ $<
 $(OBJS)/%.bc: $(CORESOURCEDIR)/%.cpp
-	$(EMCC) $(EMFLAGS) -MD -MF $(patsubst %.bc,%.d,$@) -c -o $@ $<
+	$(EMCC) $(EMFLAGS) -MD -MF $(patsubst %.bc,%.bc.d,$@) -c -o $@ $<
 $(OBJS)/%.bc: $(IOSOURCEDIR)/%.cpp
-	$(EMCC) $(EMFLAGS) -MD -MF $(patsubst %.bc,%.d,$@) -c -o $@ $<
+	$(EMCC) $(EMFLAGS) -MD -MF $(patsubst %.bc,%.bc.d,$@) -c -o $@ $<
 
 $(EM_BC_FILES): | check_sdk_dir $(OBJS)
 
@@ -251,7 +250,7 @@ vjs:	$(TARGETDIR)/vireo.js
 $(TARGETDIR)/vireo.js: $(EM_BC_FILES)
 	$(EMCC) $(EM_OPT) $(EM_WRAP) $(EMLIBRARY) $(EM_BC_FILES) $(EM_EXPORTS) -o $(TARGETDIR)/vireo.js
  
-DEPS := $(EM_BC_FILES:.bc=.d)
+DEPS := $(EM_BC_FILES:.bc=.bc.d)
 
 -include $(DEPS)
 

--- a/make-it/Makefile
+++ b/make-it/Makefile
@@ -3,8 +3,8 @@
 OBJDIR=./objs
 INCDIR=../source/include
 BIN=../bin
-OUTPUT_EXE=../dist/esh
-
+OUTPUT_DIR=../dist
+OUTPUT_EXE=$(OUTPUT_DIR)/esh
 
 COMMANDLINE = main.cpp
 CORE = VireoMerged.cpp Thread.cpp Timestamp.cpp CEntryPoints.cpp
@@ -87,11 +87,15 @@ endif
 # Add common desktop modules.
 CFLAGS+= -DVIREO_STDIO=1 -DVIREO_FILESYSTEM=1 -DVIREO_FILESYSTEM_DIRLIST=1
 
-.PHONY: install clean v32 v64 lARMv5 help prep
+ifneq ($(wildcard custom.mak),)
+   include custom.mak
+endif
+
+.PHONY: install clean v32 v64 lARMv5 help
 .DEFAULT_GOAL=help
 
-prep:
-	@mkdir -p ../dist
+$(OUTPUT_DIR):
+	@mkdir -p $(OUTPUT_DIR)
 
 install: esh
 	@username=`whoami`; \
@@ -120,8 +124,6 @@ lc:
 
 #========= 32 bit builds host platfrom
 v32:
-	# if ! ( [ -a esh ] && [ `file esh | cut -d ' ' -f 3` == "32-bit" ] ); then make clean; fi;
-	# No need to clean before every build
 	make TARGETARCH=-m32 esh
 	$(STRIP)
 
@@ -133,8 +135,6 @@ v32mini:
 
 #========= 32 bit builds host platfrom
 v64:
-	# if ! ( [ -a esh ] && [ `file esh | cut -d ' ' -f 3` == "64-bit" ] ); then make clean; fi;
-	# No need to clean before every build
 	make TARGETARCH=-m64 esh
 	$(STRIP)
 
@@ -151,7 +151,7 @@ lARMv5:
 	arm-none-linux-gnueabi-strip libvireo.so
 
 #========= Use makefile designed for emscripten builds
-vjs: prep
+vjs: $(OUTPUT_DIR)
 	# Just buid everything
 	make -f EmMakefile vjs
 
@@ -185,8 +185,10 @@ help:
 	@echo '        "make clean simple install DEBUG=1"'
 	@echo ''
 
+esh:	$(OUTPUT_EXE)
+
 # Build the executable with symbols stripped
-esh: $(OBJDIR) $(OBJS) prep
+$(OUTPUT_EXE): $(OBJDIR) $(OBJS) $(OUTPUT_DIR)
 	$(CC) -o $(OUTPUT_EXE) $(TARGETARCH) $(LDFLAGS) $(OBJS) $(LIBS)
 
 libvireo.so: $(OBJDIR) $(COREOBJS) $(IOOBJS) $(COMMANDLINEOBJS)


### PR DESCRIPTION
- Allow optional custom.mak include (.gitignore'd) so debug flags can be overridden locally
  without modifying the makefiles
- Add macro for OUTPUT_DIR=../dist since it's used in more than one place
- Change prep rule target to be the output folder itself, so it doesn't run every time and
  cause the output to be relinked unnecessarily.
- Use .bc.d instead of .d for deps in EmMakefile for vjs, so they don't collide with .d files
  from native target.