### PR TITLE
Perform --ff-only merge to validate emsdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 - npm install
 - pip install --user -r requirements.txt
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
-- if ! git clone --depth 1 https://github.com/ni-kismet/emscripten-sdk.git; then git pull; fi
+- if ! git clone --depth 1 https://github.com/ni-kismet/emscripten-sdk.git; then cd emscripten-sdk && git remote update -p && git merge --ff-only origin/master && cd ..; fi
 - emscripten-sdk/emsdk activate --build=Release sdk-master-64bit
 - source emscripten-sdk/emsdk_env.sh
 - cat ~/.emscripten

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The `esh` and `vireo.js` files will be put into the `./dist` directory.
 $ make native
 ```
 
-#### Build Javascript File
+#### Build JavaScript File
 ```shell
 $ make js
 ```
@@ -81,7 +81,7 @@ $ ./test.js -h
 Usage: ./test.js [options] [via test files]
 Options:
  -n                  Run the tests against the native vireo target (esh)
- -j                  Run the tests against the javascript target (vireo.js)
+ -j                  Run the tests against the JavaScript target (vireo.js)
  -t [test suite]     Run the tests in the given test suite
  -l [test suite]     List the tests that would be run in given test suite,
                         or list the test suite options if not provided


### PR DESCRIPTION
Noticed in a failed build the following output

```
fatal: destination path 'emscripten-sdk' already exists and is not an empty directory.
remote: Counting objects: 5, done.
remote: Compressing objects: 100% (1/1), done.
remote: Total 5 (delta 4), reused 5 (delta 4), pack-reused 0
Unpacking objects: 100% (5/5), done.
From https://github.com/ni/VireoSDK
   5436b38..e5e25c3  incoming   -> origin/incoming
Merge branch 'incoming' of https://github.com/ni/VireoSDK into HEAD
# Please enter a commit message to explain why this merge is necessary,
# especially if it merges an updated upstream into a topic branch.
#
# Lines starting with '#' will be ignored, and an empty message aborts
# the commit.
~                                                                               
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
The build has been terminated
```

Realized the script for validating the cache was actually doing the pull against ni/VireoSDK and not ni-kismet/emscripten-sdk

Modified the script to actually validate emscripten-sdk and to do so by attempting a fast forward merge. Best case changes to emscripten-sdk are correctly picked up and worst case it fails and causes cache eviction.