### PR TITLE
Temporary change for JSON encoding of enums. Return numeric value of …

### DIFF
--- a/source/include/TDCodecVia.h
+++ b/source/include/TDCodecVia.h
@@ -36,6 +36,10 @@ enum ViaFormat {
     kViaFormat_JSONStrictValidation = 32
 };
 
+#define kJSONEncoding "JSON"
+#define kVIAEncoding "VIA"
+#define kCEncoding "C"
+
 struct ViaFormatChars
 {
     ConstCStr   _name;
@@ -47,11 +51,12 @@ struct ViaFormatChars
     Utf8Char    _quote;
     ViaFormat   _fieldNameFormat;
 
-    Boolean UseFieldNames()      { return _fieldNameFormat &  kViaFormat_UseFieldNames ? true : false; }
-    Boolean QuoteFieldNames()    { return (_fieldNameFormat & kViaFormat_FieldNameMask) == kViaFormat_QuotedFieldNames; }
-    Boolean SuppressInfNaN()     { return (_fieldNameFormat & kViaFormat_SuppressInfNaN) ? true : false; }
-    Boolean LongNameInfNaN()     { return (_fieldNameFormat & kViaFormat_UseLongNameInfNaN) ? true : false; }
+    Boolean UseFieldNames()        { return _fieldNameFormat &  kViaFormat_UseFieldNames ? true : false; }
+    Boolean QuoteFieldNames()      { return (_fieldNameFormat & kViaFormat_FieldNameMask) == kViaFormat_QuotedFieldNames; }
+    Boolean SuppressInfNaN()       { return (_fieldNameFormat & kViaFormat_SuppressInfNaN) ? true : false; }
+    Boolean LongNameInfNaN()       { return (_fieldNameFormat & kViaFormat_UseLongNameInfNaN) ? true : false; }
     Boolean JSONStrictValidation() { return (_fieldNameFormat & kViaFormat_JSONStrictValidation) ? true : false; }
+    Boolean GenerateJSON()         { return strcmp(_name, kJSONEncoding) == 0; }
 };
 
 struct ViaFormatOptions

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -95,6 +95,7 @@
                 "EggShellError3.via",
                 "EggShellError4.via",
                 "EggShellError5.via",
+                "EnumBasic.via",
                 "Ethan1.via",
                 "EthanOpts2.via",
                 "ExtraArrayInializers.via",


### PR DESCRIPTION
…enum instead of name. We will revisit this once the the system dependent on Vireo is fixed