### PR TITLE
Fix to Defect DE14013. Uncaught Vireo / JS error (Instr. not generate…

### DIFF
--- a/source/core/GenericFunctions.cpp
+++ b/source/core/GenericFunctions.cpp
@@ -21,7 +21,10 @@ SDG
 
 namespace Vireo
 {
-
+//------------------------------------------------------------
+// Currently we are not calling this function, it intermittently returns different values 
+// between the first and second pass. We need to root cause the issue and reenable the code
+// This is tracked in github issue: https://github.com/ni/VireoSDK/issues/332
 //------------------------------------------------------------
 ConstCStr CopyProcName(void *pSource, void *pDest, Int32 aqSize)
 {

--- a/source/core/GenericFunctions.cpp
+++ b/source/core/GenericFunctions.cpp
@@ -22,7 +22,7 @@ SDG
 namespace Vireo
 {
 //------------------------------------------------------------
-// Currently we are not calling this function, it intermittently returns different values 
+// Currently we are not calling this function, it intermittently returns different values
 // between the first and second pass. We need to root cause the issue and reenable the code
 // This is tracked in github issue: https://github.com/ni/VireoSDK/issues/332
 //------------------------------------------------------------

--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -1524,7 +1524,11 @@ void TDViaParser::FinalizeVILoad(VirtualInstrument* vi, EventLog* pLog)
                 parser.ParseClump(pClump, &cia);
             }
         }
-        VIREO_ASSERT(cia._size == 0);
+
+        if (cia._size != 0) {
+            pLog->LogEvent(EventLog::kHardDataError, vi->_lineNumberBase, "Requested and allocated memory size is different.");
+            exit(1);
+        }
     }
 }
 //------------------------------------------------------------


### PR DESCRIPTION
…d: Copy) when using Open+Read Tag from Skyline API

Root issue: Vireo is using more memory than originally requested when
emitting code for a copy. This behavior is random.

The EmitGenericCopyInstruction function is returning different memory
size values based on the alignment of the pointers, which are not always
the same in the requested and allocation phases. This behavior is random
and when present causes different memory sizes for the same instruction
causing a "copy instruction not generated" error.

Refactored code to not use CopyProcName, which provides the name of the
copy function to use and takes into consideration the pointer alignment
of source and destination, and use always CopyN. We loss some speed, but
gain on reliability.