### PR TITLE
Fix for Number to {Hex,Oct,Bin}String

### DIFF
--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -2296,7 +2296,7 @@ Boolean NumberToStringInternal(TypeRef type, AQBlock1 *pData, Int32 minWidth, In
             AQBlock1 *pDestElement = pDestArray->BeginAt(0);
             while (count > 0) {
                 StringRef string = *(StringRef*)pDestElement;
-                NumberToExponentialStringInternal(subType, pElement, minWidth, precision, string);
+                (*formatCallback)(subType, pElement, minWidth, precision, string);
                 pElement += elementSize;
                 pDestElement += destElementSize;
                 --count;


### PR DESCRIPTION
…ctored

NumberTo{Exp,Eng,Hex,Dec}String to share polymorphic callback code; it
was always calling the exponential formatting function even for Hex, etc. cases.