### PR TITLE
This fixes all 4 issues you emailed me about today.

### DIFF
--- a/source/core/NumericString.cpp
+++ b/source/core/NumericString.cpp
@@ -482,7 +482,7 @@ void Format(SubString *format, Int32 count, StaticTypeAndData arguments[], Strin
                         TypeRef argType = arguments[argumentIndex]._paramType;
                         Double tempDouble = ReadDoubleFromMemory(argType,  arguments[argumentIndex]._pData);
                         Int32 precision = fOptions.Precision;
-                        if (precision>0 && fOptions.EngineerNotation) {
+                        if (precision>=0 && fOptions.EngineerNotation) {
                             Int32 exponent = 0;
                             if (tempDouble != 0) {
                                 Double absDouble = tempDouble;

--- a/test-it/results/NumberToString.vtr
+++ b/test-it/results/NumberToString.vtr
@@ -6,7 +6,7 @@ NumberToExponentialString (-123 9.998E+11) 11 2 ('   -1.23E+2' '   1.00E+12')
 NumberToFloatString 12345.6 7 0 '12345.600000'
 NumberToEngineeringString 12345.6 2 0 '12.345600E+3'
 NumberToDecimalString 12345.6 0 '12346'
-NumberToDecimalString (-123 9.998E+11) 8 '('-0000123' '999800000000')'
+NumberToDecimalString (-123 9.998E+11) 8 '('    -123' '999800000000')'
 NumberToHexString 12345.6 0 '303A'
 NumberToHexString (-123 9.998E+11) 8 '('FFFFFF85' 'E8C8B94E00')'
 NumberToHexString 4 8 '00000004'


### PR DESCRIPTION
Fix engineering precision to work correctly if precision is 0.
Fix DecimalStringToNumber to correctly pin/saturate out of range
numbers.
Fix NumberToFloatString to never switch to exponential notation.