### PR TITLE
Remove testing of 8 bit timer resolution. They wrap around and cause false failures.

### DIFF
--- a/test-it/TimerCount.via
+++ b/test-it/TimerCount.via
@@ -121,7 +121,6 @@ define (_%54estVI_TimerCount%2Egvi dv(.VirtualInstrument (
         Wait(8)
         Wait(9)
         And(local78 local64 local85)
-        And(local44 local85 local85)
         Copy(local85 local80 )
         Copy(local80 dataItem_Actual )
         Printf ("All tests pass: '%s'.\n" dataItem_Actual)
@@ -133,10 +132,6 @@ define (_%54estVI_TimerCount%2Egvi dv(.VirtualInstrument (
         Printf ("        Ticks different: '%s'.\n" dataItem_UInt16TicksDifferent)
         Printf ("        Microseconds different: '%s'.\n" dataItem_UInt16MicrosecondsDifferent)
         Printf ("        Milliseconds different: '%s'.\n" dataItem_UInt16MillisecondsDifferent)
-        Printf ("    UInt8  counter size: '%s'.\n" dataItem_UInt8CounterSize)
-        Printf ("        Ticks different: '%s'.\n" dataItem_UInt8TicksDifferent)
-        Printf ("        Microseconds different: '%s'.\n" dataItem_UInt8MicrosecondsDifferent)
-        Printf ("        Milliseconds different: '%s'.\n" dataItem_UInt8MillisecondsDifferent)
 /* Clump Ended. */    )
     clump(1
         WaitMilliseconds(c2 * )

--- a/test-it/Wait.via
+++ b/test-it/Wait.via
@@ -107,7 +107,6 @@ define (_%54estVI_Wait%2Egvi dv(.VirtualInstrument (
         Wait(8)
         Wait(9)
         And(local73 local59 local80)
-        And(local33 local80 local80)
         Copy(local80 local75 )
         Copy(local75 dataItem_Actual )
         Printf ("All tests pass: '%s'.\n" dataItem_Actual)
@@ -119,10 +118,6 @@ define (_%54estVI_Wait%2Egvi dv(.VirtualInstrument (
         Printf ("        Ticks different: '%s'.\n" dataItem_UInt16TicksDifferent)
         Printf ("        Microseconds different: '%s'.\n" dataItem_UInt16MicrosecondsDifferent)
         Printf ("        Milliseconds different: '%s'.\n" dataItem_UInt16MillisecondsDifferent)
-        Printf ("    UInt8  counter size: '%s'.\n" dataItem_UInt8CounterSize)
-        Printf ("        Ticks different: '%s'.\n" dataItem_UInt8TicksDifferent)
-        Printf ("        Microseconds different: '%s'.\n" dataItem_UInt8MicrosecondsDifferent)
-        Printf ("        Milliseconds different: '%s'.\n" dataItem_UInt8MillisecondsDifferent)
 /* Clump Ended. */    )
     clump(1
         Convert(c1 local9)

--- a/test-it/WaitUntilMultiple.via
+++ b/test-it/WaitUntilMultiple.via
@@ -107,7 +107,6 @@ define (_%54estVI_WaitUntilMultiple%2Egvi dv(.VirtualInstrument (
         Wait(8)
         Wait(9)
         And(local73 local59 local80)
-        And(local33 local80 local80)
         Copy(local80 local75 )
         Copy(local75 dataItem_Actual )
         Printf ("All tests pass: '%s'.\n" dataItem_Actual)
@@ -119,10 +118,6 @@ define (_%54estVI_WaitUntilMultiple%2Egvi dv(.VirtualInstrument (
         Printf ("        Ticks different: '%s'.\n" dataItem_UInt16TicksDifferent)
         Printf ("        Microseconds different: '%s'.\n" dataItem_UInt16MicrosecondsDifferent)
         Printf ("        Milliseconds different: '%s'.\n" dataItem_UInt16MillisecondsDifferent)
-        Printf ("    UInt8  counter size: '%s'.\n" dataItem_UInt8CounterSize)
-        Printf ("        Ticks different: '%s'.\n" dataItem_UInt8TicksDifferent)
-        Printf ("        Microseconds different: '%s'.\n" dataItem_UInt8MicrosecondsDifferent)
-        Printf ("        Milliseconds different: '%s'.\n" dataItem_UInt8MillisecondsDifferent)
 /* Clump Ended. */    )
     clump(1
         Convert(c1 local9)

--- a/test-it/results/TimerCount.vtr
+++ b/test-it/results/TimerCount.vtr
@@ -7,7 +7,3 @@ All tests pass: 'true'.
         Ticks different: 'true'.
         Microseconds different: 'true'.
         Milliseconds different: 'true'.
-    UInt8  counter size: 'true'.
-        Ticks different: 'true'.
-        Microseconds different: 'true'.
-        Milliseconds different: 'true'.

--- a/test-it/results/Wait.vtr
+++ b/test-it/results/Wait.vtr
@@ -7,7 +7,3 @@ All tests pass: 'true'.
         Ticks different: 'true'.
         Microseconds different: 'true'.
         Milliseconds different: 'true'.
-    UInt8  counter size: 'true'.
-        Ticks different: 'true'.
-        Microseconds different: 'true'.
-        Milliseconds different: 'true'.

--- a/test-it/results/WaitUntilMultiple.vtr
+++ b/test-it/results/WaitUntilMultiple.vtr
@@ -7,7 +7,3 @@ All tests pass: 'true'.
         Ticks different: 'true'.
         Microseconds different: 'true'.
         Milliseconds different: 'true'.
-    UInt8  counter size: 'true'.
-        Ticks different: 'true'.
-        Microseconds different: 'true'.
-        Milliseconds different: 'true'.


### PR DESCRIPTION
Remove testing of 8 bit timer resolution. They wrap around and cause false failures.