### PR TITLE
Move server log to after_script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,6 @@ script:
 - make testjs
 - make testnative
 - npm run test
-- jobs -l
-- kill $!
-- wait
-- cat ./nohup.out
 deploy:
   provider: npm
   email: mark.black@ni.com
@@ -49,3 +45,8 @@ deploy:
   on:
     tags: true
     repo: ni/VireoSDK
+after_script:
+- jobs -l
+- kill $!
+- wait
+- cat ./nohup.out


### PR DESCRIPTION
Minor change, cleans up build logs a little. Example: https://travis-ci.org/rajsite/VireoSDK/builds/213150587