### PR TITLE
Optimize EggShell_ReadValueString

### DIFF
--- a/Vireo_Xcode/VireoEggShell.xcodeproj/xcshareddata/xcschemes/EggShell.xcscheme
+++ b/Vireo_Xcode/VireoEggShell.xcodeproj/xcshareddata/xcschemes/EggShell.xcscheme
@@ -106,10 +106,11 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
-      useCustomWorkingDirectory = "NO"
+      useCustomWorkingDirectory = "YES"
+      customWorkingDirectory = "${PROJECT_DIR}/../test-it"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/source/core/TypeAndDataManager.cpp
+++ b/source/core/TypeAndDataManager.cpp
@@ -2207,7 +2207,7 @@ Boolean TypedArrayCore::ResizeDimensions(Int32 rank, IntIndex *dimensionLengths,
     }
     
     // 2. If underlying capacity changes, change that.
-    if (bOK && newCapacity != Capacity()) {
+    if (bOK && ((!noInit && newCapacity != Capacity()) || (noInit && newCapacity > Capacity()))) {
         VIREO_ASSERT(newLength <= newCapacity);
         bOK = ResizeCapacity(slabLength, Capacity(), newCapacity, (newLength < newCapacity));
     }

--- a/source/include/DataTypes.h
+++ b/source/include/DataTypes.h
@@ -143,10 +143,10 @@ typedef Int64   AQBlock8;
 //------------------------------------------------------------
 #ifdef VIREO_USING_ASSERTS
     #ifdef VIREO_MICRO
-        #define VIREO_ASSERT( _TEST_ ) VireoAssert_Hidden( _TEST_, __FILE__, __LINE__ );
+        #define VIREO_ASSERT( _TEST_ ) if (!(_TEST_)) VireoAssert_Hidden( _TEST_, __FILE__, __LINE__ ); else;
         void VireoAssert_Hidden(Boolean test, ConstCStr file, int line);
     #else
-        #define VIREO_ASSERT( _TEST_ ) VireoAssert_Hidden( _TEST_, #_TEST_, __FILE__, __LINE__ );
+        #define VIREO_ASSERT( _TEST_ ) if (!(_TEST_)) VireoAssert_Hidden( _TEST_, #_TEST_, __FILE__, __LINE__ ); else;
         void VireoAssert_Hidden(Boolean test, ConstCStr message, ConstCStr file, int line);
     #endif
 #else


### PR DESCRIPTION
The FormatData call is inefficient for arrays by resizing the output
string one sub-element at a time.  Estimating the string size ahead of time
and preallocating the output cuts the time in half.