### PR TITLE
Change optimization level

### DIFF
--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -64,7 +64,7 @@ help:
 EMCC= emcc
 
 # release config
-EM_OPTFLAG = -Os
+EM_OPTFLAG = -O3
 
 ifeq ($(BUILD), debug)
    EM_OPTFLAG = -g4 -s ASSERTIONS=2 -s SAFE_HEAP=1


### PR DESCRIPTION
Changed from -Os for the build to -O3.

-Os is used by emscripten to shrink binary size at the cost of performance
-O3 is the recommended release setting by emscripten

https://kripken.github.io/emscripten-site/docs/tools_reference/emcc.html#emcc-o3

Running the JS benchmarks, -O3 gives on average 30% improvement on peek
and poke tests into Vireo over -Os:

https://docs.google.com/spreadsheets/d/1DJWLSjlsYiivtnl-os7fVtAL566Pcz034AdIvU7berY/edit?usp=sharing

The file size change is
-Os: 962 KB
-O3: 1095 KB
which is a 13% increase in file size or 133 KB increase which is pretty minor overall.