### PR TITLE
Add EXTRACFLAGS to link lines so they can be overriden in custom.mak

### DIFF
--- a/make-it/Makefile
+++ b/make-it/Makefile
@@ -218,9 +218,9 @@ esh-test:	$(OUTPUT_TEST_EXE)
 
 # Build the executable with symbols stripped
 $(OUTPUT_EXE): $(OBJDIR) $(OBJS) $(OUTPUT_DIR)
-	$(CC) -o $(OUTPUT_EXE) $(TARGETARCH) $(LDFLAGS) $(OBJS) $(LIBS)
+	$(CC) -o $(OUTPUT_EXE) $(TARGETARCH) $(EXTRACFLAGS) $(LDFLAGS) $(OBJS) $(LIBS)
 $(OUTPUT_TEST_EXE): $(OBJDIR) $(OBJS) $(UTOBJS) $(OUTPUT_DIR)
-	$(CC) -o $@ $(TARGETARCH) $(LDFLAGS) $(OBJS) $(UTOBJS) $(LIBS)
+	$(CC) -o $@ $(TARGETARCH) $(EXTRACFLAGS) $(LDFLAGS) $(OBJS) $(UTOBJS) $(LIBS)
 
 libvireo.so: $(OBJDIR) $(COREOBJS) $(IOOBJS) $(COMMANDLINEOBJS)
 	$(CC) $(LDFLAGS) -o $@ $(OBJS) $(LIBS)


### PR DESCRIPTION
One possible use, set EXTRACFLAGS to "-m32" to build a 32-bit native build for testing.
Useful because pointer-sizes then match the emscripten build.