### PR TITLE
Fix how UTF8 strings are read from memory

### DIFF
--- a/source/core/module_coreHelpers.js
+++ b/source/core/module_coreHelpers.js
@@ -57,19 +57,20 @@
         };
 
         // Takes Vireo Strings that are UTF-8 encoded strings with known length and returns a JS string
+        // TODO mraj assumes valid UTF8 encoding https://github.com/ni/VireoSDK/issues/283
         Module.coreHelpers.sizedUtf8ArrayToJSString = function (u8Array, startIndex, length) {
             /* eslint-disable no-continue, no-plusplus, no-bitwise */
             var u0, u1, u2, u3, u4, u5;
             var idx = startIndex;
-            var lastVisitedIndex = startIndex + length;
-            lastVisitedIndex = lastVisitedIndex > u8Array.length ? u8Array.length : lastVisitedIndex;
+            var endIndex = startIndex + length;
+            endIndex = endIndex > u8Array.length ? u8Array.length : endIndex;
             var str = '';
             while (true) {
-                // For UTF8 byte structure, see http://en.wikipedia.org/wiki/UTF-8#Description and https://www.ietf.org/rfc/rfc2279.txt and https://tools.ietf.org/html/rfc3629
-                u0 = u8Array[idx++];
-                if (idx > lastVisitedIndex) {
+                if (idx >= endIndex) {
                     return str;
                 }
+                // For UTF8 byte structure, see http://en.wikipedia.org/wiki/UTF-8#Description and https://www.ietf.org/rfc/rfc2279.txt and https://tools.ietf.org/html/rfc3629
+                u0 = u8Array[idx++];
                 if (!(u0 & 0x80)) {
                     str += String.fromCharCode(u0);
                     continue;

--- a/source/core/module_coreHelpers.js
+++ b/source/core/module_coreHelpers.js
@@ -56,14 +56,7 @@
             fpSync = fn;
         };
 
-        // reference this issue https://github.com/kripken/emscripten/issues/4693
-        // TODO mraj Add the TextDecoder optimization used by emscripten https://github.com/kripken/emscripten/blob/6dc4ac5f9e4d8484e273e4dcc554f809738cedd6/src/preamble.js#L536
-        // Note: TextDecoder only works for ArrayBuffers, maybe should change tty to use arraybuffer
-        // TODO mraj when we manipulate strings in vireo do we always utf8 encode the value?
-        // TODO mraj the manual and textDecoder function may return different values in cases of corrupt utf8 or truncated multibyte utf8 character
-        // ie the character 128 would be 2 bytes in utf8
-        // Requires a length. Should NOT include a terminating null as part of length.
-        // Allows UTF8 arrays with internal null values.
+        // Takes Vireo Strings that are UTF-8 encoded strings with known length and returns a JS string
         Module.coreHelpers.sizedUtf8ArrayToJSString = function (u8Array, startIndex, length) {
             /* eslint-disable no-continue, no-plusplus, no-bitwise */
             var u0, u1, u2, u3, u4, u5;

--- a/source/core/module_coreHelpers.js
+++ b/source/core/module_coreHelpers.js
@@ -56,12 +56,15 @@
             fpSync = fn;
         };
 
+        // reference this issue https://github.com/kripken/emscripten/issues/4693
+        // TODO mraj Add the TextDecoder optimization used by emscripten https://github.com/kripken/emscripten/blob/6dc4ac5f9e4d8484e273e4dcc554f809738cedd6/src/preamble.js#L536
+        // Note: TextDecoder only works for ArrayBuffers, maybe should change tty to use arraybuffer
         // TODO mraj when we manipulate strings in vireo do we always utf8 encode the value?
         // TODO mraj the manual and textDecoder function may return different values in cases of corrupt utf8 or truncated multibyte utf8 character
         // ie the character 128 would be 2 bytes in utf8
         // Requires a length. Should NOT include a terminating null as part of length.
         // Allows UTF8 arrays with internal null values.
-        var manualSizedUtf8ArrayToJSString = function (u8Array, startIndex, length) {
+        Module.coreHelpers.sizedUtf8ArrayToJSString = function (u8Array, startIndex, length) {
             /* eslint-disable no-continue, no-plusplus, no-bitwise */
             var u0, u1, u2, u3, u4, u5;
             var idx = startIndex;
@@ -108,29 +111,6 @@
                 }
             }
         };
-
-        // reference this issue https://github.com/kripken/emscripten/issues/4693
-        // var utf8Decoder;
-        // var textDecoderSizedUtf8ArrayToJSString = function (u8Array, startIndex, length) {
-        //     // Used by the stdout to print full buffers
-        //     if (startIndex === 0 && u8Array.length <= length) {
-        //         return utf8Decoder.decode(u8Array);
-        //     }
-        //     // Stealing this optimization from emscripten https://github.com/kripken/emscripten/blob/6dc4ac5f9e4d8484e273e4dcc554f809738cedd6/src/preamble.js#L536
-        //     if (length < 16) {
-        //         return manualSizedUtf8ArrayToJSString(u8Array, startIndex, length);
-        //     }
-        //     return utf8Decoder.decode(u8Array.subarray(startIndex, startIndex + length));
-        // };
-
-        if (TextDecoder === undefined) {
-            Module.coreHelpers.sizedUtf8ArrayToJSString = manualSizedUtf8ArrayToJSString;
-        } else {
-            // TODO mraj only works for ArrayBuffers, maybe should change tty to use arraybuffer
-            // utf8Decoder = new TextDecoder('utf8');
-            // Module.coreHelpers.sizedUtf8ArrayToJSString = textDecoderSizedUtf8ArrayToJSString;
-            Module.coreHelpers.sizedUtf8ArrayToJSString = manualSizedUtf8ArrayToJSString;
-        }
 
         Module.coreHelpers.jsCurrentBrowserFPS = function () {
             if (trackingFPS === false) {

--- a/source/core/vireo.loader.js
+++ b/source/core/vireo.loader.js
@@ -50,7 +50,7 @@
         var ttyout = [];
         Module.stdout = function (val) {
             if (val === null || val === 0x0A) {
-                Module.print(Module.coreHelpers.utf8ArrayToStringWithNull(ttyout, 0));
+                Module.print(Module.coreHelpers.sizedUtf8ArrayToJSString(ttyout, 0, ttyout.length));
                 ttyout = [];
             } else {
                 ttyout.push(val);

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -289,7 +289,7 @@
         Module.eggShell.dataReadString = function (stringPointer) {
             var begin = Data_GetStringBegin(stringPointer);
             var length = Data_GetStringLength(stringPointer);
-            var str = Module.Pointer_stringify(begin, length);
+            var str = Module.coreHelpers.sizedUtf8ArrayToJSString(Module.HEAP8, begin, length);
             return str;
         };
 

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -235,6 +235,7 @@
             }
 
             var arrayTypeNamePointer = Module.getValue(arrayTypeNameDoublePointer, 'i32');
+            // The following use of Pointer_stringify is safe as long as arrayTypeNamePointer is a valid C string
             var arrayTypeName = Module.Pointer_stringify(arrayTypeNamePointer);
             var arrayRank = Module.getValue(arrayRankPointer, 'i32');
             var arrayBegin = Module.getValue(arrayBeginPointer, 'i32');

--- a/test-it/karma/fixtures/publicapi/FPSyncSimple.via
+++ b/test-it/karma/fixtures/publicapi/FPSyncSimple.via
@@ -1,0 +1,11 @@
+define (c1 dv(.String 'Hello World'))
+
+define (MyVI dv(.VirtualInstrument (
+    Locals: c(
+    )
+        clump(1
+        FPSync(c1)
+    )
+)))
+enqueue (MyVI)
+

--- a/test-it/karma/fixtures/publicapi/FPSyncUtf8.via
+++ b/test-it/karma/fixtures/publicapi/FPSyncUtf8.via
@@ -1,5 +1,5 @@
 define (c0 dv(.Double 7))
-define (c1 dv(.String 'Iñtërnâtiônàlizætiøn☃💩'))
+define (c1 dv(.String 'Iñtërnâtiônàlizætiøn\x00☃💩'))
 define (c2 dv(.Double 8))
 
 define (MyVI dv(.VirtualInstrument (

--- a/test-it/karma/fixtures/publicapi/FPSyncUtf8.via
+++ b/test-it/karma/fixtures/publicapi/FPSyncUtf8.via
@@ -1,0 +1,17 @@
+define (c0 dv(.Double 7))
+define (c1 dv(.String 'Iñtërnâtiônàlizætiøn☃💩'))
+define (c2 dv(.Double 8))
+
+define (MyVI dv(.VirtualInstrument (
+    Locals: c(
+        e(.Double myDouble)
+    )
+        clump(1
+        Copy(c0 myDouble)
+        FPSync(c1)
+        Copy(c2 myDouble)
+        FPSync(c1)
+    )
+)))
+enqueue (MyVI)
+

--- a/test-it/karma/publicapi/FPSync.Test.js
+++ b/test-it/karma/publicapi/FPSync.Test.js
@@ -40,11 +40,11 @@ describe('The Vireo CoreHelpers setFPSyncFunction api', function () {
         var viName = 'MyVI';
 
         var trackerCalls = [];
-        var tracker = function (fpsyncString) {
+        var tracker = function (fpSyncString) {
             var myDouble = vireo.eggShell.readDouble(viName, 'myDouble');
             trackerCalls.push({
                 myDouble: myDouble,
-                fpsyncString: fpsyncString
+                fpSyncString: fpSyncString
             });
         };
 
@@ -52,13 +52,14 @@ describe('The Vireo CoreHelpers setFPSyncFunction api', function () {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiFPSyncUtf8ViaUrl);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
+            var fpSyncString = 'Iñtërnâtiônàlizætiøn\0☃💩';
             expect(rawPrint).toBeEmptyString();
             expect(rawPrintError).toBeEmptyString();
             expect(trackerCalls.length).toBe(2);
             expect(trackerCalls[0].myDouble).toBe(7);
-            expect(trackerCalls[0].fpsyncString).toBe('Iñtërnâtiônàlizætiøn☃💩');
+            expect(trackerCalls[0].fpSyncString).toBe(fpSyncString);
             expect(trackerCalls[1].myDouble).toBe(8);
-            expect(trackerCalls[1].fpsyncString).toBe('Iñtërnâtiônàlizætiøn☃💩');
+            expect(trackerCalls[1].fpSyncString).toBe(fpSyncString);
 
             done();
         });

--- a/test-it/karma/publicapi/FPSync.Test.js
+++ b/test-it/karma/publicapi/FPSync.Test.js
@@ -1,0 +1,66 @@
+describe('The Vireo CoreHelpers setFPSyncFunction api', function () {
+    'use strict';
+    // Reference aliases
+    var Vireo = window.NationalInstruments.Vireo.Vireo;
+    var vireoRunner = window.testHelpers.vireoRunner;
+    var fixtures = window.testHelpers.fixtures;
+
+    var vireo;
+
+    var publicApiFPSyncSimpleViaUrl = fixtures.convertToAbsoluteFromFixturesDir('publicapi/FPSyncSimple.via');
+    var publicApiFPSyncUtf8ViaUrl = fixtures.convertToAbsoluteFromFixturesDir('publicapi/FPSyncUtf8.via');
+
+    beforeAll(function (done) {
+        fixtures.preloadAbsoluteUrls([
+            publicApiFPSyncSimpleViaUrl,
+            publicApiFPSyncUtf8ViaUrl
+        ], done);
+    });
+
+    beforeEach(function () {
+        vireo = new Vireo();
+    });
+
+    it('can perform a simple fpsync', function (done) {
+        var tracker = jasmine.createSpy();
+        vireo.coreHelpers.setFPSyncFunction(tracker);
+        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiFPSyncSimpleViaUrl);
+
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrint).toBeEmptyString();
+            expect(rawPrintError).toBeEmptyString();
+            expect(tracker).toHaveBeenCalled();
+            expect(tracker).toHaveBeenCalledWith('Hello World');
+
+            done();
+        });
+    });
+
+    it('can perform a fpsync with UTF8 characters', function (done) {
+        var viName = 'MyVI';
+
+        var trackerCalls = [];
+        var tracker = function (fpsyncString) {
+            var myDouble = vireo.eggShell.readDouble(viName, 'myDouble');
+            trackerCalls.push({
+                myDouble: myDouble,
+                fpsyncString: fpsyncString
+            });
+        };
+
+        vireo.coreHelpers.setFPSyncFunction(tracker);
+        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiFPSyncUtf8ViaUrl);
+
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrint).toBeEmptyString();
+            expect(rawPrintError).toBeEmptyString();
+            expect(trackerCalls.length).toBe(2);
+            expect(trackerCalls[0].myDouble).toBe(7);
+            expect(trackerCalls[0].fpsyncString).toBe('Iñtërnâtiônàlizætiøn☃💩');
+            expect(trackerCalls[1].myDouble).toBe(8);
+            expect(trackerCalls[1].fpsyncString).toBe('Iñtërnâtiônàlizætiøn☃💩');
+
+            done();
+        });
+    });
+});

--- a/test-it/karma/publicapi/ResizeArray.Test.js
+++ b/test-it/karma/publicapi/ResizeArray.Test.js
@@ -21,7 +21,7 @@ describe('Arrays in Vireo', function () {
             expect(rawPrintError).toBeEmptyString();
 
             var resized = vireo.eggShell.resizeArray(viName, 'variableArray1d', [5]);
-            console.log(resized);
+            expect(resized).toBe(0);
             expect(vireo.eggShell.getArrayDimLength(viName, 'variableArray1d', 0)).toBe(5);
             done();
         });


### PR DESCRIPTION
Several locations intended to read Vireo Strings from memory were using the Pointer_stringify function.

Pointer_stringify takes a length parameter which is ignored in the case of UTF8 strings. This causes errors as the function will read passed the end of the string. In addition, null characters contained within the Vireo String cause the string to be truncated at that character.

The sizedUtf8ArrayToJSString function was made by modifying the Pointer_stringify algorithm to not terminate on null characters and to take a length parameter.

Also validated that the remaining active Pointer_stringify use cases are being used on null terminated C strings exposed by the Vireo APIs.