### PR TITLE
Fix lint errors for TODO usage, avoiding using namespace,  and header…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ before_script:
 - nohup python -m httpbin.core --port 64526 &
 - while ! nc -q 1 127.0.0.1 64526 </dev/null; do sleep 2; done
 - curl http://127.0.0.1:64526/get?show_env=1
-- make
 - make lint
+- make
 script:
 - make testjs
 - make testnative

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_script:
 - while ! nc -q 1 127.0.0.1 64526 </dev/null; do sleep 2; done
 - curl http://127.0.0.1:64526/get?show_env=1
 - make
+- make lint
 script:
 - make testjs
 - make testnative

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ all: native js
 
 native:	simple
 
+lint:
+	@cd make-it/cpplint; make $@
+
 simple v32 v64:
 	cd make-it; make $@
 

--- a/make-it/Makefile
+++ b/make-it/Makefile
@@ -11,7 +11,7 @@ COMMANDLINE = main.cpp
 CORE = Array.cpp Assert.cpp CEntryPoints.cpp Date.cpp EventLog.cpp ExecutionContext.cpp GenericFunctions.cpp MatchPat.cpp Math.cpp NumericString.cpp Platform.cpp Queue.cpp RefNum.cpp String.cpp StringUtilities.cpp Synchronization.cpp TDCodecLVFlat.cpp TDCodecVia.cpp Thread.cpp TimeFunctions.cpp Timestamp.cpp TypeAndDataManager.cpp TypeAndDataReflection.cpp TypeDefiner.cpp TypeTemplates.cpp UnitTest.cpp VirtualInstrument.cpp Waveform.cpp
 UNITTEST = RefNumTest.cpp
 #CORE = VireoMerged.cpp Thread.cpp Timestamp.cpp CEntryPoints.cpp
-IO = FileIO.cpp Canvas2d.cpp DebugGPIO.cpp
+IO = FileIO.cpp Canvas2d.cpp DebugGPIO.cpp HttpClient.cpp
 
 OBJS = $(COMMANDLINEOBJS) $(COREOBJS) $(IOOBJS)
 COMMANDLINEOBJS = $(COMMANDLINE:%.cpp=$(OBJDIR)/%.o)

--- a/make-it/cpplint/Makefile
+++ b/make-it/cpplint/Makefile
@@ -1,14 +1,9 @@
-LINTARGS = --linelength=160 --filter=-whitespace/braces,-build/include_what_you_use,-build/header_guard,-readability/casting,-readability/todo,-build/namespaces
+LINTARGS = --linelength=160 --filter=-whitespace/braces,-build/header_guard,-readability/casting
 
 # Ignored warnings:
 # whitespace/braces -- warn if function open brace is on its own line instead of end of previous line; why??
-# build/include_what_you_use -- generates false positives for arguments namd 'string'
 # readability/casting -- C-style casts.  AQBlock1* casts are common in polymorphic prims and reinterpret_cast would make the code harder to read.
 # build/header_guard -- wants include guard to include file path (_SOURCE_INCLUDE_) prefixes, which is unnecessary since all of our includes are in the same folder
-
-# Ignored warnings that should eventually be turned on:
-# readability/todo -- required usernames for all TODOs, probably a good idea, but we have too many without and no good way to assign
-# build/namespaces - don't use 'using namespace X'
 
 XLINTARGS = $(subst ' ',,$(LINTARGS))
 

--- a/source/CommandLine/MicroMain.cpp
+++ b/source/CommandLine/MicroMain.cpp
@@ -10,8 +10,6 @@
 #include "DataTypes.h"
 #include "ExecutionContext.h"
 
-using namespace Vireo;
-
 #ifndef VIREO_MICRO
 #error this main is for the single context micro vireo
 #endif

--- a/source/CommandLine/SimpleCountMain.cpp
+++ b/source/CommandLine/SimpleCountMain.cpp
@@ -14,7 +14,7 @@ SDG
     #include <emscripten.h>
 #endif
 
-using namespace Vireo;
+namespace Vireo {
 
 #if 1
 const char* VireoProgram = "\
@@ -68,9 +68,12 @@ enqueue (Loop)\
 
 void RunExec();
 TypeManagerRef  gpShell;
+}  // namespace Vireo
 
 int VIREO_MAIN(int argc, const char * argv[])
 {
+    using namespace Vireo;
+
     PlatformIO::Printf("Simple Counting Vireo Egg Shell built %s\n",__TIME__ );
     SubString  subString(VireoProgram);
 
@@ -89,8 +92,7 @@ int VIREO_MAIN(int argc, const char * argv[])
     return 0;
 }
 
-void RunExec() {
-
+void Vireo::RunExec() {
     gState = ((EggShell*)gpShell)->TheExecutionContext()->ExecuteSlices(400);
 
 #if kVireoOS_emscripten

--- a/source/CommandLine/main.cpp
+++ b/source/CommandLine/main.cpp
@@ -15,7 +15,7 @@ SDG
     #include <emscripten.h>
 #endif
 
-using namespace Vireo;
+namespace Vireo {
 
 static struct {
     TypeManagerRef _pRootShell;
@@ -25,10 +25,13 @@ static struct {
 
 void RunExec();
 
+}  // namespace Vireo
 
 //------------------------------------------------------------
 int VIREO_MAIN(int argc, const char * argv[])
 {
+    using namespace Vireo;  // NOLINT(build/namespaces)
+
     gPlatform.Setup();
     gShells._keepRunning = true;
     LOG_PLATFORM_MEM("Mem after init")
@@ -105,9 +108,10 @@ int VIREO_MAIN(int argc, const char * argv[])
     gPlatform.Shutdown();
     return 0;
 }
+
 //------------------------------------------------------------
 //! Execution pump.
-void RunExec() {
+void Vireo::RunExec() {
     TypeManagerRef tm = gShells._pUserShell;
     TypeManagerScope scope(tm);
     gShells._keepRunning = tm->TheExecutionContext()->ExecuteSlices(400, 10000000) != kExecutionState_None;
@@ -119,3 +123,4 @@ void RunExec() {
 #endif
     }
 }
+

--- a/source/core/Array.cpp
+++ b/source/core/Array.cpp
@@ -19,7 +19,7 @@ SDG
 #include <algorithm>
 #include <cmath>
 
-using namespace Vireo;
+namespace Vireo {
 
 //------------------------------------------------------------
 DECLARE_VIREO_PRIMITIVE2(ArrayResize, TypedArrayCoreRef, IntIndex, (_Param(0)->Resize1D(_Param(1)) ))
@@ -1924,3 +1924,5 @@ DEFINE_VIREO_BEGIN(Array)
 #endif
 
 DEFINE_VIREO_END()
+
+}  // namespace Vireo

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -19,7 +19,7 @@ SDG
 #include "CEntryPoints.h"
 
 #if defined (VIREO_C_ENTRY_POINTS)
-using namespace Vireo;
+namespace Vireo {
 
 //------------------------------------------------------------
 VIREO_EXPORT Int32 Vireo_Version()
@@ -528,4 +528,7 @@ VIREO_EXPORT void Occurrence_Set(OccurrenceRef occurrence)
     OccurrenceCore *pOcc = occurrence->ObjBegin();
     pOcc->SetOccurrence();
 }
-#endif
+
+}  // namespace Vireo
+#endif  // VIREO_C_ENTRY_POINTS
+

--- a/source/core/EventLog.cpp
+++ b/source/core/EventLog.cpp
@@ -14,16 +14,16 @@ SDG
 #include "TypeAndDataManager.h"
 #include "EventLog.h"
 
-using namespace Vireo;
+namespace Vireo {
 
 //------------------------------------------------------------
 StringRef EventLog::DevNull = (StringRef) null;
 StringRef EventLog::StdOut = (StringRef) 1;
 
 //------------------------------------------------------------
-EventLog::EventLog(StringRef string)
+EventLog::EventLog(StringRef str)
 {
-    _errorLog = string;
+    _errorLog = str;
     _softErrorCount = 0;
     _hardErrorCount = 0;
     _warningCount = 0;
@@ -95,3 +95,6 @@ DEFINE_VIREO_BEGIN(EventLog)
     DEFINE_VIREO_FUNCTION(EventLogRecordEvent, "p(i(String))")
 DEFINE_VIREO_END()
 #endif
+
+}  // namespace Vireo
+

--- a/source/core/ExecutionContext.cpp
+++ b/source/core/ExecutionContext.cpp
@@ -86,7 +86,7 @@ InstructionCore* VIVM_FASTCALL Done(InstructionCore* _this _PROGMEM)
     // Now that any caller that needs to hoist data from the clump has been
     // taken care of, see if there are other clumps that are waiting in line.
     // What they are waiting for is unimportant here, only that they have been added the
-    // waiting list for this clump.  (TODO allow prioritization)
+    // waiting list for this clump.  (TODO(PaulAustin): allow prioritization)
 
     // Disconnect the list
     VIClump* waitingClump = runningQueueElt->_waitingClumps;
@@ -144,7 +144,7 @@ VIREO_FUNCTION_SIGNATURE1(FPSync, StringRef)
 // CurrentBrowserFPS - Returns the framerate of the browser in frames per second
 // First call starts the monitor and returns an FPS of zero
 // Subsequent calls return the most recent calculated FPS value
-// TODO verify that SLI can have the error terminal removed safely and remove unused error terminal from CurrentBrowserFPS
+// TODO(rajsite): verify that SLI can have the error terminal removed safely and remove unused error terminal from CurrentBrowserFPS
 VIREO_FUNCTION_SIGNATURE2(CurrentBrowserFPS, Double, ErrorCluster)
 {
     ErrorCluster *errPtr = _ParamPointer(1);
@@ -180,7 +180,7 @@ VIREO_FUNCTION_SIGNATURE1(Wait, VIClump)
 VIREO_FUNCTION_SIGNATURET(CallVI, CallVIInstruction)
 {
     VIClump *qe = _ParamImmediate(viRootClump);
-    // TODO move this to an Execution Context method?
+    // TODO(PaulAustin): move this to an Execution Context method?
     if (qe->_shortCount > 0) {
         // If the callee clump has a positive short count
         // it is not running there fore it is ok to run.
@@ -391,7 +391,7 @@ ExecutionState ExecutionContext::ExecuteSlices(Int32 numSlices, PlatformTickType
         reply = (ExecutionState) (reply | kExecutionState_ClumpsWaitingOnTime);
     }
 #ifdef VIREO_SINGLE_GLOBAL_CONTEXT
-    // TODO check global memory manager for allocation errors
+    // TODO(PaulAustin): check global memory manager for allocation errors
 #else
     if (THREAD_TADM()->_totalAllocationFailures > 0) {
         reply = kExecutionState_None;

--- a/source/core/GenericFunctions.cpp
+++ b/source/core/GenericFunctions.cpp
@@ -48,7 +48,7 @@ ConstCStr CopyProcName(void *pSource, void *pDest, Int32 aqSize, Boolean isEnum)
 //------------------------------------------------------------
 InstructionCore* EmitGenericCopyInstruction(ClumpParseState* pInstructionBuilder)
 {
-    // TODO security. user code should only be allowed to use the "Copy" operation,
+    // TODO(PaulAustin): security. user code should only be allowed to use the "Copy" operation,
     // not the more type-specific ones this function references.
     // those should be marked as kernel access. (can user name spaces over load the same names?)
     InstructionCore* pInstruction = null;
@@ -308,7 +308,7 @@ InstructionCore* EmitGenericBinOpInstruction(ClumpParseState* pInstructionBuilde
             // this will be the name of the _instructionPointerType.
             savedOperation = pInstructionBuilder->_instructionPointerType->Name();
             ConstCStr pVectorBinOpName = null;
-            // TODO: Validating runtime will require  type checking
+            // TODO(PaulAustin): Validating runtime will require  type checking
             if (sourceXType->IsArray() && sourceYType->IsArray()) {
                 if (savedOperation.CompareCStr("Split"))
                     pVectorBinOpName = "VectorVectorSplitOp";
@@ -358,7 +358,7 @@ InstructionCore* EmitGenericBinOpInstruction(ClumpParseState* pInstructionBuilde
                 pInstructionBuilder->BeginEmitSubSnippet(&snippetBuilder, vectorBinOp, accumulatorOpArgId);
                 snippetBuilder.StartInstruction(&accumulatorToken);
                 snippetBuilder.InternalAddArg(null, vectorBinOp == kFakedInstruction ?
-                                        null : vectorBinOp->_piSnippet);  // TODO this seems redundant
+                                        null : vectorBinOp->_piSnippet);  // TODO(PaulAustin): this seems redundant
                 snippetBuilder.EmitInstruction();
                 pInstructionBuilder->EndEmitSubSnippet(&snippetBuilder);
             }
@@ -723,7 +723,7 @@ VIREO_FUNCTION_SIGNATURET(ClusterMaxMinOp, AggregateMaxAndMinInstruction)
         pInstruction->_p1 += (size_t)_ParamPointer(SY);
         pInstruction->_p2 += (size_t)_ParamPointer(SMax);
         pInstruction->_p3 += (size_t)_ParamPointer(SMin);
-        InstructionCore* next = _PROGMEM_PTR(pInstruction, _function)(pInstruction);  // execute inline for now. TODO yield to the scheduler
+        InstructionCore* next = _PROGMEM_PTR(pInstruction, _function)(pInstruction);  // execute inline for now. TODO(PaulAustin): yield to the scheduler
         pInstruction->_p0 -= (size_t)_ParamPointer(SX);
         pInstruction->_p1 -= (size_t)_ParamPointer(SY);
         pInstruction->_p2 -= (size_t)_ParamPointer(SMax);
@@ -835,7 +835,7 @@ InstructionCore* EmitGenericInRangeAndCoerceInstruction(ClumpParseState* pInstru
             // this will be the name of the _instructionPointerType.
             savedOperation = pInstructionBuilder->_instructionPointerType->Name();
             ConstCStr pVectorBinOpName = null;
-            // TODO: Validating runtime will require  type checking
+            // TODO(PaulAustin): Validating runtime will require  type checking
             pVectorBinOpName = "VectorOrScalarInRangeOp";
             SubString vectorBinOpToken(pVectorBinOpName);
             pInstructionBuilder->ReresolveInstruction(&vectorBinOpToken, false);  // build a vector op
@@ -1544,7 +1544,7 @@ VIREO_FUNCTION_SIGNATUREV(ArrayConcatenateInternal, ArrayConcatenateInternalPara
         Int32 originalLength = pDest->Length();
         Int32 totalLength = 0;
         for (Int32 i = 0; i < numInputs; i++) {
-            // TODO check for overflow
+            // TODO(PaulAustin): check for overflow
             if (typeComparisons[i]) {  // input is an array
                 TypedArrayCoreRef arrayInput = *((TypedArrayCoreRef *) inputs[i]);
                 totalLength += arrayInput->Length();
@@ -1697,7 +1697,7 @@ VIREO_FUNCTION_SIGNATURET(ClusterUnaryOp, AggregateUnOpInstruction)
     while (ExecutionContext::IsNotCulDeSac(pInstruction)) {
         pInstruction->_p0 += (size_t)_ParamPointer(SSource);
         pInstruction->_p1 += (size_t)_ParamPointer(SDest);
-        InstructionCore* next = _PROGMEM_PTR(pInstruction, _function)(pInstruction);  // execute inline for now. TODO yield to the scheduler
+        InstructionCore* next = _PROGMEM_PTR(pInstruction, _function)(pInstruction);  // execute inline for now. TODO(PaulAustin): yield to the scheduler
         pInstruction->_p0 -= (size_t)_ParamPointer(SSource);
         pInstruction->_p1 -= (size_t)_ParamPointer(SDest);
         pInstruction = (Instruction2<AQBlock1, AQBlock1>*)next;
@@ -1712,7 +1712,7 @@ VIREO_FUNCTION_SIGNATURET(ClusterUnary2OutputOp, AggregateUnOp2OutputInstruction
         pInstruction->_p0 += (size_t)_ParamPointer(SSource);
         pInstruction->_p1 += (size_t)_ParamPointer(SDest);
         pInstruction->_p2 += (size_t)_ParamPointer(SDest2);
-        InstructionCore* next = _PROGMEM_PTR(pInstruction, _function)(pInstruction);  // execute inline for now. TODO yield to the scheduler
+        InstructionCore* next = _PROGMEM_PTR(pInstruction, _function)(pInstruction);  // execute inline for now. TODO(PaulAustin): yield to the scheduler
         pInstruction->_p0 -= (size_t)_ParamPointer(SSource);
         pInstruction->_p1 -= (size_t)_ParamPointer(SDest);
         pInstruction->_p2 -= (size_t)_ParamPointer(SDest2);

--- a/source/core/MatchPat.cpp
+++ b/source/core/MatchPat.cpp
@@ -14,7 +14,7 @@
 #include "TypeDefiner.h"
 #include <ctype.h>
 
-using namespace Vireo;
+namespace Vireo {
 
 static const UInt8 *AMatch(const UInt8 *, const Utf8Char*, const Utf8Char *);
 static Int32 InSet(UInt8 c, const Utf8Char *s, const Utf8Char *se);
@@ -418,3 +418,5 @@ VIREO_FUNCTION_SIGNATURE7(MatchPattern, StringRef, StringRef, Int32, StringRef, 
 DEFINE_VIREO_BEGIN(String)
 DEFINE_VIREO_FUNCTION(MatchPattern, "p(i(String) i(String) i(Int32) o(String) o(String) o(String) o(Int32))")
 DEFINE_VIREO_END()
+
+}  // namespace Vireo

--- a/source/core/Math.cpp
+++ b/source/core/Math.cpp
@@ -23,8 +23,6 @@ SDG
 #define DEFINE_VIREO_FUNCTION_TYPED(_root_, _type_, _proto_)  DEFINE_VIREO_FUNCTION_CUSTOM(_root_, _root_##_type_, _proto_)
 #define DEFINE_VIREO_FUNCTION_2TYPED(_root_, _type1_, _type2_, _proto_)  DEFINE_VIREO_FUNCTION_CUSTOM(_root_, _type1_##_root_##_type2_, _proto_)
 
-using namespace Vireo;
-
 // Different compilers expose different sets of function signatures for
 // integer abs, so we define our own.
 inline Int8  IntAbs(Int8  value) { return abs(value); }
@@ -42,11 +40,12 @@ inline Int64 IntAbs(Int64 value) { return llabs(value); }
     #endif
 #endif
 
+namespace Vireo {
+
 extern "C" {
 
 // For some platforms isnan, isinf, abs are functions in std not macros
-using namespace std;
-
+using namespace std;  // NOLINT(build/namespaces)s
 
 // Basic Math
 #define DECLARE_VIREO_MATH_PRIMITIVES(TYPE) \
@@ -338,7 +337,6 @@ DECLARE_SCALE2X_INTN_HELPER(Single)
 
 //------------------------------------------------------------
 // Conversion
-// #define BOOLEAN 0 //TODO, do we need boolean conversions?
 #define TC_UINT8 1
 #define TC_UINT16 2
 #define TC_UINT32 3
@@ -574,7 +572,7 @@ VIREO_FUNCTION_SIGNATURE1(Random, Double)
 DECLARE_VIREO_COMPARISON_PRIMITIVES(Utf8Char)
 //------------------------------------------------------------
 
-// TODO: Make this into a macro and move to INTEGER_MATH
+// TODO(PaulAustin): Make this into a macro and move to INTEGER_MATH
 VIREO_FUNCTION_SIGNATURE3(LogicalShiftInt32, UInt32, Int32, UInt32)
 {
     Int32 shift = _Param(1);
@@ -588,7 +586,7 @@ VIREO_FUNCTION_SIGNATURE3(LogicalShiftInt32, UInt32, Int32, UInt32)
 
 VIREO_FUNCTION_SIGNATURE3(RotateInt32, Int32, Int32, Int32)
 {
-    // TODO complete this function
+    // TODO(PaulAustin): complete this function
     Int32 rotate = _Param(1);
     if (rotate < 0) {
         _Param(2) = _Param(0) >> -rotate;
@@ -653,7 +651,6 @@ DEFINE_VIREO_BEGIN(IEEE754Math)
     DEFINE_VIREO_FUNCTION(BranchIfNull, "p(i(BranchTarget) i(DataPointer))");
     DEFINE_VIREO_FUNCTION(BranchIfNotNull, "p(i(BranchTarget) i(DataPointer))");
     DEFINE_VIREO_COMPARISON_FUNCTIONS(Boolean)
-    // TODO do we need conversion functions for booleans?? just to int16?
 
     //--------------------------
     // UInt8
@@ -766,7 +763,7 @@ DEFINE_VIREO_BEGIN(IEEE754Math)
     DEFINE_VIREO_BRANCH_FUNCTIONS(Int32)
 
 #if 1
-    // TODO remove these once no targets are no longer relying on current gen LV via emitter
+    // TODO(PaulAustin): remove these once no targets are no longer relying on current gen LV via emitter
     // Generator 1.0 VIA generator for LV and a few of the tests use type specific
     // branch instructions. These support the ones needed.
 #if defined (VIREO_TYPE_Int32)
@@ -805,7 +802,7 @@ DEFINE_VIREO_BEGIN(IEEE754Math)
     // Single
 #if defined(VIREO_TYPE_Single)
 #if 0
-    // TODO once type dependency sequencing works these definitions can be moved here.
+    // TODO(PaulAustin): once type dependency sequencing works these definitions can be moved here.
     DEFINE_VIREO_TYPE(SingleAtomic, "c(e(bc(e(bb(32 IEEE754B)))))")
     DEFINE_VIREO_TYPE(SingleCluster, "c(e(bc(e(bb(1 Boolean) sign) e(bb(8 BiasedInt) exponent) e(bb(23 Q1) fraction))))")
     DEFINE_VIREO_TYPE(Single, "eq(e(.SingleAtomic), e(.SingleCluster))")
@@ -1125,4 +1122,6 @@ DEFINE_VIREO_BEGIN(IEEE754ComplexDoubleMath)
 DEFINE_VIREO_END()
 
 #endif
+
+}  // namespace Vireo
 

--- a/source/core/NumericString.cpp
+++ b/source/core/NumericString.cpp
@@ -619,7 +619,7 @@ void Format(SubString *format, Int32 count, StaticTypeAndData arguments[], Strin
                     break;
                     case 'a': case 'A':
                     {
-                        // TODO don't assume data type. This just becomes the default format for real numbers, then use formatter
+                        // TODO(PaulAustin): don't assume data type. This just becomes the default format for real numbers, then use formatter
                         SubString percentFormat(fOptions.FmtSubString.Begin()-1, fOptions.FmtSubString.End());
                         TempStackCString tempFormat(&percentFormat);
                         // Get the numeric string that will replace the format string
@@ -1915,12 +1915,12 @@ void MakeFormatString(StringRef format, ErrorCluster *error, Int32 argCount, Sta
         } else if (argType->IsTimestamp()) {
             format->AppendCStr("%T ");
         } else {
-            error->code = -1;  // TODO ErrorCluster fix error codes
+            error->code = -1;  // TODO(sanmut): ErrorCluster fix error codes
             error->status = true;
             break;
         }
         if (error->status == false && format->Length() > 255) {
-            error->code = -1;  // TODO ErrorCluster fix error codes
+            error->code = -1;  // TODO(sanmut): ErrorCluster fix error codes
             error->status = true;
             break;
         }

--- a/source/core/Platform.cpp
+++ b/source/core/Platform.cpp
@@ -57,8 +57,6 @@ extern "C" void std_io_init();
 extern "C" void _exit();
 extern uint32_t gTickCount;
 
-using namespace Vireo;
-
 void* operator new(std::size_t size) {
     return gPlatform.Mem.Malloc(size);
 }
@@ -207,22 +205,22 @@ void DumpPlatformMemoryLeaks() {  // to be called from debugger
 #endif
 //============================================================
 //! Static memory deallocator used for all TM memory management.
-void PlatformIO::Print(ConstCStr string)
+void PlatformIO::Print(ConstCStr str)
 {
-    fwrite(string, 1, strlen(string), stdout);
+    fwrite(str, 1, strlen(str), stdout);
 #if kVireoOS_emscripten
     fflush(stdout);
 #endif
 #if VIREO_JOURNAL_ALLOCS
-    if (*string == 256)  // never true, hack to prevent dead code elim, only for debugging
+    if (*str == 256)  // never true, hack to prevent dead code elim, only for debugging
         DumpPlatformMemoryLeaks();
 #endif
 }
 //------------------------------------------------------------
 //! Static memory deallocator used for all TM memory management.
-void PlatformIO::Print(Int32 len, ConstCStr string)
+void PlatformIO::Print(Int32 len, ConstCStr str)
 {
-    fwrite(string, 1, len, stdout);
+    fwrite(str, 1, len, stdout);
 #if kVireoOS_emscripten
     fflush(stdout);
 #endif
@@ -322,7 +320,7 @@ void PlatformIO::ReadStdin(StringRef buffer)
             }
             PlatformIO::Print("\n");
 
-            string->AliasAssign((Utf8Char*)_mallocBuffer, (Utf8Char*)_mallocBuffer + packetSize);
+            buffer->AliasAssign((Utf8Char*)_mallocBuffer, (Utf8Char*)_mallocBuffer + packetSize);
             PlatformIO::Printf("packet read complete <%d>\n", (int)packetSize);
             return kNIError_Success;
         } else {
@@ -334,7 +332,7 @@ void PlatformIO::ReadStdin(StringRef buffer)
                 _mallocBuffer[i++] = c;
                 c = fgetc(stdin);
             }
-            string->AliasAssign((Utf8Char*)_mallocBuffer, (Utf8Char*)_mallocBuffer + i);
+            buffer->AliasAssign((Utf8Char*)_mallocBuffer, (Utf8Char*)_mallocBuffer + i);
             return ((c == (char)EOF) && (0 == i)) ? kNIError_kResourceNotFound : kNIError_Success;
         }
         return kNIError_Success;

--- a/source/core/RefNum.cpp
+++ b/source/core/RefNum.cpp
@@ -15,8 +15,9 @@ Craig S.
 #include "RefNum.h"
 #include "ExecutionContext.h"
 #include "VirtualInstrument.h"
+#include <vector>
 
-using namespace Vireo;
+namespace Vireo {
 
 #define kNumberOfIndexBits  20
 #define kNumberOfMagicBits  (32 - kNumberOfIndexBits)    // 12 bits of magic number 4K
@@ -194,7 +195,7 @@ Int32 RefNumStorageBase::GetRefNumCount() {
 
 NIError RefNumStorageBase::GetRefNumList(RefNumList *list) {
     list->clear();
-#if 0  // TODO finish
+#if 0  // TODO(spathiwa): finish
     list->reserve(_refStorage.size());
     typename RefNumMap::iterator it = _refStorage.begin(), ite = _refStorage.end();
     while (it != ite) {
@@ -312,6 +313,8 @@ void RefNumManager::RunCleanupProcs(VirtualInstrument *vi) {
     }
 }
 
-void Vireo::RunCleanupProcs(VirtualInstrument *vi) {
+void RunCleanupProcs(VirtualInstrument *vi) {
     return RefNumManager::RunCleanupProcs(vi);
 }
+
+}  // namespace Vireo

--- a/source/core/String.cpp
+++ b/source/core/String.cpp
@@ -18,15 +18,15 @@ SDG
 #include "TDCodecVia.h"
 #include <ctype.h>
 
-using namespace Vireo;
+namespace Vireo {
 
 //---------------------------------------------
 //! Append a ViaEncoded string, decode it in the process.
-void String::AppendViaDecoded(SubString* string)
+void String::AppendViaDecoded(SubString* str)
 {
     Int32 value = 0;
     Utf8Char c;
-    SubString ss(*string);
+    SubString ss(*str);
 
     IntIndex originalLength = Length();
     Int32 decodedLength = originalLength + ss.Length();
@@ -43,7 +43,7 @@ void String::AppendViaDecoded(SubString* string)
         // Pass two, copy over the characters and decode
         // valid %XX sequences. Warning, %XX values above
         // 127 could easily result in invalid Utf8 sequences.
-        ss = *string;
+        ss = *str;
         Utf8Char* pDest = BeginAt(originalLength);
         while (ss.ReadRawChar(&c)) {
             if (c == '%' && ss.ReadHex2(&value)) {
@@ -137,7 +137,7 @@ struct ReplaceSubstringStruct : public InstructionCore
     _ParamDef(StringRef, ReplacementString);
     _ParamDef(Int32, Offset);
     _ParamDef(Int32, Length);
-    _ParamDef(StringRef, ResultString);  // TODO cannot be in-place , might need to allow for this
+    _ParamDef(StringRef, ResultString);  // TODO(PaulAustin): cannot be in-place , might need to allow for this
     _ParamDef(StringRef, ReplacedSubString);
     NEXT_INSTRUCTION_METHOD()
 };
@@ -356,7 +356,7 @@ VIREO_FUNCTION_SIGNATURE2(StringToUpper, StringRef, StringRef)
 
     _Param(1)->Resize1D(targetLength);
 
-    // TODO only works for U+0000 .. U+007F
+    // TODO(PaulAustin): only works for U+0000 .. U+007F
     Utf8Char *pSourceChar      = _Param(0)->Begin();
     Utf8Char *pSourceCharEnd   = _Param(0)->End();
     Utf8Char *pDestChar        = _Param(1)->Begin();
@@ -372,11 +372,11 @@ VIREO_FUNCTION_SIGNATURE2(StringToUpper, StringRef, StringRef)
 //------------------------------------------------------------
 VIREO_FUNCTION_SIGNATURE2(StringToLower, StringRef, StringRef)
 {
-    IntIndex targetLength = _Param(0)->Length();  // TODO only works for Ascii
+    IntIndex targetLength = _Param(0)->Length();  // TODO(PaulAustin): only works for Ascii
 
     _Param(1)->Resize1D(targetLength);
 
-    // TODO only works for U+0000 .. U+007F
+    // TODO(PaulAustin): only works for U+0000 .. U+007F
     // Adding Latin/Russian/Greek/Armenian not "too" hard
     // http://www.unicode.org/Public/UNIDATA/UnicodeData.txt
     // ftp://ftp.unicode.org/Public/3.0-Update/UnicodeData-3.0.0.html
@@ -665,7 +665,7 @@ VIREO_FUNCTION_SIGNATUREV(StringConcatenate, StringConcatenateParamBlock)
     for (Int32 i = 0; i < numInputs; i++) {
         TypedArrayCoreRef arrayInput = *(inputs[i]);
         if (arrayInput->ElementType()->IsArray()) {
-            // TODO this needs to support N-Dim string arrays
+            // TODO(PaulAustin): this needs to support N-Dim string arrays
             for (Int32 j = 0; j < arrayInput->Length(); j++) {
                 StringRef stringInput = *(StringRef*) arrayInput->BeginAt(j);
                 totalLength += stringInput->Length();
@@ -675,7 +675,7 @@ VIREO_FUNCTION_SIGNATUREV(StringConcatenate, StringConcatenateParamBlock)
         }
     }
     pDest->Resize1D(totalLength);
-    // TODO error check
+    // TODO(PaulAustin): error check
     AQBlock1* pInsert = pDest->BeginAt(0);
 
     TypeRef elementType = pDest->ElementType();  // Flat char type
@@ -683,7 +683,7 @@ VIREO_FUNCTION_SIGNATUREV(StringConcatenate, StringConcatenateParamBlock)
     for (Int32 i = 0; i < numInputs; i++) {
         TypedArrayCoreRef arrayInput = *(inputs[i]);
         if (arrayInput->ElementType()->IsArray())  {
-            // TODO this needs to support N-Dim string arrays
+            // TODO(PaulAustin): this needs to support N-Dim string arrays
             for (Int32 j = 0; j < arrayInput->Length(); j++) {
                 StringRef stringInput = *(StringRef*) arrayInput->BeginAt(j);
                 VIREO_ASSERT(stringInput != pDest);
@@ -861,3 +861,5 @@ DEFINE_VIREO_BEGIN(String)
 
 
 DEFINE_VIREO_END()
+
+}  // namespace Vireo

--- a/source/core/StringUtilities.cpp
+++ b/source/core/StringUtilities.cpp
@@ -327,7 +327,7 @@ Int32 SubString::ReadEscapeToken(SubString* token)
         } else if (c == 'u') {
             //  "...\uhhhh..."
             newBegin = _begin + 5;
-            expandedSize = 1;  // TODO size will be UTF8 translation of UTF codepoint
+            expandedSize = 1;  // TODO(PaulAustin): size will be UTF8 translation of UTF codepoint
         } else if (c >= '0' && c <= '7') {
             //  "...\ooo..."
             newBegin = _begin + 1;
@@ -437,7 +437,7 @@ void SubString::ProcessEscapes(Utf8Char* dest, Utf8Char* end)
                 } else {
                     *dest++ = (c & 255);
                 }
-                // TODO Unicode \u codepoints > \u00ff
+                // TODO(spathiwa): Unicode \u codepoints > \u00ff
             } else {
                 // Incorrectly formatted escape, ignore second char
             }
@@ -873,7 +873,7 @@ Boolean SubString::ReadInt(IntMax *pValue, Boolean *overflow /*=null*/)
 //------------------------------------------------------------
 Boolean SubString::ParseDouble(Double *pValue, Boolean suppressInfNaN /*= false*/, Int32 *errCodePtr /*= null*/)
 {
-    // TODO not so pleased with the standard functions for parsing  numbers
+    // TODO(PaulAustin): not so pleased with the standard functions for parsing  numbers
     // many are not thread safe, none seem to be bound on how many characters they will read
     //
     Double value;

--- a/source/core/Synchronization.cpp
+++ b/source/core/Synchronization.cpp
@@ -15,8 +15,9 @@
 #include "ExecutionContext.h"
 #include "VirtualInstrument.h"
 #include "RefNum.h"
+#include <map>
 
-using namespace Vireo;
+namespace Vireo {
 
 //------------------------------------------------------------
 //! Insert an observer into the ObservableObject's list
@@ -1188,3 +1189,5 @@ DEFINE_VIREO_BEGIN(Synchronization)
     // DEFINE_VIREO_FUNCTION_CUSTOM(EnqueueElement, Queue_EnqueueElement, "p(io(Queue<.$1> queue)i($1 element)i(Int32 timeOut)o(Boolean timedOut))")
     // DEFINE_VIREO_FUNCTION_CUSTOM(DequeueElement, Queue_DequeueElement, "p(io(Queue<.$1> queue)o($1 element)i(Int32 timeOut)o(Boolean timedOut))")
 DEFINE_VIREO_END()
+
+}  // namespace Vireo

--- a/source/core/TDCodecLVFlat.cpp
+++ b/source/core/TDCodecLVFlat.cpp
@@ -13,7 +13,7 @@ SDG
 
 #include "TypeDefiner.h"
 
-// TODO: Code review
+// TODO(PaulAustin): Code review
 namespace Vireo
 {
 inline UInt32 ReadLittleEndianUInt32(UInt8 *aBuf, IntIndex i) {

--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -21,7 +21,7 @@ SDG
 #include "StringUtilities.h"
 #include "TDCodecVia.h"
 
-#include "VirtualInstrument.h"  // TODO remove once it is all driven by the type system.
+#include "VirtualInstrument.h"  // TODO(PaulAustin): remove once it is all driven by the type system.
 
 #if !kVireoOS_windows
     #include <math.h>
@@ -89,7 +89,7 @@ TypeRef TDViaParser::ParseEnqueue()
 {
     TypeRef type = BadType();
 
-    //! TODO merge with runtime enqueue function
+    //! TODO(PaulAustin): merge with runtime enqueue function
     SubString viName;
 
     if (!_string.EatChar('(')) {
@@ -416,7 +416,7 @@ TypeRef TDViaParser::ParseLiteral(TypeRef patternType)
 //------------------------------------------------------------
 TypeRef TDViaParser::ParseBitCluster()
 {
-    TypeRef elementTypes[1000];  // TODO enforce limits or make them dynamic
+    TypeRef elementTypes[1000];  // TODO(PaulAustin): enforce limits or make them dynamic
     ClusterAlignmentCalculator calc(_typeManager);
     ParseAggregateElementList(elementTypes, &calc);
     return BitClusterType::New(_typeManager, elementTypes, calc.ElementCount);
@@ -424,7 +424,7 @@ TypeRef TDViaParser::ParseBitCluster()
 //------------------------------------------------------------
 TypeRef TDViaParser::ParseCluster()
 {
-    TypeRef elementTypes[1000];   // TODO enforce limits or make them dynamic
+    TypeRef elementTypes[1000];   // TODO(PaulAustin): enforce limits or make them dynamic
     ClusterAlignmentCalculator calc(_typeManager);
     ParseAggregateElementList(elementTypes, &calc);
     return ClusterType::New(_typeManager, elementTypes, calc.ElementCount);
@@ -465,7 +465,7 @@ TypeRef TDViaParser::ParseDefine()
 //------------------------------------------------------------
 TypeRef TDViaParser::ParseEquivalence()
 {
-    TypeRef elementTypes[1000];   // TODO enforce limits or make them dynamic
+    TypeRef elementTypes[1000];   // TODO(PaulAustin): enforce limits or make them dynamic
     EquivalenceAlignmentCalculator calc(_typeManager);
     ParseAggregateElementList(elementTypes, &calc);
     return EquivalenceType::New(_typeManager, elementTypes, calc.ElementCount);
@@ -473,7 +473,7 @@ TypeRef TDViaParser::ParseEquivalence()
 //------------------------------------------------------------
 TypeRef TDViaParser::ParseParamBlock()
 {
-    TypeRef elementTypes[1000];   // TODO enforce limits or make them dynamic
+    TypeRef elementTypes[1000];   // TODO(PaulAustin): enforce limits or make them dynamic
     ParamBlockAlignmentCalculator calc(_typeManager);
     ParseAggregateElementList(elementTypes, &calc);
     return ParamBlockType::New(_typeManager, elementTypes, calc.ElementCount);
@@ -675,34 +675,34 @@ TypeRef TDViaParser::ParseEnumType(SubString *token)
     return enumVal;
 }
 //------------------------------------------------------------
-EncodingEnum TDViaParser::ParseEncoding(SubString *string)
+EncodingEnum TDViaParser::ParseEncoding(SubString *str)
 {
     EncodingEnum enc = kEncoding_None;
-    if (string->CompareCStr(tsBoolean)) {
+    if (str->CompareCStr(tsBoolean)) {
         enc = kEncoding_Boolean;
-    } else if (string->CompareCStr(tsIEEE754Binary)) {
+    } else if (str->CompareCStr(tsIEEE754Binary)) {
         enc = kEncoding_IEEE754Binary;
-    } else if (string->CompareCStr(tsUInt)) {
+    } else if (str->CompareCStr(tsUInt)) {
         enc = kEncoding_UInt;
-    } else if (string->CompareCStr(tsSInt)) {
+    } else if (str->CompareCStr(tsSInt)) {
         enc = kEncoding_S2CInt;
-    } else if (string->CompareCStr(tsFixedPoint)) {
+    } else if (str->CompareCStr(tsFixedPoint)) {
         enc = kEncoding_Q;
-    } else if (string->CompareCStr(ts1plusFractional)) {
+    } else if (str->CompareCStr(ts1plusFractional)) {
         enc = kEncoding_Q1;
-    } else if (string->CompareCStr(tsBiasedInt)) {
+    } else if (str->CompareCStr(tsBiasedInt)) {
         enc = kEncoding_BiasedInt;
-    } else if (string->CompareCStr(tsInt1sCompliment)) {
+    } else if (str->CompareCStr(tsInt1sCompliment)) {
         enc = kEncoding_S1CInt;
-    } else if (string->CompareCStr(tsAscii)) {
+    } else if (str->CompareCStr(tsAscii)) {
         enc = kEncoding_Ascii;
-    } else if (string->CompareCStr(tsUnicode)) {
+    } else if (str->CompareCStr(tsUnicode)) {
         enc = kEncoding_Unicode;
-    } else if (string->CompareCStr(tsGeneric)) {
+    } else if (str->CompareCStr(tsGeneric)) {
         enc = kEncoding_Generic;
-    } else if (string->CompareCStr(tsPointer)) {
+    } else if (str->CompareCStr(tsPointer)) {
         enc = kEncoding_Pointer;
-    } else if (string->CompareCStr(tsEnum)) {
+    } else if (str->CompareCStr(tsEnum)) {
         enc = kEncoding_Enum;
     }
 
@@ -843,7 +843,7 @@ Int32 TDViaParser::ParseArrayData(TypedArrayCoreRef pArray, void* pFirstEltInSli
                 charCount = token.LengthAfterProcessingEscapes();
                 pArray->Resize1D(charCount);
                 if (arrayElementType->TopAQSize() == 1 && arrayElementType->BitEncoding() == kEncoding_Ascii) {
-                    // TODO convert from Utf8 to ASCII, map chars that do not fit to something.
+                    // TODO(PaulAustin): convert from Utf8 to ASCII, map chars that do not fit to something.
                     token.ProcessEscapes(pArray->RawBegin(), pArray->RawBegin());
                 } else if (arrayElementType->TopAQSize() == 1 && arrayElementType->BitEncoding() == kEncoding_Unicode) {
                     token.ProcessEscapes(pArray->RawBegin(), pArray->RawBegin());
@@ -853,7 +853,7 @@ Int32 TDViaParser::ParseArrayData(TypedArrayCoreRef pArray, void* pFirstEltInSli
                 pArray->Resize1D(charCount);
 
                 if (arrayElementType->TopAQSize() == 1 && arrayElementType->BitEncoding() == kEncoding_Ascii) {
-                    // TODO convert from Utf8 to ASCII, map chars that do not fit to something.
+                    // TODO(PaulAustin): convert from Utf8 to ASCII, map chars that do not fit to something.
                     memcpy(pArray->RawBegin(), pBegin, charCount);
                 } else if (arrayElementType->TopAQSize() == 1 && arrayElementType->BitEncoding() == kEncoding_Unicode) {
                     memcpy(pArray->RawBegin(), pBegin, charCount);
@@ -948,7 +948,7 @@ Int32 TDViaParser::ParseArrayData(TypedArrayCoreRef pArray, void* pFirstEltInSli
 }
 
 //------------------------------------------------------------
-//! Skip over a JSON item.  TODO merge with ReadSubexpression
+//! Skip over a JSON item.  TODO(PaulAustin): merge with ReadSubexpression
 Boolean EatJSONItem(SubString* input)
 {
     SubString token;
@@ -1109,7 +1109,7 @@ Int32 TDViaParser::ParseData(TypeRef type, void* pData)
                     return kLVError_ArgError;
                 }
 
-                // TODO support 16 bit reals? 128 bit reals? those are defined by IEEE754
+                // TODO(PaulAustin): support 16 bit reals? 128 bit reals? those are defined by IEEE754
             }
             break;
         case kEncoding_Ascii:
@@ -1123,23 +1123,23 @@ Int32 TDViaParser::ParseData(TypeRef type, void* pData)
                 } else {
                     LOG_EVENT(kSoftDataError, "Scalar that is unicode");
                     return kLVError_ArgError;
-                    // TODO support escaped chars, more error checking
+                    // TODO(PaulAustin): support escaped chars, more error checking
                 }
             }
             break;
         case kEncoding_None:
-            // TODO any thing to do ? value for empty cluster, how
+            // TODO(PaulAustin): anything to do? value for empty cluster?
             break;
         case kEncoding_Pointer:
             {
-                // TODO this is not really flat.
+                // TODO(PaulAustin): this is not really flat.
                 static SubString strTypeType(tsTypeType);
                 static SubString strExecutionContextType(tsExecutionContextType);
                 if (type->IsA(&strTypeType)) {
                     if (pData) {
                         *(TypeRef*)pData = this->ParseType();
                     } else {
-                        this->ParseType();  // TODO if preflight its read and lost
+                        this->ParseType();  // TODO(PaulAustin): if preflight its read and lost
                     }
                     return kLVError_NoError;
                 } else if (type->IsA(&strExecutionContextType)) {
@@ -1147,7 +1147,7 @@ Int32 TDViaParser::ParseData(TypeRef type, void* pData)
                     if (token.CompareCStr(tsWildCard)) {
                         // If a generic is specified then the default for the type should be
                         // used. For some pointer types this may be a process or thread global, etc.
-                        // TODO this is at too low a level, it could be done at
+                        // TODO(PaulAustin): this is at too low a level, it could be done at
                         // a higher level.
                         *(ExecutionContextRef*)pData = THREAD_EXEC();
                         return kLVError_NoError;
@@ -1629,7 +1629,7 @@ void TDViaParser::ParseClump(VIClump* viClump, InstructionAllocator* cia)
 
                     state._parserFocus = token;
                     if (formalType) {
-                        // TODO the type classification can be moved into a codec independent class.
+                        // TODO(PaulAustin): the type classification can be moved into a codec independent class.
                         SubString formalParameterTypeName = formalType->Name();
 
                         if (formalParameterTypeName.CompareCStr("VarArgCount")) {
@@ -1906,11 +1906,11 @@ ViaFormatChars TDViaFormatter::formatJSONEggShell = { kJSONEncoding, '[', ']', '
 ViaFormatChars TDViaFormatter::formatC =         { kCEncoding,    '{', '}', '{', '}', ',', '\"', kViaFormat_NoFieldNames};
 
 //------------------------------------------------------------
-TDViaFormatter::TDViaFormatter(StringRef string, Boolean quoteOnTopString, Int32 fieldWidth,
+TDViaFormatter::TDViaFormatter(StringRef str, Boolean quoteOnTopString, Int32 fieldWidth,
     SubString* format, Boolean jsonLVExt/*= false*/, Boolean quoteInfNaN/*= false*/)
 {
     // Might move all options to format string.
-    _string = string;
+    _string = str;
     _options._bQuoteStrings = quoteOnTopString;
     _options._fieldWidth = fieldWidth;
     _options._precision = -1;
@@ -2079,7 +2079,7 @@ void TDViaFormatter::FormatArrayData(TypeRef arrayType, TypedArrayCoreRef pArray
         // Unicode + elt size == 1 => Utf8
         // not planning on doing UTF16, or 32 at this time
         // These encodings have a special format
-        // TODO option for raw or escaped forms need to be covered, sometime in quotes
+        // TODO(PaulAustin): option for raw or escaped forms need to be covered, sometime in quotes
         if (_options._bQuoteStrings) {
             _string->Append(Fmt()._quote);
         }
@@ -2158,7 +2158,7 @@ void TDViaFormatter::FormatClusterData(TypeRef type, void *pData)
             if (useQuotes)
                 _string->Append('\"');
 
-           // TODO use percent encoding when needed
+           // TODO(PaulAustin): use percent encoding when needed
            // _string->Append(ss.Length(), ss.Begin());
             IntIndex pos = _string->Length();
             _string->AppendViaDecoded(&ss);
@@ -2361,7 +2361,7 @@ VIREO_FUNCTION_SIGNATUREV(UnflattenFromJSON, UnflattenFromJSONParamBlock)
     if (!error) {
         Int32 topSize = arg[0]._paramType->TopAQSize();
         char *buffer = new char[topSize];  // passed in default data is overwritten since it's also the output.  Save a copy.
-        // TODO Consider refactor to make default and output different args?
+        // TODO(spathiwa): Consider refactor to make default and output different args?
         memset(buffer, 0, topSize);
         arg[0]._paramType->InitData(buffer);
         arg[0]._paramType->CopyData(arg[0]._pData, buffer);
@@ -2388,10 +2388,10 @@ VIREO_FUNCTION_SIGNATURE4(FromString, StringRef, StaticType, void, StringRef)
 {
     TypeRef type = _ParamPointer(1);
 
-    SubString string = _Param(0)->MakeSubStringAlias();
+    SubString str = _Param(0)->MakeSubStringAlias();
     EventLog log(_Param(3));
 
-    TDViaParser parser(THREAD_TADM(), &string, &log, 1);
+    TDViaParser parser(THREAD_TADM(), &str, &log, 1);
     parser._loadVIsImmediately = true;
 
     parser.ParseData(type, _ParamPointer(2));
@@ -2416,7 +2416,7 @@ static void SaturateValue(TypeRef type, Int64 *value, Boolean sourceIsFloat) {
 //------------------------------------------------------------
 VIREO_FUNCTION_SIGNATURE6(DecimalStringToNumber, StringRef, Int32, void, Int32, StaticType, void)
 {
-    StringRef string = _Param(0);
+    StringRef str = _Param(0);
     Int32 beginOffset = _ParamPointer(1) ? _Param(1) : 0;
     void *pDefault = _ParamPointer(2);
     TypeRef type = _ParamPointer(4);
@@ -2424,7 +2424,7 @@ VIREO_FUNCTION_SIGNATURE6(DecimalStringToNumber, StringRef, Int32, void, Int32, 
 
     if (beginOffset < 0)
         beginOffset = 0;
-    SubString substring(string->BeginAt(beginOffset), string->End());
+    SubString substring(str->BeginAt(beginOffset), str->End());
     Int32 length1 = substring.Length();
     Int32 length2;
     Boolean success;
@@ -2469,10 +2469,10 @@ VIREO_FUNCTION_SIGNATURE6(DecimalStringToNumber, StringRef, Int32, void, Int32, 
     return _NextInstruction();
 }
 
-static void BaseStringToNumber(Int32 base, StringRef string, Int32 beginOffset, Int32 *endOffset, void *pDefault, TypeRef type, void *pData) {
+static void BaseStringToNumber(Int32 base, StringRef str, Int32 beginOffset, Int32 *endOffset, void *pDefault, TypeRef type, void *pData) {
     if (beginOffset < 0)
         beginOffset = 0;
-    SubString substring(string->BeginAt(beginOffset), string->End());
+    SubString substring(str->BeginAt(beginOffset), str->End());
     Int32 length1 = substring.Length();
     Int32 length2;
     Boolean success;
@@ -2549,7 +2549,7 @@ VIREO_FUNCTION_SIGNATURE6(BinaryStringToNumber, StringRef, Int32, void, Int32, S
 //------------------------------------------------------------
 VIREO_FUNCTION_SIGNATURE6(ExponentialStringToNumber, StringRef, Int32, void, Int32, StaticType, void)
 {
-    StringRef string = _Param(0);
+    StringRef str = _Param(0);
     Int32 beginOffset = _ParamPointer(1) ? _Param(1) : 0;
     void *pDefault = _ParamPointer(2);
     TypeRef type = _ParamPointer(4);
@@ -2557,7 +2557,7 @@ VIREO_FUNCTION_SIGNATURE6(ExponentialStringToNumber, StringRef, Int32, void, Int
 
     if (beginOffset < 0)
         beginOffset = 0;
-    SubString substring(string->BeginAt(beginOffset), string->End());
+    SubString substring(str->BeginAt(beginOffset), str->End());
     Int32 length1 = substring.Length();
     Int32 length2;
     Boolean success;
@@ -2605,35 +2605,35 @@ VIREO_FUNCTION_SIGNATURE6(ExponentialStringToNumber, StringRef, Int32, void, Int
 }
 
 //------------------------------------------------------------
-typedef void (*NumberToStringCallback)(TypeRef type, void *pData, Int32 minWidth, Int32 precision, StringRef string);
+typedef void (*NumberToStringCallback)(TypeRef type, void *pData, Int32 minWidth, Int32 precision, StringRef str);
 
-void NumberToFloatStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32 precision, StringRef string) {
+void NumberToFloatStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32 precision, StringRef str) {
     StaticTypeAndData arguments[1] = {{ type, pData }};
     SubString format;
     char formatBuffer[32];
     snprintf(formatBuffer, sizeof(formatBuffer), "%%%d.%dF", minWidth, precision);
     format.AliasAssignCStr(formatBuffer);
-    Format(&format, 1, arguments, string, null);
+    Format(&format, 1, arguments, str, null);
 }
-void NumberToExponentialStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32 precision, StringRef string)
+void NumberToExponentialStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32 precision, StringRef str)
 {
     StaticTypeAndData arguments[1] = {{ type, pData }};
     SubString format;
     char formatBuffer[32];
     snprintf(formatBuffer, sizeof(formatBuffer), "%%%d.%dE", minWidth, precision);
     format.AliasAssignCStr(formatBuffer);
-    Format(&format, 1, arguments, string, null);
+    Format(&format, 1, arguments, str, null);
 }
-void NumberToEngineeringStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32 precision, StringRef string)
+void NumberToEngineeringStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32 precision, StringRef str)
 {
     StaticTypeAndData arguments[1] = {{ type, pData }};
     SubString format;
     char formatBuffer[32];
     snprintf(formatBuffer, sizeof(formatBuffer), "%%^%d.%dE", minWidth, precision);
     format.AliasAssignCStr(formatBuffer);
-    Format(&format, 1, arguments, string, null);
+    Format(&format, 1, arguments, str, null);
 }
-void NumberToDecimalStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32, StringRef string)
+void NumberToDecimalStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32, StringRef str)
 {
     StaticTypeAndData arguments[1] = {{ type, pData }};
     SubString format;
@@ -2643,34 +2643,34 @@ void NumberToDecimalStringInternal(TypeRef type, void *pData, Int32 minWidth, In
     else
         snprintf(formatBuffer, sizeof(formatBuffer), "%%%dd", minWidth);
     format.AliasAssignCStr(formatBuffer);
-    Format(&format, 1, arguments, string, null);
+    Format(&format, 1, arguments, str, null);
 }
-void NumberToHexStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32, StringRef string)
+void NumberToHexStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32, StringRef str)
 {
     StaticTypeAndData arguments[1] = {{ type, pData }};
     SubString format;
     char formatBuffer[32];
     snprintf(formatBuffer, sizeof(formatBuffer), "%%0%dX", minWidth);
     format.AliasAssignCStr(formatBuffer);
-    Format(&format, 1, arguments, string, null);
+    Format(&format, 1, arguments, str, null);
 }
-void NumberToOctalStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32, StringRef string)
+void NumberToOctalStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32, StringRef str)
 {
     StaticTypeAndData arguments[1] = {{ type, pData }};
     SubString format;
     char formatBuffer[32];
     snprintf(formatBuffer, sizeof(formatBuffer), "%%0%do", minWidth);
     format.AliasAssignCStr(formatBuffer);
-    Format(&format, 1, arguments, string, null);
+    Format(&format, 1, arguments, str, null);
 }
-void NumberToBinaryStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32, StringRef string)
+void NumberToBinaryStringInternal(TypeRef type, void *pData, Int32 minWidth, Int32, StringRef str)
 {
     StaticTypeAndData arguments[1] = {{ type, pData }};
     SubString format;
     char formatBuffer[32];
     snprintf(formatBuffer, sizeof(formatBuffer), "%%0%db", minWidth);
     format.AliasAssignCStr(formatBuffer);
-    Format(&format, 1, arguments, string, null);
+    Format(&format, 1, arguments, str, null);
 }
 
 Boolean NumberToStringInternal(TypeRef type, AQBlock1 *pData, Int32 minWidth, Int32 precision,
@@ -2694,8 +2694,8 @@ Boolean NumberToStringInternal(TypeRef type, AQBlock1 *pData, Int32 minWidth, In
             AQBlock1 *pElement = pArray->BeginAt(0);
             AQBlock1 *pDestElement = pDestArray->BeginAt(0);
             while (count > 0) {
-                StringRef string = *(StringRef*)pDestElement;
-                (*formatCallback)(subType, pElement, minWidth, precision, string);
+                StringRef str = *(StringRef*)pDestElement;
+                (*formatCallback)(subType, pElement, minWidth, precision, str);
                 pElement += elementSize;
                 pDestElement += destElementSize;
                 --count;
@@ -2720,8 +2720,8 @@ Boolean NumberToStringInternal(TypeRef type, AQBlock1 *pData, Int32 minWidth, In
             while (i < count) {
                 TypeRef subType = type->GetSubElement(i);
                 AQBlock1 *pElement = pData + subType->ElementOffset();
-                StringRef string = *(StringRef*)pDestElement;
-                (*formatCallback)(subType, pElement, minWidth, precision, string);
+                StringRef str = *(StringRef*)pDestElement;
+                (*formatCallback)(subType, pElement, minWidth, precision, str);
                 pDestElement += destElementSize;
                 ++i;
             }
@@ -2733,8 +2733,8 @@ Boolean NumberToStringInternal(TypeRef type, AQBlock1 *pData, Int32 minWidth, In
         case kEncoding_Enum:
         case kEncoding_IEEE754Binary:
             if (destEncoding == kEncoding_Array && destType->Rank() == 1 && destType->GetSubElement(0)->BitEncoding() == kEncoding_Unicode) {
-                StringRef string = *(StringRef*)pDestData;
-                (*formatCallback)(type, pData, minWidth, precision, string);
+                StringRef str = *(StringRef*)pDestData;
+                (*formatCallback)(type, pData, minWidth, precision, str);
                 break;
             }  // else fall through...
         default:

--- a/source/core/TypeAndDataReflection.cpp
+++ b/source/core/TypeAndDataReflection.cpp
@@ -65,7 +65,7 @@ class DataReflectionVisitor : public TypeVisitor
 //------------------------------------------------------------
 TypeRef TypeManager::PointerToSymbolPath(TypeRef tNeedle, DataPointer pNeedle, StringRef path)
 {
-    // TODO needs scope output (local, global, type constant)
+    // TODO(PaulAustin): needs scope output (local, global, type constant)
 
     path->Resize1D(0);
     DataReflectionVisitor drv(tNeedle, pNeedle, path);

--- a/source/core/TypeDefiner.cpp
+++ b/source/core/TypeDefiner.cpp
@@ -156,9 +156,9 @@ void TypeDefiner::DefineCustomDataProcs(TypeManagerRef tm, ConstCStr name, IData
 //------------------------------------------------------------
 void TypeDefiner::DefineCustomValue(TypeManagerRef tm, ConstCStr name, Int32 value, ConstCStr typeString)
 {
-    SubString string(typeString);
+    SubString str(typeString);
 
-    TDViaParser parser(tm, &string, null, 1);
+    TDViaParser parser(tm, &str, null, 1);
     TypeRef t = parser.ParseType();
 
     DefaultValueType *cdt = DefaultValueType::New(tm, t, false);
@@ -166,8 +166,8 @@ void TypeDefiner::DefineCustomValue(TypeManagerRef tm, ConstCStr name, Int32 val
     if (cdt->BitEncoding() == kEncoding_S2CInt && cdt->TopAQSize() == 4) {
         *(Int32*)cdt->Begin(kPAInit) = value;
 
-        string.AliasAssignCStr(name);
-        tm->Define(&string, cdt);
+        str.AliasAssignCStr(name);
+        tm->Define(&str, cdt);
     }
 }
 //------------------------------------------------------------
@@ -247,7 +247,7 @@ void TypeDefiner::DefineStandardTypes(TypeManagerRef tm)
     Define(tm, "Object", "DataPointer");
     Define(tm, "Array", "DataPointer");    // Object with Rank > 0
     Define(tm, "Array1D", "DataPointer");
-    Define(tm, "Variant", "DataPointer");  // TODO is this any different from the Type type if the type has a default value?
+    Define(tm, "Variant", "DataPointer");  // TODO(PaulAustin): is this any different from the Type type if the type has a default value?
 
     Define(tm, "ErrorCluster", ERROR_CLUST_TYPE_STRING);
     Define(tm, "NIPath", "c(e(a(String *) components) e(String type))");

--- a/source/core/TypeTemplates.cpp
+++ b/source/core/TypeTemplates.cpp
@@ -95,7 +95,7 @@ IntIndex TypeTemplateVisitor::AcceptIntDim(IntIndex value)
             return (IntIndex) ReadIntFromMemory(type, type->Begin(kPARead));
         } else {
             // If no parameter is supplied then change it to simply being variable size
-            // TODO(templates) or shift its position?, thats not hard either.
+            // TODO(PaulAustin): templates - or shift its position?, that's not hard either.
             return kArrayVariableLengthSentinel;
         }
     } else {
@@ -147,7 +147,7 @@ void TypeTemplateVisitor::VisitCluster(ClusterType* type)
     AggregateAlignmentCalculator* saveCalc = _alignmentCalculator;
     _alignmentCalculator = &calc;
 
-    TypeRef elementTypes[1000];   // TODO enforce limits or make them dynamic
+    TypeRef elementTypes[1000];   // TODO(PaulAustin): enforce limits or make them dynamic
     IntIndex subElementCount = type->SubElementCount();
 
     for (Int32 i = 0; i < subElementCount; i++) {
@@ -180,7 +180,7 @@ void TypeTemplateVisitor::VisitEquivalence(EquivalenceType* type)
     AggregateAlignmentCalculator* saveCalc = _alignmentCalculator;
     _alignmentCalculator = &calc;
 
-    TypeRef elementTypes[1000];   // TODO enforce limits or make them dynamic
+    TypeRef elementTypes[1000];   // TODO(PaulAustin): enforce limits or make them dynamic
     IntIndex subElementCount = type->SubElementCount();
 
     for (Int32 i = 0; i < subElementCount; i++) {
@@ -283,7 +283,7 @@ void TypeTemplateVisitor::VisitNamed(NamedType* type)
     // base type is also generic. First create the hypothetical new name
     // and see if the instance already exists. If not, make one.
 
-    // Create a new name, TODO should  really use TDCodecVIA to parse the type
+    // Create a new name, TODO(PaulAustin): should really use TDCodecVIA to parse the type
     STACK_VAR(String, tempString);
 
     tempString.Value->Append(name.Length(), (Utf8Char*)name.Begin());

--- a/source/core/UnitTest.cpp
+++ b/source/core/UnitTest.cpp
@@ -16,8 +16,6 @@ Craig S.
 
 #include <vector>
 
-using namespace Vireo;
-
 VireoUnitTest::TestList *VireoUnitTest::_s_unitTests;
 
 bool VireoUnitTest::RunTests(bool *pass) {
@@ -25,7 +23,7 @@ bool VireoUnitTest::RunTests(bool *pass) {
     bool ranTests = false;
     TestList *testList = _s_unitTests;
     while (testList) {
-        gPlatform.IO.Printf("Executing test: %s\n", testList->_test->Name());
+        Vireo::gPlatform.IO.Printf("Executing test: %s\n", testList->_test->Name());
         if (!testList->_test->Execute())
             *pass = false;
         ranTests = true;

--- a/source/core/VirtualInstrument.cpp
+++ b/source/core/VirtualInstrument.cpp
@@ -145,12 +145,12 @@ void VirtualInstrument::SetVIName(const SubString &s, bool decode)   {
 //                         \      /
 // Clump4:                  B----H
 //
-// TODO Wait Many?, right way to wait till first, or allow for one that is a time out.
+// TODO(PaulAustin): Wait Many?  Right way to wait until first, or allow for one that is a time-out?
 // Easy enough to do as a var arg function.
 //
 void VIClump::Trigger()
 {
-    // TODO Make sure there is a MT version of this (or all are MT safe)
+    // TODO(PaulAustin): Make sure there is a MT version of this (or all are MT safe)
     VIREO_ASSERT(_shortCount > 0)
 
     // Strictly speaking, this assert can be relaxed, but It will be interesting
@@ -398,7 +398,7 @@ TypeRef ClumpParseState::ReadFormalParameterType()
 //------------------------------------------------------------
 void ClumpParseState::SetClumpFireCount(Int32 fireCount)
 {
-    // TODO some bootstrap that could be a bit cleaner.
+    // TODO(PaulAustin): some bootstrap that could be a bit cleaner.
     // If the short count is less than the fire count then the clump was enqueued
     // before it has been fully loaded. Don't stomp that
     // This should only be true for root clumps
@@ -590,7 +590,7 @@ void ClumpParseState::ResolveActualArgument(SubString* argument, void** ppData, 
         UsageTypeEnum usageType = _formalParameterType->ElementUsageType();
         void* pData = null;
 
-        // TODO access-option based on parameter direction;
+        // TODO(PaulAustin): access-option based on parameter direction;
         if (usageType == kUsageTypeInput) {
             pData = _actualArgumentType->Begin(kPARead);
         } else if (usageType == kUsageTypeOutput) {
@@ -891,7 +891,7 @@ void ClumpParseState::LogArgumentProcessing(Int32 lineNumber)
 // the VI's parameter block.
 InstructionCore* ClumpParseState::EmitCallVIInstruction()
 {
-    VIREO_ASSERT(this->_argCount > 0);  // TODO arg[0] is subVI
+    VIREO_ASSERT(this->_argCount > 0);  // TODO(PaulAustin): arg[0] is subVI
 
     ClumpParseState snippetBuilder(this);
 
@@ -1104,7 +1104,7 @@ InstructionCore* ClumpParseState::EmitInstruction()
         return instruction;
 
     if (_perchIndexToRecordNextInstrAddr >= 0) {
-        // TODO support multiple perch patching
+        // TODO(PaulAustin): support multiple perch patching
         VIREO_ASSERT(_perches[_perchIndexToRecordNextInstrAddr] == kPerchBeingAllocated);
         _perches[_perchIndexToRecordNextInstrAddr] = instruction;
         _perchIndexToRecordNextInstrAddr = -1;
@@ -1258,7 +1258,7 @@ InstructionBlockDataProcsClass gInstructionBlockDataProcs;
 DEFINE_VIREO_BEGIN(VirtualInstrument)
     DEFINE_VIREO_REQUIRE(TypeManager)
     DEFINE_VIREO_REQUIRE(Synchronization)
-    DEFINE_VIREO_TYPE(ExecutionContext, "DataPointer");  // TODO define as type string
+    DEFINE_VIREO_TYPE(ExecutionContext, "DataPointer");  // TODO(PaulAustin): define as type string
     DEFINE_VIREO_CUSTOM_DP(InstructionBlock, "Instruction", &gInstructionBlockDataProcs);
     DEFINE_VIREO_TYPE(Clump, Clump_TypeString);
     DEFINE_VIREO_TYPE(EmptyParameterList, "c()");

--- a/source/core/Waveform.cpp
+++ b/source/core/Waveform.cpp
@@ -19,7 +19,7 @@ SDG
 #include <cmath>
 #include "Waveform.h"
 
-using namespace Vireo;
+namespace Vireo {
 
 #ifdef VIREO_TYPE_Waveform
 DEFINE_VIREO_BEGIN(Waveform)
@@ -54,3 +54,5 @@ VIREO_FUNCTION_SIGNATURE4(AnalogWaveformBuild, AnalogWaveform, Timestamp, Double
 DEFINE_VIREO_BEGIN(Waveform)
 DEFINE_VIREO_FUNCTION(AnalogWaveformBuild, "p(o(AnalogWaveform) i(Timestamp) i(Double) i(Array))")
 DEFINE_VIREO_END()
+
+}  // namespace Vireo

--- a/source/include/BuildConfig.h
+++ b/source/include/BuildConfig.h
@@ -143,7 +143,7 @@ SDG
 
     #define VIREO_TYPE_CONSTRUCTION 1
 
-    // TODO #define VIREO_MULTI_THREAD 1
+    // TODO(PaulAustin): #define VIREO_MULTI_THREAD 1
 
     // FILEIO covers read and write operation, perhaps only for stdio.
     #define VIREO_POSIX_FILEIO 1
@@ -158,7 +158,7 @@ SDG
 
 #endif
 
-// TODO allow for thread locals on linux/unix
+// TODO(PaulAustin): allow for thread locals on linux/unix
 #define VIVM_THREAD_LOCAL
 
 #ifdef VIREO_DEBUG

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -11,7 +11,8 @@ SDG
     \brief  C entry points for core Vireo functions. Used when the runtime is built and loaded as a library
  */
 
-using namespace Vireo;
+namespace Vireo {
+
 //------------------------------------------------------------
 // Keep in sync with module_eggShell.js
 typedef enum {
@@ -94,3 +95,5 @@ VIREO_EXPORT void Data_WriteBytes(TypedBlock* object, Int32 offset, Int32 count,
 //------------------------------------------------------------
 //! Occurrence functions
 VIREO_EXPORT void Occurrence_Set(OccurrenceRef occurrence);
+
+}  // namespace Vireo

--- a/source/include/DataTypes.h
+++ b/source/include/DataTypes.h
@@ -154,7 +154,7 @@ typedef enum {
     kLVError_JSONInvalidPath = -375004,
     kLVError_JSONInvalidString = -375003,
     // The rest are semantic analysis errors so can never be seen in LV-generated code:
-    // TODO (spathiwa) Implement for benefit of hand-written Vireo
+    // TODO(spathiwa): Implement for benefit of hand-written Vireo
     kLVError_JSONInvalidElementNameError = -375002,
     kLVError_JSONInvalidRootContainerError = -375001,
     kLVError_JSONUnsupportedTypeError = -375000

--- a/source/include/EventLog.h
+++ b/source/include/EventLog.h
@@ -52,7 +52,7 @@ class EventLog {
     void LogEvent(EventSeverity severity, Int32 lineNumber, ConstCStr message, ...);
     void LogEventCore(EventSeverity severity, Int32 lineNumber, ConstCStr message);
 
-    // TODO: change to use streams
+    // TODO(PaulAustin): change to use streams
     //! Special string instance for constructor to skip all messages (counts still tallied)
     static StringRef DevNull;
     //! Special string instance for constructor to direct messages to stdout

--- a/source/include/ExecutionContext.h
+++ b/source/include/ExecutionContext.h
@@ -99,7 +99,7 @@ class ExecutionContext
     ECONTEXT    Int32           _breakoutCount;   // Inner execution loop "breaks out" when this gets to 0
     ECONTEXT    ExecutionState  _state;
  public:
-    ECONTEXT    Timer           _timer;           // TODO can be moved out of the execcontext once
+    ECONTEXT    Timer           _timer;           // TODO(PaulAustin): can be moved out of the execcontext once
                                                  // instruction can take injected parameters.
 
 #ifdef VIREO_SUPPORTS_ISR

--- a/source/include/Platform.h
+++ b/source/include/Platform.h
@@ -54,8 +54,8 @@ class PlatformMemory {
 //! Process level functions for stdio.
 class PlatformIO {
  public:
-    void Print(Int32 len, ConstCStr string);
-    void Print(ConstCStr string);
+    void Print(Int32 len, ConstCStr str);
+    void Print(ConstCStr str);
     void Printf(ConstCStr format, ...);
     void ReadFile(SubString *name, StringRef buffer);
     void ReadStdin(StringRef buffer);

--- a/source/include/StringUtilities.h
+++ b/source/include/StringUtilities.h
@@ -252,7 +252,7 @@ class SubString : public SubVector<Utf8Char>
     Boolean SplitString(SubString* beforeMatch, SubString* afterMatch, char separator) const;
 
     //! Compare the SubString with a reference string.
-    Boolean Compare(const SubString* string)  const { return Compare(string->Begin(), string->Length()); }
+    Boolean Compare(const SubString* str)  const { return Compare(str->Begin(), str->Length()); }
     Boolean Compare(const Utf8Char* begin, IntIndex length) const;
     Boolean Compare(const Utf8Char* begin, IntIndex length, Boolean ignoreCase) const;
     Boolean CompareCStr(ConstCStr begin) const;
@@ -267,7 +267,7 @@ class SubString : public SubVector<Utf8Char>
     }
 
     //! Compare with the encoded string
-    Boolean CompareViaEncodedString(SubString* string);
+    Boolean CompareViaEncodedString(SubString* str);
 
     //! Functions to work with backslash '\' escapes in strings
     Int32 ReadEscapeToken(SubString* token);
@@ -371,15 +371,15 @@ class TempStackCString : public FixedCArray<Utf8Char, kTempCStringLength>
     TempStackCString() { }
 
     //! Construct a null terminated from an existing SubString.
-    explicit TempStackCString(SubString* string) : FixedCArray(string) { }
+    explicit TempStackCString(SubString* str) : FixedCArray(str) { }
 
     //! Construct a null terminated from rwa block of UTF-8 characters.
     TempStackCString(Utf8Char* begin, Int32 length) : FixedCArray((Utf8Char*)begin, length) { }
 
     //! Append a SubString.
-    Boolean Append(SubString* string)
+    Boolean Append(SubString* str)
     {
-        return FixedCArray::Append(string->Begin(), (size_t)string->Length());
+        return FixedCArray::Append(str->Begin(), (size_t)str->Length());
     }
 
     //! Append a null terminated String.

--- a/source/include/TDCodecVia.h
+++ b/source/include/TDCodecVia.h
@@ -147,7 +147,7 @@ class TDViaParser
     TypeRef ParsePointerType(Boolean shortNotation);
     TypeRef ParseRefNumType();
     TypeRef ParseEnumType(SubString *token);
-    EncodingEnum ParseEncoding(SubString* string);
+    EncodingEnum ParseEncoding(SubString* str);
 };
 
 #if defined (VIREO_VIA_FORMATTER)
@@ -165,7 +165,7 @@ class TDViaFormatter
 
     static const Int32 kTempFormattingBufferSize = 100;
  public:
-    TDViaFormatter(StringRef string, Boolean quoteOnTopString, Int32 fieldWidth = 0, SubString* format = null,
+    TDViaFormatter(StringRef str, Boolean quoteOnTopString, Int32 fieldWidth = 0, SubString* format = null,
                    Boolean jsonLVExt = false, Boolean quoteInfNaN = false);
     // Type formatters
     void    FormatType(TypeRef type);

--- a/source/include/TDCodecVib.h
+++ b/source/include/TDCodecVib.h
@@ -48,7 +48,7 @@ class TDVibDecoder
 
  private:
     void MarkError(ConstCStr message);
-    TypeRef BadType()   {return _typeManager->BadType();}   // TODO could create error that encodes scan point
+    TypeRef BadType()   {return _typeManager->BadType();}   // TODO(PaulAustin): could create error that encodes scan point
     NIError ParseAggregateElementList(TypeRef ElementTypes[], Int32* pElementCount);
     TypeRef ParseArray();
     TypeRef ParseBitBlock();
@@ -58,7 +58,7 @@ class TDVibDecoder
     TypeRef ParseEquivalence();
     TypeRef ParseParamBlock();
     TypeRef ParsePointerType(Boolean shortNotation);
-    EncodingEnum ParseEncoding(SubString* string);
+    EncodingEnum ParseEncoding(SubString* str);
 };
 
 //------------------------------------------------------------

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -95,14 +95,14 @@ typedef TypeCommon StaticType;
 //------------------------------------------------------------
 class TypedArrayCore;
 typedef TypedArrayCore *TypedArrayCoreRef, *TypedObjectRef, TypedBlock;
-    // TODO get rid of TypedBlock   ->TypeBlock ObjectRef??
-typedef TypedBlock *TypedBlockRef;  // TODO => merge into ArrayCoreRef
+    // TODO(PaulAustin): get rid of TypedBlock   ->TypeBlock ObjectRef??
+typedef TypedBlock *TypedBlockRef;  // TODO(PaulAustin): merge into ArrayCoreRef
 
 template <class T>
 class TypedArray1D;
 
 #ifdef VIREO_SINGLE_GLOBAL_CONTEXT
-    // TODO Type manager needs single instance global option like that used by execution context.
+    // TODO(PaulAustin): Type manager needs single instance global option like that used by execution context.
     #error
     #define THREAD_TADM()  // TBD
 #else
@@ -252,7 +252,7 @@ class TypeManager
 
     friend class TDViaParser;
 
-    // TODO The manager needs to define the Addressable Quantum size (bit in an addressable item, often a octet
+    // TODO(PaulAustin): The manager needs to define the Addressable Quantum size (bit in an addressable item, often a octet
     // but some times it is larger (e.g. 16 or 32) the CDC 7600 was 60
     // also defines alignment rules. Each element in a cluster is addressable
  private:
@@ -302,7 +302,7 @@ class TypeManager
 
  public:
     // Low level allocation functions
-    // TODO pull out into its own class.
+    // TODO(PaulAustin): pull out into its own class.
     void* Malloc(size_t countAQ);
     void* Realloc(void* pBuffer, size_t countAQ, size_t preserveAQ);
     void Free(void* pBuffer);
@@ -547,7 +547,7 @@ class TypeCommon
     //! True is the parameter is only visible to the callee, but may be cleared between calls.
     Boolean IsTempParam()           { return _elementUsageType == kUsageTypeTemp; }
     //! True if the parameter is not required. For non flat values null may be passed in.
-    Boolean IsOptionalParam()       { return true; }  // TODO {return _elementUsageType == kUsageTypeOptionalInput ;}
+    Boolean IsOptionalParam()       { return true; }  // TODO(PaulAustin): {return _elementUsageType == kUsageTypeOptionalInput ;}
     UsageTypeEnum ElementUsageType() { return (UsageTypeEnum)_elementUsageType; }
  private:
     //! True if the type owns data that needs to be freed when the TypeManager is cleared.
@@ -612,7 +612,7 @@ class TypeCommon
     Boolean IsComplex();
     //! Size of the type in bits including padding. If the type is bit level it's the raw bit size with no padding.
     virtual IntIndex BitLength()  {
-        return _topAQSize * _typeManager->AQBitLength(); }  // TODO defer to type manager for scale factor
+        return _topAQSize * _typeManager->AQBitLength(); }  // TODO(PaulAustin): defer to type manager for scale factor
 };
 
 //------------------------------------------------------------
@@ -647,7 +647,7 @@ class WrappedType : public TypeCommon
     virtual NIError ClearData(void* pData)              { return _wrapped->ClearData(pData); }
 };
 
-// TODO forward declarations (this covers asynchronous resolution of sub VIs as well)
+// TODO(PaulAustin): forward declarations (this covers asynchronous resolution of sub VIs as well)
 // for the most part types are not mutable.
 // here might be the exceptions
 // 1. if a name is not resolved it can be kept on a short list. when the name is introduced
@@ -859,7 +859,7 @@ class ParamBlockType : public AggregateType
         }
     virtual NIError CopyData(const void* pData, void* pDataCopy)
         {
-            VIREO_ASSERT(false);  // TODO
+            VIREO_ASSERT(false);  // TODO(PaulAustin): Is this needed? (spathiwa)
             return kNIError_kInsufficientResources;
         }
     virtual NIError ClearData(void* pData)
@@ -931,7 +931,7 @@ class PointerType : public WrappedType
     virtual void    Accept(TypeVisitor *tv)             { tv->VisitPointer(this); }
     virtual TypeRef GetSubElement(Int32 index)          { return index == 0 ? _wrapped : null; }
     virtual Int32   SubElementCount()                   { return 1; }
-    // TODO Add GetSubElementAddressFromPath
+    // TODO(PaulAustin): Add GetSubElementAddressFromPath
 };
 //------------------------------------------------------------
 //! A type describes a refnum to another type.
@@ -982,7 +982,7 @@ class EnumType : public WrappedType
     virtual IntIndex GetEnumItemCount();
     virtual ~EnumType();
 
-    // TODO Add GetSubElementAddressFromPath
+    // TODO(spathiwa): Add GetSubElementAddressFromPath
 };
 //------------------------------------------------------------
 //! A type describes a pointer with a predefined value. For example, the address to a C function.
@@ -1203,25 +1203,25 @@ class String : public TypedArray1D< Utf8Char >
 {
  public:
     SubString MakeSubStringAlias()              { return SubString(Begin(), End()); }
-    void CopyFromSubString(const SubString* string)   {
-        if (string->Length())
-            CopyFrom(string->Length(), string->Begin());
+    void CopyFromSubString(const SubString* str)   {
+        if (str->Length())
+            CopyFrom(str->Length(), str->Begin());
         else
             Resize1D(0);
     }
     void AppendCStr(ConstCStr cstr)             { Append((IntIndex)strlen(cstr), (Utf8Char*)cstr); }
     void AppendUtf8Str(Utf8Char* begin, IntIndex length) { Append(length, begin); }
-    void AppendSubString(SubString* string)     { Append((IntIndex)string->Length(), (Utf8Char*)string->Begin()); }
+    void AppendSubString(SubString* str)     { Append((IntIndex)str->Length(), (Utf8Char*)str->Begin()); }
     void AppendStringRef(StringRef stringRef)           {
         Append((IntIndex)stringRef->Length(), (Utf8Char*)stringRef->Begin());
     }
     void InsertCStr(IntIndex position, ConstCStr cstr)
                                               { Insert(position, (IntIndex)strlen(cstr), (Utf8Char*)cstr); }
-    void AppendViaDecoded(SubString *string);
+    void AppendViaDecoded(SubString *str);
     void AppendEscapeEncoded(const Utf8Char* source, IntIndex len);
 
-    void InsertSubString(IntIndex position, SubString* string) {
-        Insert(position, (IntIndex)string->Length(), (Utf8Char*)string->Begin());
+    void InsertSubString(IntIndex position, SubString* str) {
+        Insert(position, (IntIndex)str->Length(), (Utf8Char*)str->Begin());
     }
 };
 
@@ -1254,8 +1254,8 @@ typedef NIPath *NIPathRef;
 class TempStackCStringFromString : public TempStackCString
 {
  public:
-    explicit TempStackCStringFromString(StringRef string)
-    : TempStackCString(string->Begin(), string->Length())
+    explicit TempStackCStringFromString(StringRef str)
+    : TempStackCString(str->Begin(), str->Length())
     { }
 };
 

--- a/source/include/Waveform.h
+++ b/source/include/Waveform.h
@@ -23,7 +23,7 @@ struct AnalogWaveform {
     Timestamp _t0;
     Double _dt;
     TypedArrayCoreRef _Y;
-    // TODO Add attributes
+    // TODO(sanmut): Add attributes
 };
 
 }

--- a/source/io/Canvas2d.cpp
+++ b/source/io/Canvas2d.cpp
@@ -19,7 +19,7 @@
     #include <emscripten.h>
 #endif
 
-using namespace Vireo;
+namespace Vireo {
 
 typedef Int32 Canvas2D;
 
@@ -265,3 +265,6 @@ DEFINE_VIREO_BEGIN(Canvas2D)
     DEFINE_VIREO_FUNCTION(Font, "p(io(Canvas2D)i(String))")
 DEFINE_VIREO_END()
 #endif
+
+}  // namespace Vireo
+

--- a/source/io/DebugGPIO.cpp
+++ b/source/io/DebugGPIO.cpp
@@ -33,7 +33,8 @@ void InitGPIO()
 }
 #endif
 
-using namespace Vireo;
+namespace Vireo {
+
 //------------------------------------------------------------
 VIREO_FUNCTION_SIGNATURE1(DebugLED, Boolean)
 {
@@ -72,3 +73,5 @@ DEFINE_VIREO_BEGIN(DebugGPIO)
     DEFINE_VIREO_FUNCTION(DebugLED, "p(i(Boolean))")
     DEFINE_VIREO_FUNCTION(DebugButton, "p(o(Boolean))")
 DEFINE_VIREO_END()
+
+}  // namespace Vireo

--- a/source/io/FileIO.cpp
+++ b/source/io/FileIO.cpp
@@ -17,6 +17,9 @@
     #include <io.h>
     #include <share.h>
     #include <codecvt>
+    #include <string>
+    #include <vector>
+    #include <algorithm>
     #include <regex>     // NOLINT(build/c++11)
     #include <iostream>  // REMOVE
     typedef size_t ssize_t;
@@ -39,7 +42,7 @@
 #include <sys/stat.h>
 #include <stdio.h>
 
-using namespace Vireo;
+namespace Vireo {
 
 typedef Int32 FileHandle;
 
@@ -408,3 +411,6 @@ DEFINE_VIREO_BEGIN(FileSystem)
 #endif
 
 DEFINE_VIREO_END()
+
+}  // namespace Vireo
+

--- a/source/io/HttpClient.cpp
+++ b/source/io/HttpClient.cpp
@@ -16,7 +16,7 @@ SDG
 #include "VirtualInstrument.h"
 
 #if defined (VIREO_TYPE_HttpClient)
-using namespace Vireo;
+namespace Vireo {
 
 #if kVireoOS_emscripten
 enum HttpClientMethodId {
@@ -37,7 +37,8 @@ extern "C" {
     extern void jsHttpClientGetHeader(UInt32, StringRef, StringRef, Boolean *, Int32 *, StringRef);
     extern void jsHttpClientHeaderExists(UInt32, StringRef, UInt32 *, StringRef, Boolean *, Int32 *, StringRef);
     extern void jsHttpClientListHeaders(UInt32, StringRef, Boolean *, Int32 *, StringRef);
-    extern void jsHttpClientMethod(HttpClientMethodId, UInt32, StringRef, StringRef, StringRef, Int32 *, StringRef, StringRef, UInt32 *, Boolean *, Int32 *, StringRef, OccurrenceRef);
+    extern void jsHttpClientMethod(HttpClientMethodId, UInt32, StringRef, StringRef, StringRef,
+                Int32 *, StringRef, StringRef, UInt32 *, Boolean *, Int32 *, StringRef, OccurrenceRef);
     extern void jsHttpClientConfigCORS(UInt32, UInt32, Boolean *, Int32 *, StringRef);
 }
 #endif
@@ -79,7 +80,7 @@ void GenerateNotSupportedOnPlatformError(ErrorCluster *errorCluster, ConstCStr m
 VIREO_FUNCTION_SIGNATURE6(HttpClientOpen, StringRef, StringRef, StringRef, UInt32, UInt32, ErrorCluster)
 {
 #if kVireoOS_emscripten
-    // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
     if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2) || !_ParamPointer(3) || !_ParamPointer(4) || !_ParamPointer(5)) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
         return THREAD_EXEC()->Stop();
@@ -109,7 +110,7 @@ VIREO_FUNCTION_SIGNATURE6(HttpClientOpen, StringRef, StringRef, StringRef, UInt3
 VIREO_FUNCTION_SIGNATURE2(HttpClientClose, UInt32, ErrorCluster)
 {
 #if kVireoOS_emscripten
-    // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
     if (!_ParamPointer(0) || !_ParamPointer(1)) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
         return THREAD_EXEC()->Stop();
@@ -136,7 +137,7 @@ VIREO_FUNCTION_SIGNATURE2(HttpClientClose, UInt32, ErrorCluster)
 VIREO_FUNCTION_SIGNATURE4(HttpClientAddHeader, UInt32, StringRef, StringRef, ErrorCluster)
 {
 #if kVireoOS_emscripten
-    // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
     if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2) || !_ParamPointer(3)) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
         return THREAD_EXEC()->Stop();
@@ -163,7 +164,7 @@ VIREO_FUNCTION_SIGNATURE4(HttpClientAddHeader, UInt32, StringRef, StringRef, Err
 VIREO_FUNCTION_SIGNATURE3(HttpClientRemoveHeader, UInt32, StringRef, ErrorCluster)
 {
 #if kVireoOS_emscripten
-    // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
     if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2)) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
         return THREAD_EXEC()->Stop();
@@ -189,7 +190,7 @@ VIREO_FUNCTION_SIGNATURE3(HttpClientRemoveHeader, UInt32, StringRef, ErrorCluste
 VIREO_FUNCTION_SIGNATURE4(HttpClientGetHeader, UInt32, StringRef, StringRef, ErrorCluster)
 {
 #if kVireoOS_emscripten
-    // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
     if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2) || !_ParamPointer(3)) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
         return THREAD_EXEC()->Stop();
@@ -216,7 +217,7 @@ VIREO_FUNCTION_SIGNATURE4(HttpClientGetHeader, UInt32, StringRef, StringRef, Err
 VIREO_FUNCTION_SIGNATURE5(HttpClientHeaderExists, UInt32, StringRef, UInt32, StringRef, ErrorCluster)
 {
 #if kVireoOS_emscripten
-    // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
     if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2) || !_ParamPointer(3) || !_ParamPointer(4)) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
         return THREAD_EXEC()->Stop();
@@ -244,7 +245,7 @@ VIREO_FUNCTION_SIGNATURE5(HttpClientHeaderExists, UInt32, StringRef, UInt32, Str
 VIREO_FUNCTION_SIGNATURE3(HttpClientListHeaders, UInt32, StringRef, ErrorCluster)
 {
 #if kVireoOS_emscripten
-    // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
     if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2)) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
         return THREAD_EXEC()->Stop();
@@ -271,7 +272,7 @@ VIREO_FUNCTION_SIGNATURE3(HttpClientListHeaders, UInt32, StringRef, ErrorCluster
 VIREO_FUNCTION_SIGNATURE9(HttpClientGet, UInt32, StringRef, StringRef, Int32, StringRef, StringRef, UInt32, ErrorCluster, OccurrenceRef)
 {
 #if kVireoOS_emscripten
-    // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
     // Timeout(3) null value is handled by js and occurrence(8) handled by vireo
     if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2) || !_ParamPointer(4) || !_ParamPointer(5) || !_ParamPointer(6) || !_ParamPointer(7)) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
@@ -301,12 +302,10 @@ VIREO_FUNCTION_SIGNATURE9(HttpClientGet, UInt32, StringRef, StringRef, Int32, St
             pObserver = clump->ReserveObservationStatesWithTimeout(2, 0);
             pOcc->InsertObserver(pObserver + 1, pOcc->Count() + 1);
             return clump->WaitOnObservableObject(_this);
-        }
-        else {
+        } else {
             return _NextInstruction();
         }
-    }
-    else {
+    } else {
         // re-entering the instruction and the operation is done or it timed out.
         // the clump should continue.
         AddCallChainToSourceIfErrorPresent(_ParamPointer(7), "HttpClientGet");
@@ -324,7 +323,7 @@ VIREO_FUNCTION_SIGNATURE9(HttpClientGet, UInt32, StringRef, StringRef, Int32, St
 VIREO_FUNCTION_SIGNATURE7(HttpClientHead, UInt32, StringRef, Int32, StringRef, UInt32, ErrorCluster, OccurrenceRef)
 {
 #if kVireoOS_emscripten
-    // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
     // Timeout(2) null value is handled by js and occurrence(6) handled by vireo
     if (!_ParamPointer(0) || !_ParamPointer(1)|| !_ParamPointer(3) || !_ParamPointer(4) || !_ParamPointer(5)) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
@@ -354,8 +353,7 @@ VIREO_FUNCTION_SIGNATURE7(HttpClientHead, UInt32, StringRef, Int32, StringRef, U
             pObserver = clump->ReserveObservationStatesWithTimeout(2, 0);
             pOcc->InsertObserver(pObserver + 1, pOcc->Count() + 1);
             return clump->WaitOnObservableObject(_this);
-        }
-        else {
+        } else {
             return _NextInstruction();
         }
     } else {
@@ -376,9 +374,10 @@ VIREO_FUNCTION_SIGNATURE7(HttpClientHead, UInt32, StringRef, Int32, StringRef, U
 VIREO_FUNCTION_SIGNATURE10(HttpClientPut, UInt32, StringRef, StringRef, StringRef, Int32, StringRef, StringRef, UInt32, ErrorCluster, OccurrenceRef)
 {
 #if kVireoOS_emscripten
-    // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
     // Timeout(4) null value is handled by js and occurrence(9) handled by vireo
-    if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2) || !_ParamPointer(3) || !_ParamPointer(5) || !_ParamPointer(6) || !_ParamPointer(7) || !_ParamPointer(8)) {
+    if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2) || !_ParamPointer(3)
+        || !_ParamPointer(5) || !_ParamPointer(6) || !_ParamPointer(7) || !_ParamPointer(8)) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
         return THREAD_EXEC()->Stop();
     }
@@ -406,8 +405,7 @@ VIREO_FUNCTION_SIGNATURE10(HttpClientPut, UInt32, StringRef, StringRef, StringRe
             pObserver = clump->ReserveObservationStatesWithTimeout(2, 0);
             pOcc->InsertObserver(pObserver + 1, pOcc->Count() + 1);
             return clump->WaitOnObservableObject(_this);
-        }
-        else {
+        } else {
             return _NextInstruction();
         }
     } else {
@@ -428,9 +426,10 @@ VIREO_FUNCTION_SIGNATURE10(HttpClientPut, UInt32, StringRef, StringRef, StringRe
 VIREO_FUNCTION_SIGNATURE9(HttpClientDelete, UInt32, StringRef, StringRef, Int32, StringRef, StringRef, UInt32, ErrorCluster, OccurrenceRef)
 {
 #if kVireoOS_emscripten
-    // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
     // Timeout(3) null value is handled by js and occurrence(8) handled by vireo
-    if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2) || !_ParamPointer(4) || !_ParamPointer(5) || !_ParamPointer(6) || !_ParamPointer(7)) {
+    if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2) || !_ParamPointer(4)
+        || !_ParamPointer(5) || !_ParamPointer(6) || !_ParamPointer(7)) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
         return THREAD_EXEC()->Stop();
     }
@@ -458,8 +457,7 @@ VIREO_FUNCTION_SIGNATURE9(HttpClientDelete, UInt32, StringRef, StringRef, Int32,
             pObserver = clump->ReserveObservationStatesWithTimeout(2, 0);
             pOcc->InsertObserver(pObserver + 1, pOcc->Count() + 1);
             return clump->WaitOnObservableObject(_this);
-        }
-        else {
+        } else {
             return _NextInstruction();
         }
     } else {
@@ -480,9 +478,10 @@ VIREO_FUNCTION_SIGNATURE9(HttpClientDelete, UInt32, StringRef, StringRef, Int32,
 VIREO_FUNCTION_SIGNATURE10(HttpClientPost, UInt32, StringRef, StringRef, StringRef, Int32, StringRef, StringRef, UInt32, ErrorCluster, OccurrenceRef)
 {
 #if kVireoOS_emscripten
-    // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
     // Timeout(4) null value is handled by js and occurrence(9) handled by vireo
-    if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2) || !_ParamPointer(3) || !_ParamPointer(5) || !_ParamPointer(6) || !_ParamPointer(7) || !_ParamPointer(8)) {
+    if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2) || !_ParamPointer(3)
+        || !_ParamPointer(5) || !_ParamPointer(6) || !_ParamPointer(7) || !_ParamPointer(8)) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
         return THREAD_EXEC()->Stop();
     }
@@ -510,8 +509,7 @@ VIREO_FUNCTION_SIGNATURE10(HttpClientPost, UInt32, StringRef, StringRef, StringR
             pObserver = clump->ReserveObservationStatesWithTimeout(2, 0);
             pOcc->InsertObserver(pObserver + 1, pOcc->Count() + 1);
             return clump->WaitOnObservableObject(_this);
-        }
-        else {
+        } else {
             return _NextInstruction();
         }
     } else {
@@ -532,25 +530,25 @@ VIREO_FUNCTION_SIGNATURE10(HttpClientPost, UInt32, StringRef, StringRef, StringR
 VIREO_FUNCTION_SIGNATURE3(HttpClientConfigCORS, UInt32, UInt32, ErrorCluster)
 {
 #if kVireoOS_emscripten
-   // TODO mraj these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
-   if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2)) {
-      THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
-      return THREAD_EXEC()->Stop();
-   }
+    // TODO(rajsite): these checks are too aggressive. Should allow unwired values for optional terminals and avoid checking types inserted by Vireo
+    if (!_ParamPointer(0) || !_ParamPointer(1) || !_ParamPointer(2)) {
+        THREAD_EXEC()->LogEvent(EventLog::kHardDataError, HTTP_REQUIRED_INPUTS_MESSAGE);
+        return THREAD_EXEC()->Stop();
+    }
 
-   if (!_Param(2).status) {
-      jsHttpClientConfigCORS(
-         _Param(0),
-         _Param(1),
-         &_Param(2).status,
-         &_Param(2).code,
-         _Param(2).source);
-      AddCallChainToSourceIfErrorPresent(_ParamPointer(2), "HttpClientConfigCORS");
-   }
+    if (!_Param(2).status) {
+        jsHttpClientConfigCORS(
+             _Param(0),
+             _Param(1),
+             &_Param(2).status,
+             &_Param(2).code,
+             _Param(2).source);
+        AddCallChainToSourceIfErrorPresent(_ParamPointer(2), "HttpClientConfigCORS");
+    }
 #else
-   GenerateNotSupportedOnPlatformError(_ParamPointer(2), "HttpClientConfigCORS");
+    GenerateNotSupportedOnPlatformError(_ParamPointer(2), "HttpClientConfigCORS");
 #endif
-   return _NextInstruction();
+    return _NextInstruction();
 }
 
 //------------------------------------------------------------
@@ -565,9 +563,14 @@ DEFINE_VIREO_BEGIN(HttpClient)
     DEFINE_VIREO_FUNCTION(HttpClientListHeaders, "p(io(.UInt32) o(.String) io(ErrorCluster))")
     DEFINE_VIREO_FUNCTION(HttpClientGet, "p(io(.UInt32) i(.String) i(.String) i(.Int32) o(.String) o(.String) o(.UInt32) io(ErrorCluster) s(.Occurrence))")
     DEFINE_VIREO_FUNCTION(HttpClientHead, "p(io(.UInt32) i(.String) i(.Int32) o(.String) o(.UInt32) io(" ERROR_CLUST_TYPE_STRING ") s(.Occurrence))")
-    DEFINE_VIREO_FUNCTION(HttpClientPut, "p(io(.UInt32) i(.String) i(.String) i(.String) i(.Int32) o(.String) o(.String) o(.UInt32) io(" ERROR_CLUST_TYPE_STRING ") s(.Occurrence))")
-    DEFINE_VIREO_FUNCTION(HttpClientDelete, "p(io(.UInt32) i(.String) i(.String) i(.Int32) o(.String) o(.String) o(.UInt32) io(" ERROR_CLUST_TYPE_STRING ") s(.Occurrence))")
-    DEFINE_VIREO_FUNCTION(HttpClientPost, "p(io(.UInt32) i(.String) i(.String) i(.String) i(.Int32) o(.String) o(.String) o(.UInt32) io(ErrorCluster) s(.Occurrence))")
+    DEFINE_VIREO_FUNCTION(HttpClientPut, "p(io(.UInt32) i(.String) i(.String) i(.String) i(.Int32) o(.String) "
+                          "o(.String) o(.UInt32) io(ErrorCluster) s(.Occurrence))")
+    DEFINE_VIREO_FUNCTION(HttpClientDelete, "p(io(.UInt32) i(.String) i(.String) i(.Int32) o(.String) "
+                          "o(.String) o(.UInt32) io(ErrorCluster) s(.Occurrence))")
+    DEFINE_VIREO_FUNCTION(HttpClientPost, "p(io(.UInt32) i(.String) i(.String) i(.String) i(.Int32) "
+                          "o(.String) o(.String) o(.UInt32) io(ErrorCluster) s(.Occurrence))")
     DEFINE_VIREO_FUNCTION(HttpClientConfigCORS, "p(io(.UInt32) i(.UInt32) io(ErrorCluster))")
 DEFINE_VIREO_END()
-#endif
+
+}  // namespace Vireo
+#endif  // VIREO_TYPE_HttpClient

--- a/source/unittest/RefNumTest.cpp
+++ b/source/unittest/RefNumTest.cpp
@@ -15,7 +15,7 @@ Craig S.
 #include "RefNum.h"
 #include "UnitTest.h"
 
-using namespace Vireo;
+namespace Vireo {
 
 #ifndef VIREO_TEST_REFNUM
 #define VIREO_TEST_REFNUM VIREO_UNIT_TEST
@@ -105,3 +105,5 @@ bool RefNumTest::Execute() {
     return pass;
 }
 #endif
+
+}  // namespace Vireo


### PR DESCRIPTION
…/include-what-you-use

We now have zero lint errors except for the a couple of disabled ones.

The only lint errors still disabled are: enforcing open braces at end of
line, the format of the #ifdef include guard name, and C-style casts.
We also allow line to be up to 160 chars rather than 80.
See the comment at the top of make-it/cpplint/Makefile.