### PR TITLE
MandelbrotInline Test Workaround

### DIFF
--- a/test-it/MandelbrotInline.via
+++ b/test-it/MandelbrotInline.via
@@ -6,8 +6,9 @@ define(MandelbrotMain dv(.VirtualInstrument (
 
         e(dv(.Utf8Char '.')    char1)
         e(dv(.Utf8Char '#')    char2)
-        e(dv(.Utf8Char @'
-')   charLineFeed)
+
+        // TODO changed to Int32 from Utf8Char due to https://github.com/ni/VireoSDK/issues/123
+        e(dv(.Int32 10) intLineFeed)
 
         e(dv(.String '.')    str1)
         e(dv(.String '#')    str2)
@@ -73,7 +74,7 @@ define(MandelbrotMain dv(.VirtualInstrument (
                 Add(x xDelta x)
             BranchIfLE(1 x xLast)
 
-        ArrayAppendElt(buffer charLineFeed)
+        ArrayAppendElt(buffer intLineFeed)
         Add(y yDelta y)
         BranchIfGE(0 y yLast)
 


### PR DESCRIPTION
This is a partial change to the MandelbrotInline test failure that occurs on Windows. The root cause is that the test relied on a string literal with a newline character that is platform specific.

See https://github.com/ni/VireoSDK/issues/123