### PR TITLE
Refactor executeSlices to return a different result value allowing for more efficient scheduling, sleeping when nothing to do.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -122,7 +122,7 @@ module.exports = {
         'no-mixed-operators': 'error',
         'no-mixed-spaces-and-tabs': 'error',
         'no-multiple-empty-lines': 'error',
-        'no-negated-condition': 'error',
+        'no-negated-condition': 'off',
         'no-nested-ternary': 'error',
         'no-new-object': 'error',
         'no-plusplus': 'error',

--- a/source/CommandLine/main.cpp
+++ b/source/CommandLine/main.cpp
@@ -14,6 +14,7 @@ SDG
 #if kVireoOS_emscripten
     #include <emscripten.h>
 #endif
+#include <unistd.h>
 
 namespace Vireo {
 
@@ -114,8 +115,11 @@ int VIREO_MAIN(int argc, const char * argv[])
 void Vireo::RunExec() {
     TypeManagerRef tm = gShells._pUserShell;
     TypeManagerScope scope(tm);
-    gShells._keepRunning = tm->TheExecutionContext()->ExecuteSlices(400, 10000000) != kExecutionState_None;
-
+    Int32 state = tm->TheExecutionContext()->ExecuteSlices(400, 10000000);
+    Int32 delay = state > 0 ? state : 0;
+    gShells._keepRunning = (state != kExecSlices_ClumpsFinished);
+    if (delay)
+        gPlatform.Timer.SleepMilliseconds(delay);
     if (!gShells._keepRunning) {
         // No more to execute
 #if defined(kVireoOS_emscripten)

--- a/source/CommandLine/main.cpp
+++ b/source/CommandLine/main.cpp
@@ -14,7 +14,6 @@ SDG
 #if kVireoOS_emscripten
     #include <emscripten.h>
 #endif
-#include <unistd.h>
 
 namespace Vireo {
 

--- a/source/core/ExecutionContext.cpp
+++ b/source/core/ExecutionContext.cpp
@@ -14,7 +14,6 @@ SDG
 #include "TypeDefiner.h"
 #include "ExecutionContext.h"
 #include "VirtualInstrument.h"
-#include <unistd.h>
 #if kVireoOS_emscripten
 #include <emscripten.h>
 #endif

--- a/source/core/ExecutionContext.cpp
+++ b/source/core/ExecutionContext.cpp
@@ -14,7 +14,7 @@ SDG
 #include "TypeDefiner.h"
 #include "ExecutionContext.h"
 #include "VirtualInstrument.h"
-
+#include <unistd.h>
 #if kVireoOS_emscripten
 #include <emscripten.h>
 #endif
@@ -311,7 +311,7 @@ InstructionCore* ExecutionContext::SuspendRunningQueueElt(InstructionCore* nextI
     }
 }
 //------------------------------------------------------------
-ExecutionState ExecutionContext::ExecuteSlices(Int32 numSlices, PlatformTickType tickCount)
+Int32 /*ExecSlicesResult*/ ExecutionContext::ExecuteSlices(Int32 numSlices, PlatformTickType tickCount)
 {
     VIREO_ASSERT((_runningQueueElt == null))
 
@@ -383,21 +383,38 @@ ExecutionState ExecutionContext::ExecuteSlices(Int32 numSlices, PlatformTickType
         }
     }
 
-    ExecutionState reply = kExecutionState_None;
+    ExecutionState state = kExecutionState_None;
+    Int32 reply = kExecSlices_ClumpsFinished;
     if (!_runQueue.IsEmpty()) {
-        reply = (ExecutionState) (reply | kExecutionState_ClumpsInRunQueue);
+        state = kExecutionState_ClumpsInRunQueue;
+        reply = kExecSlices_ClumpsInRunQueue;
     }
     if (_timer.AnythingWaiting()) {
-        reply = (ExecutionState) (reply | kExecutionState_ClumpsWaitingOnTime);
+        state = (ExecutionState) (reply | kExecutionState_ClumpsWaitingOnTime);
+        reply = kExecSlices_ClumpsWaiting;
+        Int32 timeToWait = Int32(gPlatform.Timer.TickCountToMilliseconds(_timer.NextWakeUpTime() - currentTime));
+        // This is the time of earliest scheduled clump to wake up; we return this time to allow the caller to sleep.
+        // They are allowed to call us earlier, say, if they set an occurrence to give us something to do.
+        // If we're called with nothing to run, we'll do nothing and return the remaining waiting time.
+        if (timeToWait < 0)
+            timeToWait = 0;
+        else if (timeToWait > kMaxExecWakeUpTime)
+            timeToWait = kMaxExecWakeUpTime;
+        // Negative return value (kExecSlices_ClumpsInRunQueue) means we should be called again immediately/ASAP
+        // because there is stuff to run. Zero (kExecSlices_ClumpsFinished) means the VI is completely finished
+        // and nothing is waiting to be scheduled.
+        if (timeToWait > 0)
+            reply = timeToWait;
     }
 #ifdef VIREO_SINGLE_GLOBAL_CONTEXT
     // TODO(PaulAustin): check global memory manager for allocation errors
 #else
     if (THREAD_TADM()->_totalAllocationFailures > 0) {
-        reply = kExecutionState_None;
+        state = kExecutionState_None;
+        reply = kExecSlices_ClumpsFinished;
     }
 #endif
-    _state = reply;
+    _state = state;
     return reply;
 }
 //------------------------------------------------------------

--- a/source/core/Platform.cpp
+++ b/source/core/Platform.cpp
@@ -25,9 +25,11 @@
   #include <pthread.h>
   #include <time.h>
   #include <mach/mach_time.h>
+  #include <unistd.h>
 #elif (kVireoOS_linuxU)
   #include <pthread.h>
   #include <time.h>
+  #include <unistd.h>
 #elif kVireoOS_ZynqARM
   #include "xscutimer.h"
 #elif kVireoOS_emscripten
@@ -351,7 +353,6 @@ void PlatformIO::ReadStdin(StringRef buffer)
 
 #endif
 
-
 //============================================================
 PlatformTickType PlatformTimer::TickCount()
 {
@@ -545,4 +546,15 @@ Int64 PlatformTimer::TickCountToMicroseconds(PlatformTickType ticks)
 #endif
 }
 
+#if !kVireoOS_emscripten  // Cannot sleep in emscripten code, must sleep on JS side
+void PlatformTimer::SleepMilliseconds(Int64 milliseconds) {
+#if defined(_WIN32) || defined(_WIN64)
+    Sleep((DWORD)milliseconds);
+#elif kVireoOS_macosxU || kVireoOS_linuxU
+    usleep(UInt32(milliseconds * 1000));
+#else
+    #error "implement SleepMilliseconds"
+#endif
+}
+#endif  // !kVireoOS_emscripten
 }  // namespace Vireo

--- a/source/include/ExecutionContext.h
+++ b/source/include/ExecutionContext.h
@@ -63,8 +63,13 @@ enum ExecutionState
     kExecutionState_None = 0,
     kExecutionState_ClumpsInRunQueue = 0x01,
     kExecutionState_ClumpsWaitingOnTime = 0x02,
-    kExecutionState_ClumpsWaitingOnQueues = 0x04,
-    kExecutionState_ClumpsWaitingOnISRs = 0x08,
+};
+
+enum ExecSlicesResult {
+    kExecSlices_ClumpsWaiting = -2,
+    kExecSlices_ClumpsInRunQueue = -1,
+    kExecSlices_ClumpsFinished = 0,
+    // ... or positive value indicating clumps waiting for specific time (in ms)
 };
 
 // Each thread can have at most one ExecutionContext (ECs). ExecutionContexts can work
@@ -114,7 +119,7 @@ class ExecutionContext
     ECONTEXT    void            ExecuteFunction(FunctionClump* fclump);  // Run a simple function to completion.
 
     // Run the concurrent execution system for a short period of time
-    ECONTEXT    ExecutionState  ExecuteSlices(Int32 numSlices, PlatformTickType tickCount);
+    ECONTEXT    Int32 /*ExecSlicesResult*/ ExecuteSlices(Int32 numSlices, PlatformTickType tickCount);
     ECONTEXT    InstructionCore* SuspendRunningQueueElt(InstructionCore* whereToWakeUp);
     ECONTEXT    InstructionCore* Stop();
     ECONTEXT    void            ClearBreakout() { _breakoutCount = 0; }

--- a/source/include/Platform.h
+++ b/source/include/Platform.h
@@ -80,6 +80,9 @@ class PlatformTimer {
     Int64 TickCountToMicroseconds(PlatformTickType);
     PlatformTickType MillisecondsFromNowToTickCount(Int64 milliseconds);
     PlatformTickType MicrosecondsFromNowToTickCount(Int64 microseconds);
+#if !kVireoOS_emscripten
+    void SleepMilliseconds(Int64 milliseconds);  // Cannot sleep in emscripten code without using interpreter, must sleep in caller on JS side
+#endif
 };
 
 //------------------------------------------------------------

--- a/source/include/Synchronization.h
+++ b/source/include/Synchronization.h
@@ -69,12 +69,15 @@ class OccurrenceCore : public ObservableCore
 };
 typedef TypedObject<OccurrenceCore> OccurrenceObject, *OccurrenceRef;
 
+const Int32 kMaxExecWakeUpTime = 10000;  // (milliseconds).  10 seconds.
+
 //------------------------------------------------------------
 //! Timer object that clumps can wait on.
 class Timer : public ObservableCore
 {
  public:
     Boolean AnythingWaiting()                   { return _observerList != null; }
+    IntMax NextWakeUpTime()                     { return _observerList != null ? _observerList->_info : 0; }
     void QuickCheckTimers(PlatformTickType t)   { if (_observerList) { CheckTimers(t); } }
     void CheckTimers(PlatformTickType t);
     void InitObservableTimerState(Observer* pObserver, PlatformTickType tickCount);

--- a/test-it/esh.js
+++ b/test-it/esh.js
@@ -34,25 +34,25 @@
 
     var fs = require('fs');
     try {
-       var text = fs.readFileSync(arg).toString();
+        var text = fs.readFileSync(arg).toString();
+        vireo.loadVia(text);
     } catch (e) {
-       console.log("Usage: " + command + " [file.via]...");
-       if (arg.substring(0,1)!=="-")
-           console.log("Can't open " + arg);
-       process.exit(1);
-    }
-
-    vireo.loadVia(text);
-
-    var execVireo = function() {
-        var state;
-        while ((state = vireo.executeSlices(100000)) != 0) {
-           var timeDelay = state > 0 ? state : 0;
-           if (timeDelay > 0) {
-               setTimeout(execVireo, timeDelay);
-               break;
-           }
+        console.log('Usage: ' + command + ' [file.via]...');
+        if (arg.substring(0, 1) !== '-') {
+            console.log('Cannot open ' + arg);
         }
+        process.exit(1);
     }
-    execVireo()
+
+    var execVireo = function () {
+        var state;
+        while ((state = vireo.executeSlices(100000)) !== 0) {
+            var timeDelay = state > 0 ? state : 0;
+            if (timeDelay > 0) {
+                setTimeout(execVireo, timeDelay);
+                break;
+            }
+        }
+    };
+    execVireo();
 }());

--- a/test-it/esh.js
+++ b/test-it/esh.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Simple command line Vireo shell
+(function () {
+    'use strict';
+
+    var argv = process.argv.slice();
+    argv.shift();
+    var command = argv.shift();
+    var arg = argv[0];
+    var vireo = {};
+    var actualVireo;
+
+    var setupVJS = function () {
+        var Vireo;
+        try {
+            Vireo = require('../');
+
+            actualVireo = new Vireo();
+            vireo = actualVireo.eggShell;
+        } catch (err) {
+            if (err.code === 'MODULE_NOT_FOUND') {
+                console.log('Error: vireo.js not found (Maybe build it first?)');
+                process.exit(1);
+            } else {
+                throw err;
+            }
+        }
+        vireo.setPrintFunction(function (text) {
+            console.log(text);
+        });
+    };
+
+    setupVJS();
+
+    var fs = require('fs');
+    try {
+       var text = fs.readFileSync(arg).toString();
+    } catch (e) {
+       console.log("Usage: " + command + " [file.via]...");
+       if (arg.substring(0,1)!=="-")
+           console.log("Can't open " + arg);
+       process.exit(1);
+    }
+
+    vireo.loadVia(text);
+
+    var execVireo = function() {
+        var state;
+        while ((state = vireo.executeSlices(100000)) != 0) {
+           var timeDelay = state > 0 ? state : 0;
+           if (timeDelay > 0) {
+               setTimeout(execVireo, timeDelay);
+               break;
+           }
+        }
+    }
+    execVireo()
+}());

--- a/test-it/httptest1/hostwebworker.js
+++ b/test-it/httptest1/hostwebworker.js
@@ -12,8 +12,9 @@
         vireo.eggShell.setPrintFunction(console.log.bind(console));
         vireo.eggShell.loadVia(viaCode);
         (function runUntildone () {
-            if (vireo.eggShell.executeSlices(1000000)) {
-                setTimeout(runUntildone, 0);
+            var execResult = vireo.eggShell.executeSlices(1000000);
+            if (execResult != 0) {
+                setTimeout(runUntildone, execResult > 0 ? execResult : 0);
             }
         }());
     };

--- a/test-it/httptest1/hostwebworker.js
+++ b/test-it/httptest1/hostwebworker.js
@@ -13,7 +13,7 @@
         vireo.eggShell.loadVia(viaCode);
         (function runUntildone () {
             var execResult = vireo.eggShell.executeSlices(1000000);
-            if (execResult != 0) {
+            if (execResult !== 0) {
                 setTimeout(runUntildone, execResult > 0 ? execResult : 0);
             }
         }());

--- a/test-it/httptest1/loaderamd.js
+++ b/test-it/httptest1/loaderamd.js
@@ -25,7 +25,7 @@
         var continueUntilDone = function () {
             var execResult = eggShell.executeSlices(1000);
 
-            if (execResult != 0) {
+            if (execResult !== 0) {
                 setTimeout(continueUntilDone, execResult > 0 ? execResult : 0);
             } else {
                 console.log('finished :D');

--- a/test-it/httptest1/loaderamd.js
+++ b/test-it/httptest1/loaderamd.js
@@ -23,10 +23,10 @@
         };
 
         var continueUntilDone = function () {
-            var remainingSlices = eggShell.executeSlices(1000);
+            var execResult = eggShell.executeSlices(1000);
 
-            if (remainingSlices > 0) {
-                setTimeout(continueUntilDone, 0);
+            if (execResult != 0) {
+                setTimeout(continueUntilDone, execResult > 0 ? execResult : 0);
             } else {
                 console.log('finished :D');
             }

--- a/test-it/httptest1/loaderglobal.js
+++ b/test-it/httptest1/loaderglobal.js
@@ -13,10 +13,10 @@
     };
 
     var continueUntilDone = function () {
-        var remainingSlices = eggShell.executeSlices(1000);
+        var execResult = eggShell.executeSlices(1000);
 
-        if (remainingSlices > 0) {
-            setTimeout(continueUntilDone, 0);
+        if (execResult != 0) {
+            setTimeout(continueUntilDone, execResult > 0 ? execResult : 0);
         } else {
             console.log('finished :D');
         }

--- a/test-it/httptest1/loaderglobal.js
+++ b/test-it/httptest1/loaderglobal.js
@@ -15,7 +15,7 @@
     var continueUntilDone = function () {
         var execResult = eggShell.executeSlices(1000);
 
-        if (execResult != 0) {
+        if (execResult !== 0) {
             setTimeout(continueUntilDone, execResult > 0 ? execResult : 0);
         } else {
             console.log('finished :D');

--- a/test-it/httptest1/loaderglobalperf.js
+++ b/test-it/httptest1/loaderglobalperf.js
@@ -14,7 +14,7 @@
     var continueUntilDone = function () {
         var execResult = vireo.eggShell.executeSlices(1000);
 
-        if (execResult != 0) {
+        if (execResult !== 0) {
             setTimeout(continueUntilDone, execResult > 0 ? execResult : 0);
         } else {
             console.log('finished :D');

--- a/test-it/httptest1/loaderglobalperf.js
+++ b/test-it/httptest1/loaderglobalperf.js
@@ -12,10 +12,10 @@
     };
 
     var continueUntilDone = function () {
-        var remainingSlices = vireo.eggShell.executeSlices(1000);
+        var execResult = vireo.eggShell.executeSlices(1000);
 
-        if (remainingSlices > 0) {
-            setTimeout(continueUntilDone, 0);
+        if (execResult != 0) {
+            setTimeout(continueUntilDone, execResult > 0 ? execResult : 0);
         } else {
             console.log('finished :D');
         }

--- a/test-it/httptest1/loadernode.js
+++ b/test-it/httptest1/loadernode.js
@@ -8,7 +8,7 @@ var eggShell = new Vireo().eggShell;
 eggShell.loadVia(viaCode);
 
 var execResult = eggShell.executeSlices(1000);
-while (execResult != 0) {
+while (execResult !== 0) {
     execResult = eggShell.executeSlices(1000);
 }
 

--- a/test-it/httptest1/loadernode.js
+++ b/test-it/httptest1/loadernode.js
@@ -7,9 +7,9 @@ var eggShell = new Vireo().eggShell;
 
 eggShell.loadVia(viaCode);
 
-var remainingSlices = eggShell.executeSlices(1000);
-while (remainingSlices > 0) {
-    remainingSlices = eggShell.executeSlices(1000);
+var execResult = eggShell.executeSlices(1000);
+while (execResult != 0) {
+    execResult = eggShell.executeSlices(1000);
 }
 
 console.log('done :D');

--- a/test-it/httptest1/testhttp.js
+++ b/test-it/httptest1/testhttp.js
@@ -12,10 +12,10 @@
     };
 
     var continueUntilDone = function () {
-        var remainingSlices = eggShell.executeSlices(1000);
+        var execResult = eggShell.executeSlices(1000);
 
-        if (remainingSlices > 0) {
-            setTimeout(continueUntilDone, 0);
+        if (execResult != 0) {
+            setTimeout(continueUntilDone, execResult > 0 ? execResult : 0);
         } else {
             console.log(JSON.parse(eggShell.readJSON('%3AWeb%20Server%3AInteractive%3AApplication%3AMain%2Egviweb', 'dataItem_Body')));
             console.log('finished :D');

--- a/test-it/httptest1/testhttp.js
+++ b/test-it/httptest1/testhttp.js
@@ -14,7 +14,7 @@
     var continueUntilDone = function () {
         var execResult = eggShell.executeSlices(1000);
 
-        if (execResult != 0) {
+        if (execResult !== 0) {
             setTimeout(continueUntilDone, execResult > 0 ? execResult : 0);
         } else {
             console.log(JSON.parse(eggShell.readJSON('%3AWeb%20Server%3AInteractive%3AApplication%3AMain%2Egviweb', 'dataItem_Body')));

--- a/test-it/karma/utilities/TestHelpers.VireoRunner.js
+++ b/test-it/karma/utilities/TestHelpers.VireoRunner.js
@@ -39,14 +39,17 @@
 
             (function runExecuteSlicesAsync () {
                 // TODO mraj Executing 1000 slices at a time ran much slower, need better tuning of this value
-                var remainingSlices = vireo.eggShell.executeSlices(1000000);
+                var execState = vireo.eggShell.executeSlices(1000000);
                 executeSlicesInvocationCount += 1;
 
-                if (remainingSlices > 0) {
+                if (execState != 0) {
+                    var timeUntilNextClump = execState > 0 ? execState : 0;
                     // The setImmediate polyfill in PhantomJS does not work when combined with xhr requests.
                     // I think the polyfill blocks servicing network ops...
                     // so periodically use setTimeout to let PhantomJS service the network stack
-                    if (executeSlicesInvocationCount % 1000 === 0) {
+                    if (timeUntilNextClump > 0)
+                        setTimeout(runExecuteSlicesAsync, timeUntilNextClump);
+                    else if (executeSlicesInvocationCount % 1000 === 0) {
                         setTimeout(runExecuteSlicesAsync, 0);
                     } else {
                         setImmediate(runExecuteSlicesAsync);

--- a/test-it/karma/utilities/TestHelpers.VireoRunner.js
+++ b/test-it/karma/utilities/TestHelpers.VireoRunner.js
@@ -42,14 +42,14 @@
                 var execState = vireo.eggShell.executeSlices(1000000);
                 executeSlicesInvocationCount += 1;
 
-                if (execState != 0) {
+                if (execState !== 0) {
                     var timeUntilNextClump = execState > 0 ? execState : 0;
                     // The setImmediate polyfill in PhantomJS does not work when combined with xhr requests.
                     // I think the polyfill blocks servicing network ops...
                     // so periodically use setTimeout to let PhantomJS service the network stack
-                    if (timeUntilNextClump > 0)
+                    if (timeUntilNextClump > 0) {
                         setTimeout(runExecuteSlicesAsync, timeUntilNextClump);
-                    else if (executeSlicesInvocationCount % 1000 === 0) {
+                    } else if (executeSlicesInvocationCount % 1000 === 0) {
                         setTimeout(runExecuteSlicesAsync, 0);
                     } else {
                         setImmediate(runExecuteSlicesAsync);

--- a/test-it/test.js
+++ b/test-it/test.js
@@ -197,7 +197,7 @@
             }
         }
         var hrstart = process.hrtime();
-        tester(testName, function(newResults) {
+        tester(testName, function (newResults) {
             var hrend = process.hrtime(hrstart);
             var msec = hrend[1] / 1000000;
 
@@ -225,35 +225,35 @@
                 viaPath = testName;
                 try {
                     viaCode = fs.readFileSync(viaPath).toString();
-		} catch (e) {
+                } catch (e) {
                     if (e.code === 'ENOENT') {
                         viaCode = '';
                         throw new Error('No such test ' + testName);
-	            }
-		}
+                    }
+                }
             }
         }
         var testOutput = '';
         vireo.setPrintFunction(function (text) {
-                        testOutput = testOutput + text + '\n';
-                        });
+            testOutput = testOutput + text + '\n';
+        });
 
         if (viaCode !== '' && vireo.loadVia(viaCode) === 0) {
             // TODO mraj because this is running synchronously we cannot do tests that rely on asynchronous results like http
             // TODO spathiwa I think we can now...
-            var execVireo = function(done) {
+            var execVireo = function () {
                 var state;
-                while ((state = vireo.executeSlices(1000000)) != 0) {
-                   var timeDelay = state > 0 ? state : 0;
-                   if (timeDelay > 0) {
-                       setTimeout(execVireo, timeDelay);
-                       break;
-                   }
+                while ((state = vireo.executeSlices(1000000)) !== 0) {
+                    var timeDelay = state > 0 ? state : 0;
+                    if (timeDelay > 0) {
+                        setTimeout(execVireo, timeDelay);
+                        break;
+                    }
                 }
-                if (state == 0) {
+                if (state === 0) {
                     testFinishedCB(testOutput);
                 }
-            }
+            };
             execVireo(testFinishedCB);
         } else {
             testFinishedCB(testOutput);
@@ -307,7 +307,7 @@
     };
     var errorCode = 0;
 
-    var Report = function() {
+    var report = function () {
         // ----------------------------------------------------------------------
         // Run twice to look for global state issues.
         // Some tests are failing on a second iteration during the test execution.
@@ -501,25 +501,25 @@
         }
 
         if (testFiles.length > 0) {
-            var runNextTest = function(testFiles, chain) {
+            var runNextTest = function (testFiles, chain) {
                 if (testFiles.length > 0) {
                     var testName = testFiles.shift();
-                    tester(testName, function() {
-                           runNextTest(testFiles, chain);
-                           }, execOnly);
+                    tester(testName, function () {
+                        runNextTest(testFiles, chain);
+                    }, execOnly);
                 } else if (!execOnly) {
                     chain();
                 }
             };
             var saveTestFiles = testFiles.slice();
 
-            runNextTest(testFiles, function() {
+            runNextTest(testFiles, function () {
                 if (once) {
-                    Report();
+                    report();
                     process.exit(errorCode);
                 } else {
-                    runNextTest(saveTestFiles, function() {
-                        Report();
+                    runNextTest(saveTestFiles, function () {
+                        report();
                         process.exit(errorCode);
                     });
                 }
@@ -528,6 +528,5 @@
             console.log('Nothing to test.  Use test.js -h for help');
             process.exit(1);
         }
-
     }());
 }());


### PR DESCRIPTION
A negative return value means there is still work to schedule, caller can recall executeSlices
immediately.
A zero return value means all clumps are finished with nothing waiting
on timers; VI is done, don't call again unless you load a new via file.
A positive return value is a time delay in milliseconds before the next
clump needs to be waken up; the caller can use an OS-specific sleep call
or schedule itself asynchronously after a delay before calling
executeSlices again.

Change native caller (esh) main to handle the new result and sleep when
appropriate, using a new Platform.Timer API.

Change VJS callers to handle new result:
  Karma TestHelpers.VireoRunner was already scheduling executeSlices
asynchronously, it just needed to be modifed to use the given timeout
instead of 0.
  test.js has been refactored so the test driver is asynchronous and
can sleep when executeSlices tells it to.
  The manual http tests have been modified to check that the executeSlices
return value is != 0, rather than > 0, and to use the returned delay
in their setTimeout call iff they were already asynchronous.

There are no new tests added here rather than the 'meta'-test that all
the test runners continue to run their tests correctly.
This is a pure refactor such that no via code changes functionality,
it just uses CPU more efficiently.  To test manually, run tests
which have Waits or blocking calls, and monitor CPU during the run
to verify CPU does not go to 100%/#processors.