### PR TITLE
Make VI own a copy of its name string instead of using a substring,

### DIFF
--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -430,7 +430,7 @@ TypeRef TDViaParser::ParseDefine()
         VirtualInstrumentObjectRef vio = *(VirtualInstrumentObjectRef*)type->Begin(kPARead);
         if (vio && vio->ObjBegin()) {
             VirtualInstrument *vi = vio->ObjBegin();
-            vi->SetVIName(&symbolName);
+            vi->SetVIName(symbolName);
         }
     }
     if (!_string.EatChar(')')) {

--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -430,7 +430,7 @@ TypeRef TDViaParser::ParseDefine()
         VirtualInstrumentObjectRef vio = *(VirtualInstrumentObjectRef*)type->Begin(kPARead);
         if (vio && vio->ObjBegin()) {
             VirtualInstrument *vi = vio->ObjBegin();
-            vi->SetVIName(symbolName);
+            vi->SetVIName(&symbolName);
         }
     }
     if (!_string.EatChar(')')) {

--- a/source/core/VirtualInstrument.cpp
+++ b/source/core/VirtualInstrument.cpp
@@ -29,6 +29,7 @@ NIError VirtualInstrument::Init(TypeManagerRef tm, Int32 clumpCount, TypeRef par
     // The preliminary initialization defines a generic VI
     // finish it out by defining its type.
     _typeManager = tm;
+    _viName = NULL;
     _params->SetElementType(paramsType, false);
     _locals->SetElementType(localsType, false);
     _clumps->Resize1D(clumpCount);

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -1165,7 +1165,7 @@ class String : public TypedArray1D< Utf8Char >
 {
 public:
     SubString MakeSubStringAlias()              { return SubString(Begin(), End()); }
-    void CopyFromSubString(SubString* string)   {
+    void CopyFromSubString(const SubString* string)   {
         if (string->Length())
             CopyFrom(string->Length(), string->Begin());
         else

--- a/source/include/VirtualInstrument.h
+++ b/source/include/VirtualInstrument.h
@@ -73,10 +73,10 @@ public:
             s.AliasAssignLen(_viName, IntIndex(strlen(ConstCStr(_viName))));
         return s;
     }
-    void SetVIName(const SubString *s)   {
-        IntIndex len = s->Length();
-        _viName = (Utf8Char*)malloc(len+1);
-        memcpy(_viName, s->Begin(), len);
+    void SetVIName(const SubString &s)   {
+        IntIndex len = s.Length();
+        _viName = new Utf8Char[len+1];
+        memcpy(_viName, s.Begin(), len);
         _viName[len] = 0;
     }
     SubString ClumpSource() const       { return _clumpSource; }

--- a/source/include/VirtualInstrument.h
+++ b/source/include/VirtualInstrument.h
@@ -62,7 +62,7 @@ public :
 
 public:
     VirtualInstrument(ExecutionContextRef context, int clumps, TypeRef paramsType, TypeRef localsType);
-    ~VirtualInstrument()               { if (_viName) delete _viName; }
+    ~VirtualInstrument()               { if (_viName) delete[] _viName; }
     TypeManagerRef TheTypeManager()     { return _typeManager; }
     TypedObjectRef Params()             { return _params; }
     TypedObjectRef Locals()             { return _locals; }

--- a/source/include/VirtualInstrument.h
+++ b/source/include/VirtualInstrument.h
@@ -34,7 +34,7 @@ class VIClump;
     e(a(*) Locals)                 \
     e(a(Clump *) Clumps)           \
     e(Int32 LineNumberBase)        \
-    e(SubString VIName)            \
+    e(DataPointer VIName)          \
     e(SubString ClumpSource)       \
 ))"
 
@@ -52,7 +52,7 @@ private:
     void ClearTopVIParamBlock();
 public:
     Int32                   _lineNumberBase;
-    SubString               _viName;
+    Utf8Char*               _viName;
     SubString               _clumpSource;         // For now, this is tied to the VIA codec. It has a Begin and End pointer
 public :
     NIError Init(TypeManagerRef tm, Int32 clumpCount, TypeRef paramsType, TypeRef localsType, Int32 lineNumberBase, SubString* source);
@@ -62,12 +62,23 @@ public :
 
 public:
     VirtualInstrument(ExecutionContextRef context, int clumps, TypeRef paramsType, TypeRef localsType);
+    ~VirtualInstrument()               { if (_viName) delete _viName; }
     TypeManagerRef TheTypeManager()     { return _typeManager; }
     TypedObjectRef Params()             { return _params; }
     TypedObjectRef Locals()             { return _locals; }
     TypedArray1D<VIClump>* Clumps()     { return _clumps; }
-    SubString VIName()                  { return _viName; }
-    void SetVIName(SubString s)         { _viName = s; }
+    SubString VIName()                  {
+        SubString s;
+        if (_viName)
+            s.AliasAssignLen(_viName, IntIndex(strlen(ConstCStr(_viName))));
+        return s;
+    }
+    void SetVIName(const SubString *s)   {
+        IntIndex len = s->Length();
+        _viName = (Utf8Char*)malloc(len+1);
+        memcpy(_viName, s->Begin(), len);
+        _viName[len] = 0;
+    }
     SubString ClumpSource() const       { return _clumpSource; }
 };
 

--- a/test-it/results/PrintHelloWorld.vtr
+++ b/test-it/results/PrintHelloWorld.vtr
@@ -1,4 +1,4 @@
 Hello, world. I can fly.
 42
-(^TypeManager_null * * () 0 (^DataPointer_null ^DataPointer_null) (^DataPointer_null ^DataPointer_null))
-(^TypeManager () ('Hello, world. I can fly.') ((^InstructionBlock ^DataPointer_null 0 ^DataPointer ^DataPointer_null ^DataPointer_null ^Instruction 1 0 0 (^DataPointer_null ^DataPointer_null ^DataPointer_null 0) (^DataPointer_null ^DataPointer_null ^DataPointer_null 0))) 12 (^DataPointer ^DataPointer) (^DataPointer ^DataPointer))
+(^TypeManager_null * * () 0 ^DataPointer_null (^DataPointer_null ^DataPointer_null))
+(^TypeManager () ('Hello, world. I can fly.') ((^InstructionBlock ^DataPointer_null 0 ^DataPointer ^DataPointer_null ^DataPointer_null ^Instruction 1 0 0 (^DataPointer_null ^DataPointer_null ^DataPointer_null 0) (^DataPointer_null ^DataPointer_null ^DataPointer_null 0))) 12 ^DataPointer (^DataPointer ^DataPointer))

--- a/test-it/results/V3.vtr
+++ b/test-it/results/V3.vtr
@@ -1,5 +1,5 @@
-(^TypeManager (null) ('Hello') ((^InstructionBlock ^DataPointer_null 0 ^DataPointer ^DataPointer_null ^DataPointer_null ^Instruction 1 1 0 (^DataPointer_null ^DataPointer_null ^DataPointer_null 0) (^DataPointer_null ^DataPointer_null ^DataPointer_null 0))) 29 (^DataPointer ^DataPointer) (^DataPointer ^DataPointer))
+(^TypeManager (null) ('Hello') ((^InstructionBlock ^DataPointer_null 0 ^DataPointer ^DataPointer_null ^DataPointer_null ^Instruction 1 1 0 (^DataPointer_null ^DataPointer_null ^DataPointer_null 0) (^DataPointer_null ^DataPointer_null ^DataPointer_null 0))) 29 ^DataPointer (^DataPointer ^DataPointer))
 Convert <
-(^TypeManager (null) ('Hello') ((^InstructionBlock ^DataPointer_null 0 ^DataPointer ^DataPointer_null ^DataPointer_null ^Instruction 1 1 0 (^DataPointer_null ^DataPointer_null ^DataPointer_null 0) (^DataPointer_null ^DataPointer_null ^DataPointer_null 0))) 29 (^DataPointer ^DataPointer) (^DataPointer ^DataPointer))
+(^TypeManager (null) ('Hello') ((^InstructionBlock ^DataPointer_null 0 ^DataPointer ^DataPointer_null ^DataPointer_null ^Instruction 1 1 0 (^DataPointer_null ^DataPointer_null ^DataPointer_null 0) (^DataPointer_null ^DataPointer_null ^DataPointer_null 0))) 29 ^DataPointer (^DataPointer ^DataPointer))
 Convert >
 Hello


### PR DESCRIPTION
(The source string used to initialize the VI name could be volatile.)