### PR TITLE
Content type default

### DIFF
--- a/source/io/module_httpClient.js
+++ b/source/io/module_httpClient.js
@@ -638,7 +638,6 @@
                 buffer = new Blob([typedArrayBuffer], {
                     type: 'application/x-www-form-urlencoded'
                 });
-                // TODO need tests to show that text/plain is the default and can be overridden
             }
 
             var httpClient;

--- a/source/io/module_httpClient.js
+++ b/source/io/module_httpClient.js
@@ -633,7 +633,10 @@
             if (bufferPointer !== NULL) {
                 typedArrayBuffer = Module.eggShell.dataReadStringAsArray_NoCopy(bufferPointer);
                 // TODO(mraj) would like to use the typed array directly but not supported in iOS and PhantomJS
-                buffer = new Blob([typedArrayBuffer]);
+                buffer = new Blob([typedArrayBuffer], {
+                    type: 'text/plain;charset=utf-8'
+                });
+                // TODO need tests to show that text/plain is the default and can be overridden
             }
 
             var httpClient;

--- a/source/io/module_httpClient.js
+++ b/source/io/module_httpClient.js
@@ -633,8 +633,10 @@
             if (bufferPointer !== NULL) {
                 typedArrayBuffer = Module.eggShell.dataReadStringAsArray_NoCopy(bufferPointer);
                 // TODO(mraj) would like to use the typed array directly but not supported in iOS and PhantomJS
+                // Set the type to application/x-www-form-urlencoded as this is the default on desktop
+                // User can add a Content-Type header to override this default
                 buffer = new Blob([typedArrayBuffer], {
-                    type: 'text/plain;charset=utf-8'
+                    type: 'application/x-www-form-urlencoded'
                 });
                 // TODO need tests to show that text/plain is the default and can be overridden
             }

--- a/test-it/karma/http/HttpPost.Test.js
+++ b/test-it/karma/http/HttpPost.Test.js
@@ -190,6 +190,7 @@ describe('Performing a POST request', function () {
             var requestUrl = httpParser.parseUrl(httpBinBody.url);
             expect(httpBinBody.args).toBeEmptyObject();
             expect(httpBinBody.headers).toBeNonEmptyObject();
+            expect(httpBinBody.form).toBeEmptyObject();
             expect(httpBinBody.data).toBeEmptyString();
             expect(requestUrl.pathname).toBe('/post');
 
@@ -220,7 +221,7 @@ describe('Performing a POST request', function () {
             summer: 'smith',
             mr: 'pbh'
         });
-        viPathWriter('buffer', buffer);
+        viPathWriter('buffer', 'mydata=' + buffer);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
@@ -241,7 +242,10 @@ describe('Performing a POST request', function () {
             var requestUrl = httpParser.parseUrl(httpBinBody.url);
             expect(httpBinBody.args).toBeEmptyObject();
             expect(httpBinBody.headers).toBeNonEmptyObject();
-            expect(httpBinBody.data).toBe(buffer);
+            expect(httpBinBody.form).toEqual({
+                mydata: buffer
+            });
+            expect(httpBinBody.data).toBeEmptyString();
             expect(requestUrl.pathname).toBe('/post');
 
             // status code
@@ -264,7 +268,7 @@ describe('Performing a POST request', function () {
         var url = httpBinHelpers.convertToAbsoluteUrl('post');
         viPathWriter('url', url);
         var buffer = 'Iñtërnâtiônàlizætiøn☃💩';
-        viPathWriter('buffer', buffer);
+        viPathWriter('buffer', 'mydata=' + buffer);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
@@ -285,7 +289,10 @@ describe('Performing a POST request', function () {
             var requestUrl = httpParser.parseUrl(httpBinBody.url);
             expect(httpBinBody.args).toBeEmptyObject();
             expect(httpBinBody.headers).toBeNonEmptyObject();
-            expect(httpBinBody.data).toBe(buffer);
+            expect(httpBinBody.form).toEqual({
+                mydata: buffer
+            });
+            expect(httpBinBody.data).toBeEmptyString();
             expect(requestUrl.pathname).toBe('/post');
 
             // status code
@@ -308,7 +315,7 @@ describe('Performing a POST request', function () {
         var url = httpBinHelpers.convertToAbsoluteUrl('post');
         viPathWriter('url', url);
         var buffer = '\xCB\xD2\x7C\x42\x00\xA9\x78\xC2';
-        viPathWriter('buffer', buffer);
+        viPathWriter('buffer', 'mydata=' + buffer);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
@@ -329,7 +336,10 @@ describe('Performing a POST request', function () {
             var requestUrl = httpParser.parseUrl(httpBinBody.url);
             expect(httpBinBody.args).toBeEmptyObject();
             expect(httpBinBody.headers).toBeNonEmptyObject();
-            expect(httpBinBody.data).toBe(buffer);
+            expect(httpBinBody.form).toEqual({
+                mydata: buffer
+            });
+            expect(httpBinBody.data).toBeEmptyString();
             expect(requestUrl.pathname).toBe('/post');
 
             // status code
@@ -430,6 +440,7 @@ describe('Performing a POST request', function () {
             var requestUrl = httpParser.parseUrl(httpBinBody.url);
             expect(httpBinBody.args).toBeEmptyObject();
             expect(httpBinBody.headers).toBeNonEmptyObject();
+            expect(httpBinBody.form).toBeEmptyObject();
             expect(httpBinBody.data).toBeEmptyString();
             expect(requestUrl.pathname).toBe('/post');
 
@@ -507,6 +518,7 @@ describe('Performing a POST request', function () {
             expect(httpBinBody.args).toBeEmptyObject();
             expect(httpBinBody.headers).toBeNonEmptyObject();
             expect(httpBinBody.headersLowerCase[header]).toBe(value);
+            expect(httpBinBody.form).toBeEmptyObject();
             expect(httpBinBody.data).toBeEmptyString();
             expect(requestUrl.pathname).toBe('/post');
 
@@ -562,6 +574,7 @@ describe('Performing a POST request', function () {
             expect(httpBinBody1.headersLowerCase).toHaveMember(header1);
             expect(httpBinBody1.headersLowerCase).not.toHaveMember(header2);
             expect(httpBinBody1.headersLowerCase[header1]).toBe(value1);
+            expect(httpBinBody1.form).toBeEmptyObject();
             expect(httpBinBody1.data).toBeEmptyString();
             expect(requestUrl1.pathname).toBe('/post');
 
@@ -591,6 +604,7 @@ describe('Performing a POST request', function () {
             expect(httpBinBody2.headersLowerCase).not.toHaveMember(header1);
             expect(httpBinBody2.headersLowerCase).toHaveMember(header2);
             expect(httpBinBody2.headersLowerCase[header2]).toBe(value2);
+            expect(httpBinBody2.form).toBeEmptyObject();
             expect(httpBinBody2.data).toBeEmptyString();
             expect(requestUrl2.pathname).toBe('/post');
 
@@ -635,6 +649,7 @@ describe('Performing a POST request', function () {
                 expect(httpBinBody.headers).toBeNonEmptyObject();
                 // IE and Edge do not use the Blob type as the Content-Type and instead avoid sending the header
                 expect(['application/x-www-form-urlencoded', undefined]).toContain(httpBinBody.headers['Content-Type']);
+                expect(httpBinBody.form).toBeEmptyObject();
                 expect(httpBinBody.data).toBeEmptyString();
                 expect(requestUrl.pathname).toBe('/post');
 
@@ -682,6 +697,7 @@ describe('Performing a POST request', function () {
                 expect(httpBinBody.args).toBeEmptyObject();
                 expect(httpBinBody.headers).toBeNonEmptyObject();
                 expect(httpBinBody.headers[header]).toBe(value);
+                expect(httpBinBody.form).toBeEmptyObject();
                 expect(httpBinBody.data).toBeEmptyString();
                 expect(requestUrl.pathname).toBe('/post');
 

--- a/test-it/karma/http/HttpPut.Test.js
+++ b/test-it/karma/http/HttpPut.Test.js
@@ -166,6 +166,7 @@ describe('Performing a PUT request', function () {
             var requestUrl = httpParser.parseUrl(httpBinBody.url);
             expect(httpBinBody.args).toBeEmptyObject();
             expect(httpBinBody.headers).toBeNonEmptyObject();
+            expect(httpBinBody.form).toBeEmptyObject();
             expect(httpBinBody.data).toBeEmptyString();
             expect(requestUrl.pathname).toBe('/put');
 
@@ -196,7 +197,7 @@ describe('Performing a PUT request', function () {
             summer: 'smith',
             mr: 'pbh'
         });
-        viPathWriter('buffer', buffer);
+        viPathWriter('buffer', 'mydata=' + buffer);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
@@ -217,7 +218,10 @@ describe('Performing a PUT request', function () {
             var requestUrl = httpParser.parseUrl(httpBinBody.url);
             expect(httpBinBody.args).toBeEmptyObject();
             expect(httpBinBody.headers).toBeNonEmptyObject();
-            expect(httpBinBody.data).toBe(buffer);
+            expect(httpBinBody.form).toEqual({
+                mydata: buffer
+            });
+            expect(httpBinBody.data).toBeEmptyString();
             expect(requestUrl.pathname).toBe('/put');
 
             // status code
@@ -240,7 +244,7 @@ describe('Performing a PUT request', function () {
         var url = httpBinHelpers.convertToAbsoluteUrl('put');
         viPathWriter('url', url);
         var buffer = 'Iñtërnâtiônàlizætiøn☃💩';
-        viPathWriter('buffer', buffer);
+        viPathWriter('buffer', 'mydata=' + buffer);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
@@ -261,7 +265,10 @@ describe('Performing a PUT request', function () {
             var requestUrl = httpParser.parseUrl(httpBinBody.url);
             expect(httpBinBody.args).toBeEmptyObject();
             expect(httpBinBody.headers).toBeNonEmptyObject();
-            expect(httpBinBody.data).toBe(buffer);
+            expect(httpBinBody.form).toEqual({
+                mydata: buffer
+            });
+            expect(httpBinBody.data).toBeEmptyString();
             expect(requestUrl.pathname).toBe('/put');
 
             // status code
@@ -362,6 +369,7 @@ describe('Performing a PUT request', function () {
             var requestUrl = httpParser.parseUrl(httpBinBody.url);
             expect(httpBinBody.args).toBeEmptyObject();
             expect(httpBinBody.headers).toBeNonEmptyObject();
+            expect(httpBinBody.form).toBeEmptyObject();
             expect(httpBinBody.data).toBeEmptyString();
             expect(requestUrl.pathname).toBe('/put');
 
@@ -439,6 +447,7 @@ describe('Performing a PUT request', function () {
             expect(httpBinBody.args).toBeEmptyObject();
             expect(httpBinBody.headers).toBeNonEmptyObject();
             expect(httpBinBody.headersLowerCase[header]).toBe(value);
+            expect(httpBinBody.form).toBeEmptyObject();
             expect(httpBinBody.data).toBeEmptyString();
             expect(requestUrl.pathname).toBe('/put');
 
@@ -494,6 +503,7 @@ describe('Performing a PUT request', function () {
             expect(httpBinBody1.headersLowerCase).toHaveMember(header1);
             expect(httpBinBody1.headersLowerCase).not.toHaveMember(header2);
             expect(httpBinBody1.headersLowerCase[header1]).toBe(value1);
+            expect(httpBinBody1.form).toBeEmptyObject();
             expect(httpBinBody1.data).toBeEmptyString();
             expect(requestUrl1.pathname).toBe('/put');
 
@@ -523,6 +533,7 @@ describe('Performing a PUT request', function () {
             expect(httpBinBody2.headersLowerCase).not.toHaveMember(header1);
             expect(httpBinBody2.headersLowerCase).toHaveMember(header2);
             expect(httpBinBody2.headersLowerCase[header2]).toBe(value2);
+            expect(httpBinBody2.form).toBeEmptyObject();
             expect(httpBinBody2.data).toBeEmptyString();
             expect(requestUrl2.pathname).toBe('/put');
 


### PR DESCRIPTION
Changes the Blob type from the default of empty string to application/x-www-form-urlencoded. This improves on the Coherent behavior of attempting to use a Content-Type of empty string and triggering a CORS preflight request.