### PR TITLE
Prevent emsdk update

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,11 +14,13 @@ install:
   - chocolatey install gnuwin32-coreutils.portable
   - npm install
   - pip install --user -r requirements.txt
-  - ps: Start-BitsTransfer -Source https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-1.35.0-portable-64bit.zip -Destination .\emsdk-1.35.0-portable-64bit.zip
-  - ps: Expand-Archive .\emsdk-1.35.0-portable-64bit.zip -DestinationPath .\emscripten-sdk
-  - emscripten-sdk\emsdk update-tags
-  - emscripten-sdk\emsdk install sdk-1.37.9-64bit
-  - emscripten-sdk\emsdk activate sdk-1.37.9-64bit
+#  - ps: Start-BitsTransfer -Source https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-1.35.0-portable-64bit.zip -Destination .\emsdk-1.35.0-portable-64bit.zip
+#  - ps: Expand-Archive .\emsdk-1.35.0-portable-64bit.zip -DestinationPath .\emscripten-sdk
+#  - emscripten-sdk\emsdk update-tags
+  - git clone https://github.com/juj/emsdk.git
+  - cd emsdk && git checkout a90d9ef4c805ab4a78eddb57fee8dc89d8198cdb && cd ..
+  - emsdk\emsdk install sdk-1.37.9-64bit
+  - emsdk\emsdk activate sdk-1.37.9-64bit
   - emcc -v
 platform:
   - Win32

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,7 +16,7 @@ install:
   - pip install --user -r requirements.txt
   - ps: Start-BitsTransfer -Source https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-1.35.0-portable-64bit.zip -Destination .\emsdk-1.35.0-portable-64bit.zip
   - ps: Expand-Archive .\emsdk-1.35.0-portable-64bit.zip -DestinationPath .\emscripten-sdk
-  - emscripten-sdk\emsdk update
+  - emscripten-sdk\emsdk update-tags
   - emscripten-sdk\emsdk install sdk-1.37.9-64bit
   - emscripten-sdk\emsdk activate sdk-1.37.9-64bit
   - emcc -v

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,9 +14,6 @@ install:
   - chocolatey install gnuwin32-coreutils.portable
   - npm install
   - pip install --user -r requirements.txt
-#  - ps: Start-BitsTransfer -Source https://s3.amazonaws.com/mozilla-games/emscripten/releases/emsdk-1.35.0-portable-64bit.zip -Destination .\emsdk-1.35.0-portable-64bit.zip
-#  - ps: Expand-Archive .\emsdk-1.35.0-portable-64bit.zip -DestinationPath .\emscripten-sdk
-#  - emscripten-sdk\emsdk update-tags
   - git clone https://github.com/juj/emsdk.git
   - cd emsdk && git checkout a90d9ef4c805ab4a78eddb57fee8dc89d8198cdb && cd ..
   - emsdk\emsdk install sdk-1.37.9-64bit

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,4 +5,5 @@ env/*
 source/io/library_canvas2d.js
 source/io/library_webSocketClient.js
 emscripten-sdk/*
+emsdk/*
 coverage/*

--- a/.gitignore
+++ b/.gitignore
@@ -113,4 +113,5 @@ env/
 *.tgz
 coverage/
 emscripten-sdk/
+emsdk/
 nohup.out


### PR DESCRIPTION
Running the emsdk update command causes the emsdk tool itself to update while used to install a specific version of emscripten.

This was unexpected and causes a latest incoming change to emsdk to (1) error during emsdk install resulting in breaking builds and (2) creates extremely verbose output making it difficult to look at build results.

An issue was filed here: https://github.com/juj/emsdk/issues/86

This change lets us sync to a specific version of the emsdk tool prior to those issues being introduced.

As the build is currently broken, this is a high priority change and as soon as the test builds go in I will merge this change. Please add review comments and they will be addressed before merge if possible or immediately after.