### PR TITLE
Fix Issue #310, ArrayInsertPartial test.

### DIFF
--- a/source/core/Array.cpp
+++ b/source/core/Array.cpp
@@ -791,7 +791,7 @@ VIREO_FUNCTION_SIGNATURE5(ArrayInsertSubsetND, TypedArrayCoreRef, TypedArrayCore
             if (numberOfDimensions == subArray->Rank()) {
                 sourceSlabLen[i] = subArray->SlabLengths()[i];
                 sourceDimLen[i] = subArray->DimensionLengths()[i];
-                if (sourceDimLen[i] > newLengths[i])
+                if (numberOfDimensions-1-i != dimensionToInsert && sourceDimLen[i] > newLengths[i])
                     sourceDimLen[i] = newLengths[i];
             } else {
                 if (i == numberOfDimensions-1-dimensionToInsert) {

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -281,6 +281,7 @@
                 "SubVIParameters.via",
                 "SubVISimple.via",
                 "TemplateBasics.via",
+		"TestVI_ArrayInsertPartial.via",
                 "TestVI_LargeArray.via",
                 "TestVI_VectorMaxMinOp.via",
                 "TestVI_VectorScalarBinaryOp.via",

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -281,7 +281,7 @@
                 "SubVIParameters.via",
                 "SubVISimple.via",
                 "TemplateBasics.via",
-		"TestVI_ArrayInsertPartial.via",
+                "TestVI_ArrayInsertPartial.via",
                 "TestVI_LargeArray.via",
                 "TestVI_VectorMaxMinOp.via",
                 "TestVI_VectorScalarBinaryOp.via",


### PR DESCRIPTION
ArrayInsertSubset was incorrectly limiting the dim length of
the inserted subarray to be no more than the length of the input
array along the inserted dimension.  All of the other dimensions
are correctly so-pinned (so the array grows along only one dimension), but
the inserted dimension should not be limited.
E.g.  Insert (by rows) into [[1,1][2,2]] a subarray of [3,3,3],[4,4,4],[5,5,5]]
The columns are pinned to 2 elements because the subarray has two many
columns to fit into the input array, but all 3 rows of subarray should
still be inserted into the input array, even though it has only 2 rows
to begin with, because the array grows along that dimension, but not
the others.