### PR TITLE
Prevent Karma vtr timeout intermittency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "karma-jasmine": "^1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-phantomjs-launcher": "^1.0.2",
-    "karma-verbose-reporter": "0.0.5",
+    "karma-verbose-reporter": "^0.0.6",
     "requirejs": "^2.3.2",
     "setimmediate": "^1.0.5",
     "shx": "^0.2.2",

--- a/test-it/karma/utilities/TestHelpers.Fixtures.js
+++ b/test-it/karma/utilities/TestHelpers.Fixtures.js
@@ -24,6 +24,8 @@
     };
 
     var preloadAbsoluteUrls = function (absoluteUrls, done) {
+        var startTime = window.performance.now();
+
         var filesToLoad = absoluteUrls.filter(fileNotLoaded).map(function (absoluteUrl) {
             var urlCacheAvoid = absoluteUrl + '?' + new Date().getTime();
             return fetch(urlCacheAvoid).then(function (response) {
@@ -37,7 +39,12 @@
             });
         });
 
-        window.Promise.all(filesToLoad).then(done).catch(function (message) {
+        window.Promise.all(filesToLoad).then(function () {
+            var loadTime = window.performance.now() - startTime;
+            if (loadTime > 2000) {
+                console.warn('Preload of files took longer that 2000ms', 'actual time', loadTime, 'files', filesToLoad);
+            }
+        }).then(done).catch(function (message) {
             done.fail('Failed because of the following reason: ' + message);
         });
     };


### PR DESCRIPTION
Breaks up loading of the vtr test suite to prevent timeouts. Seems that under some conditions the loads can be very slow and trigger the jasmine timeout.

This means that the beforeAll section has the same timeout as an it section in the jasmine suite.