### PR TITLE
{Decimal,Hex,Octal,Exponential}StringToNumber polymorphic conversion functions.

### DIFF
--- a/source/core/GenericFunctions.cpp
+++ b/source/core/GenericFunctions.cpp
@@ -741,7 +741,7 @@ InstructionCore* EmitGenericInRangeAndCoerceInstruction(ClumpParseState* pInstru
 		ClumpParseState snippetBuilder(pInstructionBuilder);
 		pInstructionBuilder->BeginEmitSubSnippet(&snippetBuilder, ircOp, snippetArgId);
 		snippetBuilder.EmitInstruction(&LTName, 3, sourceXType, (void*)null, sourceXType, (void*)null, booleanType, (void*)null);
-		
+
 		pInstructionBuilder->EndEmitSubSnippet(&snippetBuilder);
 		pInstructionBuilder->RecordNextHere(&ircOp->_piNext);
 		pInstruction = ircOp;
@@ -941,6 +941,107 @@ VIREO_FUNCTION_SIGNATURET(InRangeAccumulator, InRangeAndCoerceInstructionAggrega
 	_Param(BooleanDest) = true;
     type->CopyData(_ParamPointer(SX), _ParamPointer(SCoerced));
 	return _NextInstruction();
+}
+
+//------------------------------------------------------------
+struct AggregateStrToNumInstruction : public InstructionCore
+{
+    union {
+        _ParamDef(TypedArrayCoreRef, VStr);
+        _ParamDef(AQBlock1*, SStr);
+    };
+    _ParamDef(Int32, Offset);
+    _ParamDef(AQBlock1*, DefaultVal);
+    _ParamDef(Int32, EndOffset);
+    _ParamImmediateDef(StaticTypeAndData, VOutput[1]);
+    _ParamImmediateDef(InstructionCore*, Next);
+    inline InstructionCore* Snippet()   { return this + 1; }
+    inline InstructionCore* Next()      { return this->_piNext; }
+};
+typedef Instruction6<AQBlock1, Int32, AQBlock1, Int32, AQBlock1, AQBlock1> StrToNumInstructionArgs;
+
+VIREO_FUNCTION_SIGNATURET(VectorOrClusterStrToNumOp, AggregateStrToNumInstruction)
+{
+    TypeRef type = _ParamImmediate(VOutput)->_paramType;
+    Boolean isCluster = type->IsCluster();
+    StrToNumInstructionArgs* snippet = (StrToNumInstructionArgs*)_ParamMethod(Snippet());
+    AQBlock1 *beginStr, *beginDest, *endDest;
+    IntIndex elementSizeStr, elementSizeDest, count = 0;
+    if (isCluster) {
+        count = type->SubElementCount();
+        elementSizeStr = sizeof(StringRef);
+        elementSizeDest = _ParamImmediate(VOutput)->_paramType->GetSubElement(0)->TopAQSize(); // VOutput->ElementType()->TopAQSize();
+        beginStr = (AQBlock1*)_ParamPointer(SStr);
+        beginDest = (AQBlock1*)_ParamImmediate(VOutput)->_pData;
+    } else {
+        TypedArrayCoreRef VStr = _Param(VStr);
+        TypedArrayCoreRef VOutput = *(TypedArrayCoreRef*)_ParamImmediate(VOutput)->_pData;
+        elementSizeStr = VStr->ElementType()->TopAQSize();
+        elementSizeDest = _ParamImmediate(VOutput)->_paramType->GetSubElement(0)->TopAQSize(); // VOutput->ElementType()->TopAQSize();
+        count = VStr->Length();
+        VOutput->Resize1D(count);
+        beginStr = VStr->RawBegin();
+        beginDest = VOutput->RawBegin();
+    }
+    endDest = beginDest + (count * elementSizeDest);
+    snippet->_p0 = beginStr;
+    snippet->_p1 = _ParamPointer(Offset);
+    snippet->_p2 = _Param(DefaultVal);
+    snippet->_p3 = _ParamPointer(EndOffset);
+    snippet->_p4 = (AQBlock1*)type->GetSubElement(0);
+    snippet->_p5 = beginDest;
+    while (snippet->_p5 < endDest)
+    {
+        _PROGMEM_PTR(snippet, _function)(snippet);
+        snippet->_p0 += elementSizeStr;
+        snippet->_p5 += elementSizeDest;
+    }
+    return _NextInstruction();
+}
+InstructionCore* EmitGenericStringToNumber(ClumpParseState* pInstructionBuilder)
+{
+    InstructionCore* pInstruction = null;
+    TypeRef sourceStrType = pInstructionBuilder->_argTypes[0];
+    TypeRef outputType = pInstructionBuilder->_argTypes[5];
+    SubString savedOperation = pInstructionBuilder->_instructionPointerType->Name();
+    TypeRef Int32Type = pInstructionBuilder->_clump->TheTypeManager()->FindType(tsInt32Type);
+    TypeRef staticTypeAndDataType = pInstructionBuilder->_clump->TheTypeManager()->FindType("StaticTypeAndData");
+    TypeRef stringType = pInstructionBuilder->_clump->TheTypeManager()->FindType(tsStringType);
+    switch (sourceStrType->BitEncoding()) {
+        case kEncoding_Array:
+        case kEncoding_Cluster:
+        {
+            savedOperation = pInstructionBuilder->_instructionPointerType->Name();
+            ConstCStr pVectorBinOpName = null;
+            pVectorBinOpName = "VectorOrClusterStrToNumOp";
+            SubString vectorBinOpToken(pVectorBinOpName);
+            pInstructionBuilder->ReresolveInstruction(&vectorBinOpToken, false); //build a vector op
+            if (sourceStrType->BitEncoding() != outputType->BitEncoding())
+                return null;
+            TypeRef srcEltType = sourceStrType->GetSubElement(0);
+            if (!srcEltType->CompareType(stringType))
+                return null;;
+            TypeRef outEltType = outputType->GetSubElement(0);
+            Int32 snippetArgId = pInstructionBuilder->AddSubSnippet();
+
+            // Emit the vector op
+            AggregateStrToNumInstruction* vectorBinOp = (AggregateStrToNumInstruction*) pInstructionBuilder->EmitInstruction();
+            pInstruction = vectorBinOp;
+
+            // Recurse on the subtype
+            ClumpParseState snippetBuilder(pInstructionBuilder);
+
+            pInstructionBuilder->BeginEmitSubSnippet(&snippetBuilder, vectorBinOp, snippetArgId);
+            snippetBuilder.EmitInstruction(&savedOperation, 5, srcEltType, (void*)null, Int32Type, (void*)null, outEltType, (void*)null,
+                                           Int32Type, (void*)null, staticTypeAndDataType, (void*)null);
+            pInstructionBuilder->EndEmitSubSnippet(&snippetBuilder);
+            pInstructionBuilder->RecordNextHere(&vectorBinOp->_piNext);
+            break;
+        }
+        default:
+            break;
+    }
+    return pInstruction;
 }
 
 //----------------------------------------------------------------------------
@@ -2092,6 +2193,13 @@ DEFINE_VIREO_BEGIN(Generics)
 	DEFINE_VIREO_FUNCTION(VectorOrScalarInRangeOp, "p(i(Array) i(Array) i(Array) i(Boolean) i(Boolean) o(Array) o(Array) i(Int32) s(Instruction))" )
 	DEFINE_VIREO_FUNCTION(ClusterInRangeOp, "p(i(*) i(*) i(*) i(Boolean) i(Boolean) o(*) o(*) s(Instruction) s(Instruction))");
 	DEFINE_VIREO_FUNCTION(InRangeAccumulator, "p(i(*) i(*) i(*) i(Boolean) i(Boolean) o(*) o(Boolean) s(Instruction))");
+
+    DEFINE_VIREO_FUNCTION(VectorOrClusterStrToNumOp, "p(i(Array) i(Int32) i(*) o(Int32) o(StaticTypeAndData) s(Instruction))" )
+    DEFINE_VIREO_GENERIC(DecimalStringToNumber, "p(i(*) i(Int32) i(*) o(Int32) o(StaticTypeAndData))", EmitGenericStringToNumber);
+    DEFINE_VIREO_GENERIC(HexStringToNumber, "p(i(*) i(Int32) i(*) o(Int32) o(StaticTypeAndData))", EmitGenericStringToNumber);
+    DEFINE_VIREO_GENERIC(OctalStringToNumber, "p(i(*) i(Int32) i(*) o(Int32) o(StaticTypeAndData))", EmitGenericStringToNumber);
+    DEFINE_VIREO_GENERIC(BinaryStringToNumber, "p(i(*) i(Int32) i(*) o(Int32) o(StaticTypeAndData))", EmitGenericStringToNumber);
+    DEFINE_VIREO_GENERIC(ExponentialStringToNumber, "p(i(*) i(Int32) i(*) o(Int32) o(StaticTypeAndData))", EmitGenericStringToNumber);
 
 	DEFINE_VIREO_GENERIC(Search1DArray, "p(i(*) i(*) i(Int32) o(Int32) s(Instruction))", EmitSearchInstruction);
     DEFINE_VIREO_FUNCTION(Search1DArrayInternal, "p(i(Array) i(*) i(Int32) o(Int32) s(Instruction))")

--- a/source/core/GenericFunctions.cpp
+++ b/source/core/GenericFunctions.cpp
@@ -986,7 +986,7 @@ VIREO_FUNCTION_SIGNATURET(VectorOrClusterStrToNumOp, AggregateStrToNumInstructio
     endDest = beginDest + (count * elementSizeDest);
     snippet->_p0 = beginStr;
     snippet->_p1 = _ParamPointer(Offset);
-    snippet->_p2 = _Param(DefaultVal);
+    snippet->_p2 = (AQBlock1*)_ParamPointer(DefaultVal);
     snippet->_p3 = _ParamPointer(EndOffset);
     snippet->_p4 = (AQBlock1*)type->GetSubElement(0);
     snippet->_p5 = beginDest;
@@ -1021,7 +1021,11 @@ InstructionCore* EmitGenericStringToNumber(ClumpParseState* pInstructionBuilder)
             TypeRef srcEltType = sourceStrType->GetSubElement(0);
             if (!srcEltType->CompareType(stringType))
                 return null;;
+            if (!pInstructionBuilder->_argTypes[1]->CompareType(Int32Type) || !pInstructionBuilder->_argTypes[3]->CompareType(Int32Type))
+                return null;;
             TypeRef outEltType = outputType->GetSubElement(0);
+            if (!pInstructionBuilder->_argTypes[2]->CompareType(outEltType))
+                return null;;
             Int32 snippetArgId = pInstructionBuilder->AddSubSnippet();
 
             // Emit the vector op

--- a/source/core/String.cpp
+++ b/source/core/String.cpp
@@ -33,7 +33,7 @@ void String::AppendViaDecoded(SubString* string)
     // Pass one, see how many %XX sequences exist.
     // Utf8 multibyte sequences are copied over byte by byte.
     while(ss.ReadRawChar(&c)) {
-        if (c == '%' && ss.ReadHex(&value)) {
+        if (c == '%' && ss.ReadHex2(&value)) {
             decodedLength  -= 2;
         }
     }
@@ -45,7 +45,7 @@ void String::AppendViaDecoded(SubString* string)
         ss = string;
         Utf8Char* pDest = BeginAt(originalLength);
         while(ss.ReadRawChar(&c)) {
-            if (c == '%' && ss.ReadHex(&value)) {
+            if (c == '%' && ss.ReadHex2(&value)) {
                 *pDest++ = (Utf8Char)value;
             } else {
                 *pDest++ = c;

--- a/source/core/StringUtilities.cpp
+++ b/source/core/StringUtilities.cpp
@@ -681,8 +681,8 @@ Boolean SubString::ReadNameToken(SubString* token)
     return false;
 }
 //---------------------------------------------------
-//! Read n hex characters. Balk if there are not that many
-Boolean SubString::ReadHex(Int32 *pValue)
+//! Read 2 hex characters. Balk if there are not that many
+Boolean SubString::ReadHex2(Int32 *pValue)
 {
     if (Length() >= 2) {
         Int32 d1 = DigitValue(*_begin, 16);
@@ -694,6 +694,31 @@ Boolean SubString::ReadHex(Int32 *pValue)
         }
     }
     return false;
+}
+//---------------------------------------------------
+//! Read 2 hex characters. Balk if there are not that many
+Boolean SubString::ReadIntWithBase(Int64 *pValue, Int32 base)
+{
+    Int64 value = 0, sign = 1;
+    EatWhiteSpaces();
+    if (base == 10) { // allow negative other bases?
+        if (EatChar('-')) {
+            sign = -1;
+        } else {
+            EatChar('+');
+        }
+    }
+    const Utf8Char *origBegin = _begin;
+    while (_begin < _end) {
+        Int32 d = DigitValue(*_begin, base);
+        if (d >= 0) {
+            value = (value * base) + d;
+        } else
+            break;
+        ++_begin;
+    }
+    *pValue = value * sign;
+    return _begin > origBegin;
 }
 //---------------------------------------------------
 Boolean SubString::CompareViaEncodedString(SubString* encodedString)
@@ -709,7 +734,7 @@ Boolean SubString::CompareViaEncodedString(SubString* encodedString)
             decodedC = c;
         } else {
             Int32 value = 0;
-            if (ss.ReadHex(&value)) {
+            if (ss.ReadHex2(&value)) {
                 decodedC = (Utf8Char)value;
             } else {
                 decodedC = '%';

--- a/source/include/StringUtilities.h
+++ b/source/include/StringUtilities.h
@@ -277,9 +277,12 @@ public:
     
     //! Read a simple token name, value, punctuation, etc.
     TokenTraits ReadToken(SubString* token);
-    
+
     //! Read 2 digit hex value
-    Boolean ReadHex(Int32* value);
+    Boolean ReadHex2(Int32* value);
+
+    //! Read a 64-bit integer in given base
+    Boolean ReadIntWithBase(Int64 *value, Int32 base);
 
     //! Read a simple name (like a field name in a JSON object)
     Boolean ReadNameToken(SubString* token);

--- a/test-it/DHOStringToNumber.via
+++ b/test-it/DHOStringToNumber.via
@@ -1,0 +1,103 @@
+define(default20 dv(.Single 20) )
+define(stringa373 dv(.String 'a373') )
+
+define(Test dv(.VirtualInstrument (
+ c(
+    e(.Int32 x)
+    e(.Int32 y)
+    e(dv(.Int32 0) c0)
+    e(dv(.Int32 1) c1)
+    e(dv(.Int32 2) c2)
+    e(dv(.Int32 3) c3)
+    e(dv(.Int32 4) c4)
+    e(dv(.Int32 5) c5)
+    e(dv(.Int32 6) c6)
+    e(dv(.Int32 7) c7)
+    e(dv(.Int32 8) c8)
+    e(dv(.Int32 16) c16)
+    e(dv(.Int32 1234) c1234)
+    //--
+    e(dv(.Int32 -2) cn2)
+    e(dv(.Int32 -3) cn3)
+    //--
+    e(.Int32 value)
+    e(.Int32 value2)
+    e(dv(.Int16 4) width)
+    e(dv(.Int32 12) defaultVal)
+    e(dv(.Double 1.2) dDefaultVal)
+    e(dv(.Int32 0) offset)
+    e(dv(.Int32 0) endoffset)
+    //-------------------
+    e(dv(.Double 1.5) d1_5)
+    e(dv(.Double 1.76) d1_76)
+
+    e(.String outString)
+    e(dv(.String 'xxc')  badString)
+    e(dv(.String '123 456 abC')  cString)
+    e(dv(a(.String *) ('123' '456'))  aString)
+    e(a(.Int32 *) aValue)
+    e(dv(.Int16 4) width)
+    e(dv(c(e(.String) e(.String)) ('234' '567')) clustString)
+    e(dv(c(e(.Int32) e(.Int32)) (-1 -2)) clustValue)
+
+    e(.Single local1)
+    e(.Int32 local2)
+ )
+  clump(1
+    //---------------------------------------------------------
+
+    // String to Int32
+    Copy(c0 offset)
+    DecimalStringToNumber(badString offset defaultVal endoffset value)
+    Printf("DecStringToNumber '%s' %d %d %d\n" badString offset endoffset value)
+    DecimalStringToNumber(badString offset * endoffset value)
+    Printf("DecStringToNumber '%s' %d %d %d (nodflt)\n" badString offset endoffset value)
+
+    Copy(c0 offset)
+    DecimalStringToNumber(cString offset * endoffset value)
+    Printf("DecStringToNumber '%s' %d %d %d\n" cString offset endoffset value)
+
+    Copy(endoffset offset)
+    DecimalStringToNumber(cString offset defaultVal endoffset value)
+    Printf("DecStringToNumber '%s' %d %d %d\n" cString offset endoffset value)
+
+    Copy(endoffset offset)
+    DecimalStringToNumber(cString offset defaultVal endoffset value)
+    Printf("DecStringToNumber '%s' %d %d %d\n" cString offset endoffset value)
+
+    Copy(endoffset offset)
+    DecimalStringToNumber(cString offset * * value)
+    Printf("DecStringToNumber '%s' %d %d %d\n" cString offset endoffset value)
+
+    //---------------------------------------------------------
+
+    // String to Double
+    Copy(c0 offset)
+    DecimalStringToNumber(stringa373 * default20 local2 local1)
+    Printf("DecStringToNumber '%s' %d %d %f\n" stringa373 0 local2 local1)
+
+    Copy(c0 offset)
+    DecimalStringToNumber(aString * default20 local2 aValue)
+    Printf("DecStringToNumber '%s' %d %d %s\n" aString 0 local2 aValue)
+
+    Copy(c0 offset)
+    DecimalStringToNumber(clustString * default20 local2 clustValue)
+    Printf("DecStringToNumber '%s' %d %d %s\n" clustString 0 local2 clustValue)
+
+    Copy(5 offset)
+    HexStringToNumber('ffffffe'  offset defaultVal endoffset value)
+    Printf("HexStringToNumber 'ffffffe' %d %d %d\n" offset endoffset value)
+
+    Copy(0 offset)
+    OctalStringToNumber('17890'  offset defaultVal endoffset value)
+    Printf("OctalStringToNumber '17890' %d %d %d\n" offset endoffset value)
+
+    Copy(0 offset)
+    BinaryStringToNumber('  111fffffff'  offset defaultVal endoffset value)
+    Printf("BinaryStringToNumber '   111fffffff' %d %d %d\n" offset endoffset value)
+   )
+ ) ) )
+enqueue(Test)
+
+
+

--- a/test-it/DHOStringToNumber.via
+++ b/test-it/DHOStringToNumber.via
@@ -35,6 +35,7 @@ define(Test dv(.VirtualInstrument (
     e(dv(.String 'xxc')  badString)
     e(dv(.String '123 456 abC')  cString)
     e(dv(a(.String *) ('123' '456'))  aString)
+    e(dv(a(.String *) ('123' 'x456'))  aBadString)
     e(a(.Int32 *) aValue)
     e(dv(.Int16 4) width)
     e(dv(c(e(.String) e(.String)) ('234' '567')) clustString)
@@ -77,11 +78,11 @@ define(Test dv(.VirtualInstrument (
     Printf("DecStringToNumber '%s' %d %d %f\n" stringa373 0 local2 local1)
 
     Copy(c0 offset)
-    DecimalStringToNumber(aString * default20 local2 aValue)
+    DecimalStringToNumber(aString * defaultVal local2 aValue)
     Printf("DecStringToNumber '%s' %d %d %s\n" aString 0 local2 aValue)
 
     Copy(c0 offset)
-    DecimalStringToNumber(clustString * default20 local2 clustValue)
+    DecimalStringToNumber(clustString * defaultVal local2 clustValue)
     Printf("DecStringToNumber '%s' %d %d %s\n" clustString 0 local2 clustValue)
 
     Copy(5 offset)
@@ -95,6 +96,14 @@ define(Test dv(.VirtualInstrument (
     Copy(0 offset)
     BinaryStringToNumber('  111fffffff'  offset defaultVal endoffset value)
     Printf("BinaryStringToNumber '   111fffffff' %d %d %d\n" offset endoffset value)
+
+    Copy(c0 offset)
+    DecimalStringToNumber(aBadString 0 defaultVal local2 aValue)
+    Printf("DecStringToNumber '%s' %d %d %s\n" aBadString 0 local2 aValue)
+
+    Copy(c0 offset)
+    //DecimalStringToNumber(aBadString 0 default20 local2 aValue) // default type mismatch, generates error, move to separate test to check for error
+    //Printf("DecStringToNumber '%s' %d %d %s\n" aBadString 0 local2 aValue)
    )
  ) ) )
 enqueue(Test)

--- a/test-it/results/DHOStringToNumber.vtr
+++ b/test-it/results/DHOStringToNumber.vtr
@@ -1,0 +1,12 @@
+DecStringToNumber 'xxc' 0 0 12
+DecStringToNumber 'xxc' 0 0 0 (nodflt)
+DecStringToNumber '123 456 abC' 0 3 123
+DecStringToNumber '123 456 abC' 3 7 456
+DecStringToNumber '123 456 abC' 7 7 12
+DecStringToNumber '123 456 abC' 7 7 0
+DecStringToNumber 'a373' 0 0 20.000000
+DecStringToNumber '('123' '456')' 0 3 (123 456)
+DecStringToNumber '('234' '567')' 0 3 (234 567)
+HexStringToNumber 'ffffffe' 5 7 254
+OctalStringToNumber '17890' 0 2 15
+BinaryStringToNumber '   111fffffff' 0 5 7

--- a/test-it/results/DHOStringToNumber.vtr
+++ b/test-it/results/DHOStringToNumber.vtr
@@ -10,3 +10,4 @@ DecStringToNumber '('234' '567')' 0 3 (234 567)
 HexStringToNumber 'ffffffe' 5 7 254
 OctalStringToNumber '17890' 0 2 15
 BinaryStringToNumber '   111fffffff' 0 5 7
+DecStringToNumber '('123' 'x456')' 0 0 (123 12)

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -77,6 +77,7 @@
                 "DeeplyNestedInitializer.via",
                 "DefaultOutputs.via",
                 "DefaultTM.via",
+                "DHOStringToNumber.via",
                 "DuplicateSymbol.via",
                 "EggShellError1.via",
                 "EggShellError2.via",


### PR DESCRIPTION
{Decimal,Hex,Octal,Exponential}StringToNumber polymorphic conversion functions.
E.g.
DecimalStringToNumber(string offset defaultValue endOffsetOut valueOut)

ExponentialStringToNumber handles floating point.
Input can be string or array/cluster of strings.
Output is numeric matching default type, or array/cluster of elements matching default type.
DefaultValue type is always scalar.  Offset in and out are always int32s.
