### PR TITLE
Add MatchPattern Vireo prim, modeled after LV Match Pattern prim.

### DIFF
--- a/Vireo_VS/VireoCommandLine.vcxproj
+++ b/Vireo_VS/VireoCommandLine.vcxproj
@@ -20,6 +20,7 @@
     <ClCompile Include="..\source\core\EventLog.cpp" />
     <ClCompile Include="..\source\core\ExecutionContext.cpp" />
     <ClCompile Include="..\source\core\GenericFunctions.cpp" />
+    <ClCompile Include="..\source\core\MatchPat.cpp" />
     <ClCompile Include="..\source\core\Math.cpp" />
     <ClCompile Include="..\source\core\NumericString.cpp" />
     <ClCompile Include="..\source\core\Platform.cpp" />

--- a/Vireo_Xcode/VireoEggShell.xcodeproj/project.pbxproj
+++ b/Vireo_Xcode/VireoEggShell.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		444C468C1E26D73C0037FA98 /* RefNum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 444C468B1E26D73C0037FA98 /* RefNum.cpp */; };
 		444C46901E299A390037FA98 /* RefNumTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 444C468F1E299A390037FA98 /* RefNumTest.cpp */; };
 		444C46931E2D70AB0037FA98 /* UnitTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 444C46921E2D70AB0037FA98 /* UnitTest.cpp */; };
+		4466C7991E4F08EE004B5E31 /* MatchPat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4466C7971E4F08EE004B5E31 /* MatchPat.cpp */; };
+		4466C79A1E4F08EE004B5E31 /* Waveform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4466C7981E4F08EE004B5E31 /* Waveform.cpp */; };
 		4700BD741948FBF400794482 /* ExecutionContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47D84DDB17C2A271009053DB /* ExecutionContext.cpp */; };
 		4700BD751948FC0400794482 /* Math.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47D84DDF17C2A271009053DB /* Math.cpp */; };
 		4700BD7A194A08E500794482 /* Queue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47D84DE117C2A271009053DB /* Queue.cpp */; };
@@ -247,6 +249,9 @@
 		444C468F1E299A390037FA98 /* RefNumTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RefNumTest.cpp; path = ../source/unittest/RefNumTest.cpp; sourceTree = "<group>"; };
 		444C46911E2D69ED0037FA98 /* UnitTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UnitTest.h; path = include/UnitTest.h; sourceTree = "<group>"; };
 		444C46921E2D70AB0037FA98 /* UnitTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UnitTest.cpp; path = core/UnitTest.cpp; sourceTree = "<group>"; };
+		4466C7971E4F08EE004B5E31 /* MatchPat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MatchPat.cpp; path = core/MatchPat.cpp; sourceTree = "<group>"; };
+		4466C7981E4F08EE004B5E31 /* Waveform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Waveform.cpp; path = core/Waveform.cpp; sourceTree = "<group>"; };
+		4466C79B1E4FEDFB004B5E31 /* Waveform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Waveform.h; path = include/Waveform.h; sourceTree = "<group>"; };
 		44ABE7D61D3D3FEF008EB066 /* test.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = test.js; path = "../test-it/test.js"; sourceTree = "<group>"; };
 		44ABE7D71D3D6A20008EB066 /* Scale2X.via */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Scale2X.via; path = "../test-it/Scale2X.via"; sourceTree = "<group>"; };
 		44ABE7D81D3D6A20008EB066 /* UnOpFunctions.via */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = UnOpFunctions.via; path = "../test-it/UnOpFunctions.via"; sourceTree = "<group>"; };
@@ -823,9 +828,11 @@
 				444C468B1E26D73C0037FA98 /* RefNum.cpp */,
 				47E180571A083769007A8DB4 /* Synchronization.cpp */,
 				47D84DE017C2A271009053DB /* Thread.cpp */,
+				4466C7981E4F08EE004B5E31 /* Waveform.cpp */,
 				47D84DE117C2A271009053DB /* Queue.cpp */,
 				47D84DE217C2A271009053DB /* String.cpp */,
 				47D84DE317C2A271009053DB /* StringUtilities.cpp */,
+				4466C7971E4F08EE004B5E31 /* MatchPat.cpp */,
 				472A07891AA6204A008109FA /* NumericString.cpp */,
 				47D84DE417C2A271009053DB /* Timestamp.cpp */,
 				47D84DE617C2A271009053DB /* VirtualInstrument.cpp */,
@@ -838,6 +845,7 @@
 		479AFEBE170DDA76002C0FF0 /* include */ = {
 			isa = PBXGroup;
 			children = (
+				4466C79B1E4FEDFB004B5E31 /* Waveform.h */,
 				444C46871E1C5ABC0037FA98 /* Date.h */,
 				444C46881E1C5ABC0037FA98 /* LVDateTimeRecord.h */,
 				47B76CD71B28DACA0083AEEB /* Platform.h */,
@@ -1080,6 +1088,7 @@
 				47D84DE717C2A271009053DB /* Array.cpp in Sources */,
 				47D84DE817C2A271009053DB /* CEntryPoints.cpp in Sources */,
 				47A877761AE6DAEB00EC5D77 /* HttpClient.cpp in Sources */,
+				4466C7991E4F08EE004B5E31 /* MatchPat.cpp in Sources */,
 				47D84DEB17C2A271009053DB /* DataQueue.cpp in Sources */,
 				47E180581A083769007A8DB4 /* Synchronization.cpp in Sources */,
 				47D84DEF17C2A271009053DB /* ExecutionContext.cpp in Sources */,
@@ -1103,6 +1112,7 @@
 				472B7BE817D0E1FC00201196 /* FileIO.cpp in Sources */,
 				444C46841E1C5A540037FA98 /* Date.cpp in Sources */,
 				472A078A1AA6204A008109FA /* NumericString.cpp in Sources */,
+				4466C79A1E4F08EE004B5E31 /* Waveform.cpp in Sources */,
 				47B76CD91B28DB090083AEEB /* Platform.cpp in Sources */,
 				472A07901AA67EF8008109FA /* DebugGPIO.cpp in Sources */,
 				47E220B11950C1F700988185 /* Assert.cpp in Sources */,

--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -102,6 +102,7 @@ EM_BC_FILES=$(OBJS)/Array.bc\
 	$(OBJS)/EventLog.bc\
 	$(OBJS)/ExecutionContext.bc\
 	$(OBJS)/GenericFunctions.bc\
+	$(OBJS)/MatchPat.bc\
 	$(OBJS)/Math.bc\
 	$(OBJS)/NumericString.bc\
 	$(OBJS)/Platform.bc\

--- a/make-it/Makefile
+++ b/make-it/Makefile
@@ -8,7 +8,7 @@ OUTPUT_EXE=$(OUTPUT_DIR)/esh
 OUTPUT_TEST_EXE=$(OUTPUT_DIR)/esh-test
 
 COMMANDLINE = main.cpp
-CORE = Array.cpp Assert.cpp CEntryPoints.cpp Date.cpp EventLog.cpp ExecutionContext.cpp GenericFunctions.cpp Math.cpp NumericString.cpp Platform.cpp Queue.cpp RefNum.cpp String.cpp StringUtilities.cpp Synchronization.cpp TDCodecLVFlat.cpp TDCodecVia.cpp Thread.cpp TimeFunctions.cpp Timestamp.cpp TypeAndDataManager.cpp TypeAndDataReflection.cpp TypeDefiner.cpp TypeTemplates.cpp UnitTest.cpp VirtualInstrument.cpp Waveform.cpp
+CORE = Array.cpp Assert.cpp CEntryPoints.cpp Date.cpp EventLog.cpp ExecutionContext.cpp GenericFunctions.cpp MatchPat.cpp Math.cpp NumericString.cpp Platform.cpp Queue.cpp RefNum.cpp String.cpp StringUtilities.cpp Synchronization.cpp TDCodecLVFlat.cpp TDCodecVia.cpp Thread.cpp TimeFunctions.cpp Timestamp.cpp TypeAndDataManager.cpp TypeAndDataReflection.cpp TypeDefiner.cpp TypeTemplates.cpp UnitTest.cpp VirtualInstrument.cpp Waveform.cpp
 UNITTEST = RefNumTest.cpp
 #CORE = VireoMerged.cpp Thread.cpp Timestamp.cpp CEntryPoints.cpp
 IO = FileIO.cpp Canvas2d.cpp DebugGPIO.cpp

--- a/source/core/MatchPat.cpp
+++ b/source/core/MatchPat.cpp
@@ -1,0 +1,423 @@
+/**
+ *  
+ *  Copyright (c) 2017 National Instruments Corp.
+ *   
+ *   This software is subject to the terms described in the LICENSE.TXT file
+ *    
+ *    SDG
+ *    */
+
+/*! \file
+ *  */
+
+#include "TypeAndDataManager.h"
+#include "TypeDefiner.h"
+#include <ctype.h>
+
+using namespace Vireo;
+
+enum { kMatchArgErr=1, kMatchMemFullErr=2 };
+
+static const UInt8 *AMatch(const UInt8 *, const Utf8Char*, const Utf8Char *);
+static Int32 InSet(UInt8 c, const Utf8Char *s, const Utf8Char *se);
+static Int32 MakePat(Int32, const Utf8Char *str, StringRef &pat);
+static void MatchPat(StringRef pat, Int32 len, const Utf8Char *str, Int32 offset, SubString *bef, SubString *mat, SubString *aft, Int32 *offsetPastMatch);
+
+Int32 LexClass(Utf8Char c)
+{
+    static char gLexicalClass[]= {
+        1,	1,	1,	1,	1,	1,	1,	1,	1,	2,	2,	2,	2,	2,	1,	1,
+        1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,
+        2,	6,	6,	6,	6,	6,	6,	6,	6,	6,	6,	6,	6,	6,	6,	6,
+        3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	6,	6,	6,	6,	6,	6,
+        6,	4,	4,	4,	4,	4,	4,	4,	4,	4,	4,	4,	4,	4,	4,	4,
+        4,	4,	4,	4,	4,	4,	4,	4,	4,	4,	4,	6,	6,	6,	6,	6,
+        6,	5,	5,	5,	5,	5,	5,	5,	5,	5,	5,	5,	5,	5,	5,	5,
+        5,	5,	5,	5,	5,	5,	5,	5,	5,	5,	5,	6,	6,	6,	6,	1
+    };
+	c &= 0xFF;
+	return (c >= 128) ? 0 : gLexicalClass[c];
+}
+
+char ScanForBackslash(const Utf8Char **sp, const Utf8Char *se)
+{
+    const Utf8Char *s = *sp;
+    char c = *s++;
+
+    if (c == '\\') {
+        if (s < se) {
+            c= *s++;
+            if (isdigit(c) || (c >= 'A' && c <= 'F')) {
+                c -= (c >= 'A' ? 'A' - 10 : '0');
+                if (s < se) {
+                    if (isdigit(*s))
+                        c = (c<<4) + *s++ - '0';
+                    else if (*s >= 'A' && *s <= 'F')
+                        c = (c<<4) + *s++ - 'A' + 10;
+                }
+            }
+            else {
+                switch(c) {
+                    case 'b': c= '\b'; break;
+                    case 'f': c= '\f'; break;
+                    case 'n': c= '\n'; break;
+                    case 'r': c= '\r'; break;
+                    case 's': c= ' ';  break;
+                    case 't': c= '\t'; break;
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+    *sp = s;
+    return c;
+}
+
+/*
+Construct a pattern string by encoding the regular expression in str.
+(the pattern is a string if the expression is;
+if the expression contains nulls, then so does the pattern).
+
+Pattern syntax:
+	^	means anchor to start of line iff it's the first char
+	.	means any char
+	*	means indefinite repeat (0 or more) iff its preceded by an alternation or non-meta-char
+	+	means indefinite repeat (1 or more) iff its preceded by an alternation or non-meta-char
+	?	means conditional (0 or 1) iff it's preceded by an alternation or non-meta-char
+	$	means anchor to the end of the line iff it's the last char
+	\	escapes any special char including itself; \b,\f,\n,\015,\t,\xx for special characters
+	[]	enclose alternates:
+			if ^ is first it negates the set with reference to printable chars.
+			if ~ is first it negates the set with reference to all chars.
+			if - is between two alpha or numeric chars it means the inclusive set.
+*/
+#define mEOF	0
+#define mStar	1
+#define mPlus	2
+#define mCond	4
+#define mBOL	0x58
+#define mAny	0x28
+#define mEOS	0x20
+#define mChr	0x60
+#define mCCL	0x30
+
+static Int32 MakePat(Int32 len, const Utf8Char *str, StringRef &pat)
+{
+	const Utf8Char *s, *ssav, *se;
+	UInt8 *p, *lastP;
+	Int32 c, n;
+    bool regChar= false;
+
+	n = len;
+	if(!pat) {
+        TypeRef type = TypeManagerScope::Current()->FindType("String");
+        if (type)
+            type->InitData(&pat);
+        if (!pat)
+            return kMatchMemFullErr;
+	}
+    if (!pat->Resize1D(2*n + 10))
+        return kMatchMemFullErr;
+	s = str;
+	se = s + n;
+    p = pat->Begin();
+    for (lastP = 0; s < se; regChar ? (*p++ = mChr, *p++ = c) : 0) {
+        Int32 charLen = SubString::CharLength(s);
+        regChar = false;
+		if (charLen > 1) {
+			while (charLen-- > 0 && s < se) {
+				*p++ = mChr;
+				*p++ = *s++;
+			}
+			continue;
+		}
+        c = *s++;
+		if (c != '*' && c != '+' && c != '?')
+            lastP = p;
+		switch(c) {
+			case '^':
+                if (p != pat->Begin()) {
+                    regChar = true; continue;
+                }
+				*p++ = mBOL;
+				break;
+			case '.':
+				*p++ = mAny;
+				break;
+			case '*':
+                if (lastP == 0) {
+                    regChar = true; continue;
+                }
+                *lastP |= mStar;
+                lastP = 0;
+                break;
+			case '+':
+                if (lastP == 0) {
+                    regChar = true; continue;
+                }
+				*lastP |= mPlus;
+				lastP = 0;
+				break;
+			case '?':
+                if (lastP == 0) {
+                    regChar = true; continue;
+                }
+				*lastP |= mCond;
+				lastP = 0;
+				break;
+			case '$':
+                if (s < se) {
+                    regChar = true; continue;
+                }
+				*p++ = mEOS;
+				break;
+			case '\\':
+				ssav = s-1;
+				c = ScanForBackslash(&ssav, se);
+				s = ssav;
+                // fall through...
+			default:
+				*p++ = mChr;
+				*p++ = c;
+				break;
+			case '[':
+				*p++ = mCCL;
+				for (p++; s < se && (c= *s++) != ']'; *p++ = c)
+					if(c == '\\') {
+						ssav= s-1;
+						c = ScanForBackslash(&ssav, se);
+						s = ssav;
+					}
+				lastP[1] = p - lastP - 1;
+				break;
+		}
+	}
+	*p = mEOF;
+    pat->Resize1D(IntIndex(p + 1 - pat->Begin()));
+	return 0;
+}
+
+/*
+Match pat to the string str starting at position idx.
+If it matches return str up to the match point in bef,
+the match string in mat, and the remainder of str in aft.
+Return the index of the character past the match in odx.
+If no match return -1 in odx;
+One or more of bef, mat, and aft may be null.
+"pat" should not be an empty string.
+*/
+static void MatchPat(StringRef pat, Int32 len, const Utf8Char *str, Int32 offset, SubString *bef, SubString *mat, SubString *aft, Int32 *offsetPastMatch)
+{
+    const Utf8Char *s = null, *se;
+    const UInt8 *p, *t = null;
+	Int32 ns, nt;
+
+	if (offset < 0)
+        offset= 0;
+	if (pat) {
+        if (!str)
+            str = (Utf8Char*)"";
+        s = str + offset;
+        se = str + len;
+        p = pat->Begin();
+        if (*p == mBOL)
+            t = AMatch(p + 1, s, se);
+        else if (*p == mChr) {
+            for(; s < se; s++)
+                if (*s == p[1]) {
+                    t = AMatch(p, s, se);
+                    if(t)
+                        break;
+                }
+        } else {
+            for (; s < se; s++) {
+                t = AMatch(p, s, se);
+                if(t)
+                    break;
+            }
+        }
+    }
+	if (!t){ /* copy all of str to bef and set mat, aft to empty */
+        if (bef)
+            bef->AliasAssignLen(str, len);
+        if (mat)
+            mat->AliasAssignLen(null, 0);
+        if (aft)
+            aft->AliasAssignLen(null, 0);
+		if (offsetPastMatch)
+			*offsetPastMatch = -1;
+	}
+	else {	/* copy str up to s to bef, from s to t to mat, remainder of str from t to aft */
+        ns= Int32(s - str);
+        nt= Int32(t - str);
+        if (bef)
+            bef->AliasAssignLen(str, ns);
+        if (mat)
+            mat->AliasAssignLen(str + ns, nt - ns);
+        if (aft)
+            aft->AliasAssignLen(str + nt, len - nt);
+		if(offsetPastMatch)
+			*offsetPastMatch = nt;
+	}
+}
+
+static const Utf8Char *AMatch(const UInt8 *p, const Utf8Char* s, const Utf8Char *se)
+{
+	const Utf8Char *sSave, *t;
+
+	for (;;) {
+		switch(*p++) {
+			case mEOF:
+				return s > se ? 0 : s;
+			case mChr:
+				if(s >= se || *s++ != *p++)
+                    return 0;
+				continue;
+			case mAny:
+				if(s >= se)
+                    return 0;
+				s++;
+				continue;
+			case mEOS:
+				if(s != se)
+                    return 0;
+				continue;
+			case mCCL:
+				if(s >= se || !InSet(*s++, p + 1, p + *p))
+                    return 0;
+				p += *p;
+				continue;
+			case mAny | mStar:
+				sSave = s;
+				s = se;
+				break;
+			case mChr | mStar:
+				sSave = s;
+				while (s < se && *s == *p)
+                    s++;
+				p++;
+				break;
+			case mCCL | mStar:
+				sSave = s;
+				while (s < se && InSet(*s, p + 1, p + *p))
+                    s++;
+				p += *p;
+				break;
+			case mAny | mPlus:
+				sSave = s + 1;
+				s = se;
+				break;
+			case mChr | mPlus:
+				sSave = s;
+				while(s < se && *s == *p)
+                    s++;
+				if (s == sSave)
+                    return 0;
+				sSave++;
+				p++;
+				break;
+			case mCCL | mPlus:
+				sSave= s;
+				while (s < se && InSet(*s, p + 1, p + *p))
+					s++;
+				if (s == sSave)
+					return 0;
+				sSave++;
+				p += *p;
+				break;
+			case mAny | mCond:
+				sSave = s;
+				s = s + 1;
+				break;
+			case mChr | mCond:
+				sSave = s;
+				if (s < se && *s == *p)
+					s++;
+				p++;
+				break;
+			case mCCL | mCond:
+				sSave = s;
+				if (s < se && InSet(*s, p + 1, p + *p))
+					s++;
+				p += *p;
+				break;
+			default:
+				return 0;
+		}
+    //starloop:
+        for( ; s >= sSave; s--) {
+            t = AMatch(p, s, se);
+            if(t)
+                return t;
+        }
+        return 0;
+	}
+}
+
+static Int32 InSet(UInt8 c, const Utf8Char *s, const Utf8Char *se)
+{
+    Int32 i;
+    bool sense;
+
+	sense = false;
+	if (s < se && (*s == '^' || *s == '~')) {
+		if (c < ' ' && *s == '^')
+            return 0;
+		s++;
+		sense = true;
+	}
+    while (s < se) {
+		if (s < se-2 && s[1] == '-' && s[0] <= s[2] && (i=LexClass(s[0])) >= 3
+		   && i <= 5 && i == LexClass(s[2])) {
+			if (c >= s[0] && c <= s[2])
+                return !sense;
+			s += 3;
+		}
+		else if(c == *s)
+            return !sense;
+		else s++;
+    }
+	return sense;
+}
+
+
+//Int32 MatchPattern(StringRef pat, Int32 len, ConstCStr str, Int32 idx,
+//                   ConstCStr bef, ConstCStr mat, ConstCStr aft, Int32 *odx)
+
+VIREO_FUNCTION_SIGNATURE7(MatchPattern, StringRef, StringRef, Int32, StringRef, StringRef, StringRef, Int32)
+{
+    StringRef *str = _ParamPointer(0);
+    StringRef *pat = _ParamPointer(1);
+    Int32 offset = _ParamPointer(2) ? _Param(2) : 0;
+    StringRef *beforeStr = _ParamPointer(3);
+    StringRef *matchStr = _ParamPointer(4);
+    StringRef *afterStr = _ParamPointer(5);
+    Int32 *offsetOutPtr = _ParamPointer(6);
+    Int32 patLen = pat ? (*pat)->Length() : 0;
+    const Utf8Char *cstr = str ? (*str)->Begin() : null;
+    Int32 strLen = str ? (*str)->Length() : 0;
+    StringRef cpat = null;
+    SubString beforeSub, matchSub, afterSub;
+    Int32 err = MakePat(patLen, pat ? (*pat)->Begin() : null, cpat);
+    beforeSub.AliasAssignLen(cstr, strLen);
+    if (!err) {
+        MatchPat(cpat, strLen, cstr, offset, &beforeSub, &matchSub, &afterSub, offsetOutPtr);
+    } else {
+        if (offsetOutPtr)
+            *offsetOutPtr = -1;
+    }
+    if (beforeStr)
+        (*beforeStr)->CopyFromSubString(&beforeSub);
+    if (matchStr)
+        (*matchStr)->CopyFromSubString(&matchSub);
+    if (afterStr)
+        (*afterStr)->CopyFromSubString(&afterSub);
+    if (cpat)
+        cpat->Type()->ClearData(&cpat);
+    return _NextInstruction();
+}
+
+DEFINE_VIREO_BEGIN(String)
+DEFINE_VIREO_FUNCTION(MatchPattern, "p(i(String) i(String) i(Int32) o(String) o(String) o(String) o(Int32))")
+DEFINE_VIREO_END()

--- a/source/include/StringUtilities.h
+++ b/source/include/StringUtilities.h
@@ -212,7 +212,9 @@ public:
     SubString(ConstCStr begin)          { AliasAssign((const Utf8Char*)begin, (const Utf8Char*)(begin ? (begin + strlen(begin)) : begin)); }
     SubString(const Utf8Char* begin, const Utf8Char* end) { AliasAssign(begin, end); }
     SubString(SubString* original)      { AliasAssign(original->Begin(), original->End()); }
-    void AliasAssignCStr(ConstCStr begin) { AliasAssign((const Utf8Char*)begin, (const Utf8Char*)(begin + strlen(begin))); }
+    void AliasAssignCStrLen(ConstCStr begin, IntIndex n) { AliasAssign((const Utf8Char*)begin, (const Utf8Char*)(begin ? (begin + n) : begin)); }
+    void AliasAssignCStr(ConstCStr begin) { AliasAssignCStrLen(begin, IntIndex(strlen(begin))); }
+    void AliasAssignLen(const Utf8Char *begin, IntIndex len) { AliasAssign(begin, begin + len); }
     
     //! Skip all tokens and comments up to the next eol sequence
     void EatToEol();

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -1165,7 +1165,12 @@ class String : public TypedArray1D< Utf8Char >
 {
 public:
     SubString MakeSubStringAlias()              { return SubString(Begin(), End()); }
-    void CopyFromSubString(SubString* string)   { CopyFrom(string->Length(), string->Begin()); }
+    void CopyFromSubString(SubString* string)   {
+        if (string->Length())
+            CopyFrom(string->Length(), string->Begin());
+        else
+            Resize1D(0);
+    }
     void AppendCStr(ConstCStr cstr)             { Append((IntIndex)strlen(cstr), (Utf8Char*)cstr); }
     void AppendUtf8Str(Utf8Char* begin, IntIndex length) { Append(length, begin); }
     void AppendSubString(SubString* string)     { Append((IntIndex)string->Length(), (Utf8Char*)string->Begin()); }

--- a/test-it/MatchPat.via
+++ b/test-it/MatchPat.via
@@ -1,0 +1,68 @@
+//trace
+define(MatchPatternTest dv(.VirtualInstrument (
+ c(
+ e(dv(.String "a.*f") pat1)
+ e(dv(.String "!@#abcdefghi") str)
+ e(dv(.String "abcdexhi") str2)
+
+ e(dv(.String "^Ya[ab]+ada[ba]+ado+!*") pat2)
+ e(dv(.String "Yabbadabbbadoo!!") str3)
+ e(dv(.String "nYabbadabbbadoo!!") str4)
+ e(dv(.String "Yaadabbbadoo!!") str5)
+ e(dv(.String "Yabbadabbbadoofoo") str6)
+
+ e(dv(.String ".[^z\\r\\n]+\\n") pat3)
+ e(dv(.String "abcz\ndef\n") str7)
+ e(dv(.String "\nzHello\nWorld\n") str8)
+
+ e(dv(.String "xy[^a-y]+y") pat4)
+ e(dv(.String "xyzzy") str9)
+ e(dv(.String "xy\01\02y") str10)
+ e(dv(.String "xy[~a-y]+y") pat5)
+
+ e(dv(.String "") before)
+ e(dv(.String "") match)
+ e(dv(.String "") after)
+ e(dv(.Int32 0) off)
+ e(dv(.Int32 0) offOut)
+ )
+ clump(1 
+   MatchPattern(str pat1 off before match after offOut)
+   Printf("'%s' '%s' %d -> '%s' '%s' '%s' %d\n" str pat1 off before match after offOut)
+
+   MatchPattern(str2 pat1 off before match after offOut)
+   Printf("'%s' '%s' %d -> '%s' '%s' '%s' %d\n" str2 pat1 off before match after offOut)
+
+   MatchPattern(str3 pat2 off before match after offOut)
+   Printf("'%s' '%s' %d -> '%s' '%s' '%s' %d\n" str3 pat2 off before match after offOut)
+
+   MatchPattern(str4 pat2 off before match after offOut)
+   Printf("'%s' '%s' %d -> '%s' '%s' '%s' %d\n" str4 pat2 off before match after offOut)
+
+   MatchPattern(str4 pat2 1 before match after offOut)
+   Printf("'%s' '%s' %d -> '%s' '%s' '%s' %d\n" str4 pat2 1 before match after offOut)
+
+   MatchPattern(str5 pat2 off before match after offOut)
+   Printf("'%s' '%s' %d -> '%s' '%s' '%s' %d\n" str5 pat2 off before match after offOut)
+
+   MatchPattern(str6 pat2 off before match after offOut)
+   Printf("'%s' '%s' %d -> '%s' '%s' '%s' %d\n" str6 pat2 off before match after offOut)
+
+   MatchPattern(str7 pat3 off before match after offOut)
+   Printf("'%s' '%s' %d -> '%s' '%s' '%s' %d\n" str7 pat3 off before match after offOut)
+
+   MatchPattern(str8 pat3 off before match after offOut)
+   Printf("'%s' '%s' %d -> '%s' '%s' '%s' %d\n" str8 pat3 off before match after offOut)
+
+   MatchPattern(str9 pat4 off before match after offOut)
+   Printf("'%s' '%s' %d -> '%s' '%s' '%s' %d\n" str9 pat4 off before match after offOut)
+
+   MatchPattern(str10 pat4 off before match after offOut)
+   Printf("'%s' '%s' %d -> '%s' '%s' '%s' %d\n" str10 pat4 off before match after offOut)
+
+   MatchPattern(str10 pat5 off before match after offOut)
+   Printf("'%s' '%s' %d -> '%s' '%s' '%s' %d\n" str10 pat5 off before match after offOut)
+   )
+)))
+
+enqueue(MatchPatternTest)

--- a/test-it/results/MatchPat.vtr
+++ b/test-it/results/MatchPat.vtr
@@ -1,0 +1,22 @@
+'!@#abcdefghi' 'a.*f' 0 -> '!@#' 'abcdef' 'ghi' 9
+'abcdexhi' 'a.*f' 0 -> 'abcdexhi' '' '' -1
+'Yabbadabbbadoo!!' '^Ya[ab]+ada[ba]+ado+!*' 0 -> '' 'Yabbadabbbadoo!!' '' 16
+'nYabbadabbbadoo!!' '^Ya[ab]+ada[ba]+ado+!*' 0 -> 'nYabbadabbbadoo!!' '' '' -1
+'nYabbadabbbadoo!!' '^Ya[ab]+ada[ba]+ado+!*' 1 -> 'n' 'Yabbadabbbadoo!!' '' 17
+'Yaadabbbadoo!!' '^Ya[ab]+ada[ba]+ado+!*' 0 -> 'Yaadabbbadoo!!' '' '' -1
+'Yabbadabbbadoofoo' '^Ya[ab]+ada[ba]+ado+!*' 0 -> '' 'Yabbadabbbadoo' 'foo' 14
+'abcz
+def
+' '.[^z\r\n]+\n' 0 -> 'abcz' '
+def
+' '' 9
+'
+zHello
+World
+' '.[^z\r\n]+\n' 0 -> '
+' 'zHello
+' 'World
+' 8
+'xyzzy' 'xy[^a-y]+y' 0 -> '' 'xyzzy' '' 5
+'xyy' 'xy[^a-y]+y' 0 -> 'xyy' '' '' -1
+'xyy' 'xy[~a-y]+y' 0 -> '' 'xyy' '' 5

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -147,6 +147,7 @@
                 "MandelbrotInline.via",
                 "MandelbrotStringConcat.via",
                 "Mandelbrot.via",
+                "MatchPat.via",
                 "MathFunctions.via",
                 "MaxAndMinElts.via",
                 "MaxAndMin.via",


### PR DESCRIPTION
MatchPattern(i(String string) i(String pattern) i(Int32 offset)
   o(String beforeStr) o(String matchStr) o(String afterStr) o(Int32 offsetPastMatch)

Match Pattern works on a very simple subset of regular expressions and
does not support | alternation or capture groups or modern PCRE
features.
The full Match Regular Expression prim is not yet supported.

Added minimal Match Pattern unit tests, but it needs to be further
fleshed out.