### PR TITLE
git clone emscripten from ni-kismet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ addons:
     - g++-4.9
 before_script:
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
-- git clone --depth 1 https://github.com/urho3d/emscripten-sdk.git && emscripten-sdk/emsdk
+- git clone --depth 1 https://github.com/ni-kismet/emscripten-sdk.git && emscripten-sdk/emsdk
   activate --build=Release sdk-master-64bit && source emscripten-sdk/emsdk_env.sh
 - cat ~/.emscripten
 - emcc -v


### PR DESCRIPTION
@cglzaguilar 
I forked urho3d/emscripten-sdk repository into ni-kismet

Travis CI now clones the emscripten-sdk from github.com/ni-kismet/emscripten for building vireo