### PR TITLE
Vireo early wake-up and API refactors

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,6 +36,7 @@ after_build:
 test_script:
   - make testjs
   - make testnative
+  - make testhttpbin
   - npm run karma -- --browsers PhantomJS --skip-tags FailsPhantomJS
   - npm run karma -- --browsers IE --skip-tags FailsIE
   - npm run karma -- --browsers Chrome,Firefox

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_script:
 script:
 - make testjs
 - make testnative
+- make testhttpbin
 - npm run karma -- --browsers PhantomJS --skip-tags FailsPhantomJS
 - npm run karma -- --browsers Firefox
 before_deploy:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ unittest:
 
 test: testnative testjs
 
+testhttpbin:
+	cd test-it && node test.js -j -t httpbin --dots
+
 testjs:
 	cd test-it && node test.js -j --dots
 

--- a/karma.shared.js
+++ b/karma.shared.js
@@ -19,7 +19,6 @@
             'node_modules/core-js/client/core.js',
             'node_modules/whatwg-fetch/fetch.js',
             'node_modules/jasmine-expect/dist/jasmine-matchers.js',
-            'node_modules/setimmediate/setImmediate.js',
             'dist/asmjs-unknown-emscripten/release/vireo.js',
             'source/core/module_*.js',
             'source/io/module_*.js',

--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -98,6 +98,7 @@ EM_WRAP = --pre-js $(PREJS) --post-js $(POSTJS)
 
 EM_EXPORTS = -s EXPORTED_FUNCTIONS="[\
     '_Vireo_Version', \
+	'_Vireo_MaxExecWakeUpTime', \
     '_EggShell_Create', \
     '_EggShell_REPL',\
     '_EggShell_ExecuteSlices',\

--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -98,7 +98,7 @@ EM_WRAP = --pre-js $(PREJS) --post-js $(POSTJS)
 
 EM_EXPORTS = -s EXPORTED_FUNCTIONS="[\
     '_Vireo_Version', \
-	'_Vireo_MaxExecWakeUpTime', \
+    '_Vireo_MaxExecWakeUpTime', \
     '_EggShell_Create', \
     '_EggShell_REPL',\
     '_EggShell_ExecuteSlices',\

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "vireo",
   "version": "7.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
@@ -13,7 +14,11 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.15",
+        "negotiator": "0.6.1"
+      }
     },
     "acorn": {
       "version": "5.0.3",
@@ -26,6 +31,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -51,7 +59,11 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -63,7 +75,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -93,19 +110,29 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11"
+      }
     },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.0.3"
+      }
     },
     "arr-flatten": {
       "version": "1.0.3",
@@ -129,7 +156,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -201,7 +231,12 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.1"
+      }
     },
     "backo2": {
       "version": "1.0.2",
@@ -232,13 +267,19 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsite": "1.0.0"
+      }
     },
     "binary-extensions": {
       "version": "1.8.0",
@@ -263,12 +304,27 @@
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
       "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
       "dev": true,
+      "requires": {
+        "bytes": "2.4.0",
+        "content-type": "1.0.2",
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "http-errors": "1.6.1",
+        "iconv-lite": "0.4.15",
+        "on-finished": "2.3.0",
+        "qs": "6.4.0",
+        "raw-body": "2.2.0",
+        "type-is": "1.6.15"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "iconv-lite": {
           "version": "0.4.15",
@@ -282,19 +338,31 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -312,7 +380,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsite": {
       "version": "1.0.0",
@@ -336,7 +407,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      }
     },
     "caseless": {
       "version": "0.11.0",
@@ -349,19 +424,41 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.0",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.2",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
     },
     "circular-json": {
       "version": "0.3.1",
@@ -373,7 +470,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
     },
     "cli-width": {
       "version": "2.1.0",
@@ -387,6 +487,11 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -413,19 +518,28 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
       "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "component-bind": {
       "version": "1.0.0",
@@ -455,19 +569,33 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.2",
+        "typedarray": "0.0.6"
+      }
     },
     "connect": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.2.tgz",
       "integrity": "sha1-aU6NIGgb/kkCgsiriGvpjwn0L+c=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.7",
+        "finalhandler": "1.0.3",
+        "parseurl": "1.3.1",
+        "utils-merge": "1.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -499,13 +627,19 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
     },
     "custom-event": {
       "version": "1.0.1",
@@ -518,6 +652,9 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -531,13 +668,20 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1",
+        "meow": "3.7.0"
+      }
     },
     "debug": {
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -555,7 +699,16 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -585,20 +738,33 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "dom-serialize": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
       "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "custom-event": "1.0.1",
+        "ent": "2.2.0",
+        "extend": "3.0.1",
+        "void-elements": "2.0.1"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "edge-launcher": {
       "version": "1.2.2",
@@ -623,12 +789,23 @@
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.3.tgz",
       "integrity": "sha1-jef5eJXSDTm4X4ju7nd7K9QrE9Q=",
       "dev": true,
+      "requires": {
+        "accepts": "1.3.3",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "ws": "1.1.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -643,6 +820,20 @@
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.3.tgz",
       "integrity": "sha1-F5jtk0USRkU9TG9jXXogH+lA1as=",
       "dev": true,
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parsejson": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "1.1.2",
+        "xmlhttprequest-ssl": "1.5.3",
+        "yeast": "0.1.2"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
@@ -654,7 +845,10 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -668,7 +862,15 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
       "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "0.0.6",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.4",
+        "has-binary": "0.1.7",
+        "wtf-8": "1.0.0"
+      }
     },
     "ent": {
       "version": "2.2.0",
@@ -680,7 +882,10 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
     },
     "es6-object-assign": {
       "version": "1.1.0",
@@ -711,6 +916,13 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -729,7 +941,10 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -737,19 +952,61 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.0.0.tgz",
       "integrity": "sha1-cnfAFDf99B3M0WjVqg5Jt1yh8mA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.8",
+        "doctrine": "2.0.0",
+        "eslint-scope": "3.7.1",
+        "espree": "3.4.3",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.1.1",
+        "is-my-json-valid": "2.16.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.8.4",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "4.0.0",
+        "progress": "2.0.0",
+        "require-uncached": "1.0.3",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.1",
+        "text-table": "0.2.0"
+      }
     },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
     },
     "espree": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn": "5.0.3",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
       "version": "3.1.3",
@@ -761,13 +1018,20 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
     },
     "estraverse": {
       "version": "4.2.0",
@@ -792,18 +1056,30 @@
       "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
       "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
       "dev": true,
+      "requires": {
+        "array-slice": "0.2.3",
+        "array-unique": "0.2.1",
+        "braces": "0.1.5"
+      },
       "dependencies": {
         "braces": {
           "version": "0.1.5",
           "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
           "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "expand-range": "0.1.1"
+          }
         },
         "expand-range": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-number": "0.1.1",
+            "repeat-string": "0.2.2"
+          }
         },
         "is-number": {
           "version": "0.1.1",
@@ -823,13 +1099,19 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
     },
     "extend": {
       "version": "3.0.1",
@@ -841,25 +1123,44 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
       "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.18",
+        "jschardet": "1.4.2",
+        "tmp": "0.0.31"
+      }
     },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "extract-zip": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.5.0.tgz",
       "integrity": "sha1-ksz22B73Cp+kwXRxFMzvbYaIpsQ=",
       "dev": true,
+      "requires": {
+        "concat-stream": "1.5.0",
+        "debug": "0.7.4",
+        "mkdirp": "0.5.0",
+        "yauzl": "2.4.1"
+      },
       "dependencies": {
         "concat-stream": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
           "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.0.6",
+            "typedarray": "0.0.6"
+          }
         },
         "debug": {
           "version": "0.7.4",
@@ -871,13 +1172,24 @@
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
           "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "readable-stream": {
           "version": "2.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -903,19 +1215,29 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pend": "1.2.0"
+      }
     },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -927,19 +1249,38 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
     },
     "finalhandler": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
       "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.7",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
@@ -947,13 +1288,23 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.1",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -965,7 +1316,10 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -977,19 +1331,32 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
       "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
     },
     "fs-access": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "null-check": "1.0.0"
+      }
     },
     "fs-extra": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
       "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1003,6 +1370,10 @@
       "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "dev": true,
       "optional": true,
+      "requires": {
+        "nan": "2.6.2",
+        "node-pre-gyp": "0.6.36"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -1014,7 +1385,11 @@
           "version": "4.11.8",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -1031,7 +1406,11 @@
           "version": "1.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
         },
         "asn1": {
           "version": "0.2.3",
@@ -1072,22 +1451,35 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
         },
         "boom": {
           "version": "2.10.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -1114,7 +1506,10 @@
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -1135,13 +1530,19 @@
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
         },
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1155,7 +1556,10 @@
           "version": "2.6.8",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "deep-extend": {
           "version": "0.4.2",
@@ -1178,7 +1582,10 @@
           "version": "0.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "extend": {
           "version": "3.0.1",
@@ -1201,7 +1608,12 @@
           "version": "2.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -1211,25 +1623,49 @@
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
         },
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1242,7 +1678,15 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -1259,7 +1703,11 @@
           "version": "4.2.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -1271,7 +1719,13 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
         },
         "hoek": {
           "version": "2.16.3",
@@ -1282,12 +1736,21 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -1303,7 +1766,10 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -1326,7 +1792,10 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "jsbn": {
           "version": "0.1.1",
@@ -1344,7 +1813,10 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
@@ -1363,6 +1835,12 @@
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1380,12 +1858,18 @@
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
         },
         "minimist": {
           "version": "0.0.8",
@@ -1395,7 +1879,10 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -1407,19 +1894,40 @@
           "version": "0.6.36",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
         },
         "npmlog": {
           "version": "4.1.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -1441,7 +1949,10 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -1459,7 +1970,11 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -1494,6 +2009,12 @@
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -1506,18 +2027,54 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
         },
         "request": {
           "version": "2.81.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
         },
         "safe-buffer": {
           "version": "5.0.1",
@@ -1546,13 +2103,27 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "sshpk": {
           "version": "1.13.0",
           "bundled": true,
           "dev": true,
           "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -1562,15 +2133,23 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "stringstream": {
           "version": "0.0.5",
@@ -1581,7 +2160,10 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -1592,25 +2174,46 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
         },
         "tar-pack": {
           "version": "3.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
         },
         "tough-cookie": {
           "version": "2.3.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -1639,13 +2242,19 @@
           "version": "1.3.6",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
         },
         "wrappy": {
           "version": "1.0.2",
@@ -1664,7 +2273,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -1677,6 +2289,9 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1690,19 +2305,34 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -1714,7 +2344,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -1733,12 +2371,21 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -1746,19 +2393,31 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.9.0",
+        "is-my-json-valid": "2.16.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-binary": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
       "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
       "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -1784,13 +2443,23 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-stream": "1.1.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "hoek": {
       "version": "2.16.3",
@@ -1808,19 +2477,34 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
       "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "depd": "1.1.0",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      }
     },
     "http-proxy": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
+      }
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.0",
+        "sshpk": "1.13.1"
+      }
     },
     "iconv-lite": {
       "version": "0.4.18",
@@ -1844,7 +2528,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "indexof": {
       "version": "0.0.1",
@@ -1856,7 +2543,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -1868,7 +2559,23 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.1.1.tgz",
       "integrity": "sha512-H50sHQwgvvaTBd3HpKMVtL/u6LoHDvYym51gd7bGQe/+9HkCE+J0/3N5FJLfd6O6oz44hHewC2Pc2LodzWVafQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "2.0.0",
+        "chalk": "1.1.3",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.1.0",
+        "external-editor": "2.0.4",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
     },
     "interpret": {
       "version": "1.0.3",
@@ -1886,7 +2593,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "binary-extensions": "1.8.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -1898,7 +2608,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -1910,7 +2623,10 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -1928,7 +2644,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -1940,19 +2659,31 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -1964,13 +2695,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
@@ -2000,7 +2737,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -2042,7 +2782,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -2055,6 +2798,22 @@
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.5.2",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.10",
+        "js-yaml": "3.8.4",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.2.14",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -2066,13 +2825,23 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -2086,7 +2855,10 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/jasmine-expect/-/jasmine-expect-3.7.0.tgz",
       "integrity": "sha1-hB4TgvS/8CWMjcluyifE+8auSIc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "add-matchers": "0.5.0"
+      }
     },
     "js-tokens": {
       "version": "3.0.1",
@@ -2098,7 +2870,11 @@
       "version": "3.8.4",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
       "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "3.1.3"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -2123,7 +2899,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -2141,7 +2920,10 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -2160,6 +2942,12 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2174,6 +2962,35 @@
       "resolved": "https://registry.npmjs.org/karma/-/karma-1.7.0.tgz",
       "integrity": "sha1-b3oaQGRG+i4YfslTmGmPTO5HYmk=",
       "dev": true,
+      "requires": {
+        "bluebird": "3.5.0",
+        "body-parser": "1.17.2",
+        "chokidar": "1.7.0",
+        "colors": "1.1.2",
+        "combine-lists": "1.0.1",
+        "connect": "3.6.2",
+        "core-js": "2.4.1",
+        "di": "0.0.1",
+        "dom-serialize": "2.2.1",
+        "expand-braces": "0.1.2",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "http-proxy": "1.16.2",
+        "isbinaryfile": "3.0.2",
+        "lodash": "3.10.1",
+        "log4js": "0.6.38",
+        "mime": "1.3.6",
+        "minimatch": "3.0.4",
+        "optimist": "0.6.1",
+        "qjobs": "1.1.5",
+        "range-parser": "1.2.0",
+        "rimraf": "2.6.1",
+        "safe-buffer": "5.1.1",
+        "socket.io": "1.7.3",
+        "source-map": "0.5.6",
+        "tmp": "0.0.31",
+        "useragent": "2.1.13"
+      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -2187,13 +3004,24 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.1.1.tgz",
       "integrity": "sha1-IWh5xorATY1RQOmWGboEtZr9Rs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs-access": "1.0.1",
+        "which": "1.2.14"
+      }
     },
     "karma-coverage": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/karma-coverage/-/karma-coverage-1.1.1.tgz",
       "integrity": "sha1-Wv+LOc9plNwi3kyENix2ABtjfPY=",
       "dev": true,
+      "requires": {
+        "dateformat": "1.0.12",
+        "istanbul": "0.4.5",
+        "lodash": "3.10.1",
+        "minimatch": "3.0.4",
+        "source-map": "0.5.6"
+      },
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
@@ -2207,7 +3035,10 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/karma-edge-launcher/-/karma-edge-launcher-0.4.1.tgz",
       "integrity": "sha1-sE65a4z2AE66Cw/tKUtR2pNg4kQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "edge-launcher": "1.2.2"
+      }
     },
     "karma-firefox-launcher": {
       "version": "1.0.1",
@@ -2219,7 +3050,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/karma-ie-launcher/-/karma-ie-launcher-1.0.0.tgz",
       "integrity": "sha1-SXmGhCxJAZA0bNifVJTKmDDG1Zw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "karma-jasmine": {
       "version": "1.1.0",
@@ -2231,7 +3065,10 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-0.2.2.tgz",
       "integrity": "sha1-SKjl7xiAdhfuK14zwRlMNbQ5Ukw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "karma-jasmine": "1.1.0"
+      }
     },
     "karma-jasmine-spec-tags": {
       "version": "1.0.1",
@@ -2243,13 +3080,20 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-1.0.4.tgz",
       "integrity": "sha1-0jyjSAG9qYY60xjju0vUBisTrNI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4",
+        "phantomjs-prebuilt": "2.1.14"
+      }
     },
     "karma-verbose-reporter": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/karma-verbose-reporter/-/karma-verbose-reporter-0.0.6.tgz",
       "integrity": "sha1-WQkFJFHGB/Aqx3x2N5Gi/hJRJgw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "colors": "1.1.2"
+      }
     },
     "kew": {
       "version": "0.7.0",
@@ -2261,13 +3105,19 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -2280,13 +3130,24 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -2299,6 +3160,10 @@
       "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
       "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
       "dev": true,
+      "requires": {
+        "readable-stream": "1.0.34",
+        "semver": "4.3.6"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -2310,7 +3175,13 @@
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
@@ -2330,7 +3201,11 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "lru-cache": {
       "version": "2.2.4",
@@ -2355,6 +3230,18 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.3.8",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -2368,7 +3255,22 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.3"
+      }
     },
     "mime": {
       "version": "1.3.6",
@@ -2386,7 +3288,10 @@
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "mimic-fn": {
       "version": "1.1.0",
@@ -2398,7 +3303,10 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -2410,7 +3318,10 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -2447,19 +3358,31 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
+      }
     },
     "normalize-package-data": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
       "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.4.2",
+        "is-builtin-module": "1.0.0",
+        "semver": "4.3.6",
+        "validate-npm-package-license": "3.0.1"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.0.2"
+      }
     },
     "null-check": {
       "version": "1.0.0",
@@ -2495,31 +3418,48 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
     },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
@@ -2533,7 +3473,15 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "options": {
       "version": "0.0.6",
@@ -2551,31 +3499,49 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
     },
     "parsejson": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
       "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseqs": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseuri": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseurl": {
       "version": "1.3.1",
@@ -2587,7 +3553,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -2605,7 +3574,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "pend": {
       "version": "1.2.0",
@@ -2618,6 +3592,17 @@
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.14.tgz",
       "integrity": "sha1-1T0xH8+30dCN2yQBRVjxGIxRbaA=",
       "dev": true,
+      "requires": {
+        "es6-promise": "4.0.5",
+        "extract-zip": "1.5.0",
+        "fs-extra": "1.0.0",
+        "hasha": "2.2.0",
+        "kew": "0.7.0",
+        "progress": "1.1.8",
+        "request": "2.79.0",
+        "request-progress": "2.0.1",
+        "which": "1.2.14"
+      },
       "dependencies": {
         "progress": {
           "version": "1.1.8",
@@ -2643,7 +3628,10 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pluralize": {
       "version": "4.0.0",
@@ -2698,18 +3686,28 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
             }
           }
         },
@@ -2717,7 +3715,10 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
         }
       }
     },
@@ -2732,6 +3733,11 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
       "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
       "dev": true,
+      "requires": {
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.15",
+        "unpipe": "1.0.0"
+      },
       "dependencies": {
         "iconv-lite": {
           "version": "0.4.15",
@@ -2745,43 +3751,78 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.3.8",
+        "path-type": "1.1.0"
+      }
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
     },
     "readable-stream": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
       "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.2",
+        "set-immediate-shim": "1.0.1"
+      }
     },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "1.1.7"
+      }
     },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
     },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3",
+        "is-primitive": "2.0.0"
+      }
     },
     "remove-trailing-separator": {
       "version": "1.0.2",
@@ -2805,13 +3846,38 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "request": {
       "version": "2.79.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
       "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
       "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.15",
+        "oauth-sign": "0.8.2",
+        "qs": "6.3.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.4.3",
+        "uuid": "3.1.0"
+      },
       "dependencies": {
         "qs": {
           "version": "6.3.2",
@@ -2825,13 +3891,20 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "throttleit": "1.0.0"
+      }
     },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "requirejs": {
       "version": "2.3.3",
@@ -2861,26 +3934,39 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-promise": "2.1.0"
+      }
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -2892,7 +3978,10 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -2912,12 +4001,6 @@
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
-    },
     "setprototypeof": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
@@ -2928,13 +4011,23 @@
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.3",
+        "rechoir": "0.6.2"
+      }
     },
     "shx": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/shx/-/shx-0.2.2.tgz",
       "integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
       "dev": true,
+      "requires": {
+        "es6-object-assign": "1.1.0",
+        "minimist": "1.2.0",
+        "shelljs": "0.7.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -2960,19 +4053,34 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "socket.io": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.3.tgz",
       "integrity": "sha1-uK+cq6AJSeVo42nxMn6pvp6iRhs=",
       "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "engine.io": "1.8.3",
+        "has-binary": "0.1.7",
+        "object-assign": "4.1.0",
+        "socket.io-adapter": "0.5.0",
+        "socket.io-client": "1.7.3",
+        "socket.io-parser": "2.3.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -2993,12 +4101,19 @@
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
       "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
       "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "socket.io-parser": "2.3.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -3013,6 +4128,19 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.3.tgz",
       "integrity": "sha1-sw6GqhDV7zVGYBwJzeR2Xjgdo3c=",
       "dev": true,
+      "requires": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "2.3.3",
+        "engine.io-client": "1.8.3",
+        "has-binary": "0.1.7",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "2.3.1",
+        "to-array": "0.1.4"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
@@ -3024,7 +4152,10 @@
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
           "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -3039,12 +4170,21 @@
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "dev": true,
+      "requires": {
+        "component-emitter": "1.1.2",
+        "debug": "2.2.0",
+        "isarray": "0.0.1",
+        "json3": "3.3.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "isarray": {
           "version": "0.0.1",
@@ -3070,7 +4210,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -3095,6 +4238,16 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3110,17 +4263,24 @@
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true
-    },
     "string-width": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
       "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -3132,19 +4292,28 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
     },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -3162,7 +4331,15 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
       "integrity": "sha1-qBFsEz+sLGH0pCCrbN9cTWHw5DU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.0.0"
+      }
     },
     "text-table": {
       "version": "0.2.0",
@@ -3186,7 +4363,10 @@
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
     },
     "to-array": {
       "version": "0.1.4",
@@ -3198,7 +4378,10 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -3229,13 +4412,20 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.15"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -3248,7 +4438,12 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "source-map": "0.5.6",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -3273,7 +4468,11 @@
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.1.13.tgz",
       "integrity": "sha1-u6Q+iqJNXOuDwpN0c+EC4h33TBA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "2.2.4",
+        "tmp": "0.0.31"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -3297,13 +4496,20 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "verror": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extsprintf": "1.0.2"
+      }
     },
     "void-elements": {
       "version": "2.0.1",
@@ -3321,7 +4527,10 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "window-size": {
       "version": "0.1.0",
@@ -3346,18 +4555,31 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "ws": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
       "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "options": "0.0.6",
+        "ultron": "1.0.2"
+      }
     },
     "wtf-8": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
       "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
+      "dev": true
+    },
+    "xhr2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
+      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
       "dev": true
     },
     "xmlhttprequest-ssl": {
@@ -3378,6 +4600,12 @@
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "1.2.1",
@@ -3392,7 +4620,10 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fd-slicer": "1.0.1"
+      }
     },
     "yeast": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-verbose-reporter": "^0.0.6",
     "requirejs": "^2.3.2",
-    "setimmediate": "^1.0.5",
     "shx": "^0.2.2",
-    "whatwg-fetch": "^2.0.3"
+    "whatwg-fetch": "^2.0.3",
+    "xhr2": "^0.1.4"
   },
   "scripts": {
     "test": "npm run lint && npm run karma -- --browsers Chrome",

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -51,10 +51,10 @@ VIREO_EXPORT NIError EggShell_REPL(TypeManagerRef tm, const Utf8Char* commands, 
 }
 //------------------------------------------------------------
 //! Run the vireo execution system for a few slices.
-VIREO_EXPORT Int32 EggShell_ExecuteSlices(TypeManagerRef tm, Int32 numSlices)
+VIREO_EXPORT Int32 EggShell_ExecuteSlices(TypeManagerRef tm, Int32 numSlices, Int32 millisecondsToRun)
 {
     TypeManagerScope scope(tm);
-    return tm->TheExecutionContext()->ExecuteSlices(numSlices, 20);
+    return tm->TheExecutionContext()->ExecuteSlices(numSlices, millisecondsToRun);
 }
 //------------------------------------------------------------
 VIREO_EXPORT TypeRef EggShell_GetTypeList(TypeManagerRef tm)

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -27,6 +27,12 @@ VIREO_EXPORT Int32 Vireo_Version()
     // TODO(paul) need to tie into semantic version numbers
     return 0x00020003;
 }
+
+VIREO_EXPORT Int32 Vireo_MaxExecWakeUpTime()
+{
+    return kMaxExecWakeUpTime;
+}
+
 //------------------------------------------------------------
 //! Create a new shell with a designated parent, or null for a new root.
 VIREO_EXPORT void* EggShell_Create(TypeManagerRef parent)

--- a/source/core/ExecutionContext.cpp
+++ b/source/core/ExecutionContext.cpp
@@ -312,12 +312,11 @@ InstructionCore* ExecutionContext::SuspendRunningQueueElt(InstructionCore* nextI
 // ExecuteSlices - execute instructions in run queue repeatedly (numSlices at a time before breaking out and checking
 // timers), until all clumps are finished or tickCount time is reached.
 // See enum ExecSlicesResult for explanation of return values, or comments below where result is set.
-Int32 /*ExecSlicesResult*/ ExecutionContext::ExecuteSlices(Int32 numSlices, PlatformTickType tickCount)
+Int32 /*ExecSlicesResult*/ ExecutionContext::ExecuteSlices(Int32 numSlices, Int32 millisecondsToRun)
 {
     VIREO_ASSERT((_runningQueueElt == null))
-
     PlatformTickType currentTime  = gPlatform.Timer.TickCount();
-    PlatformTickType breakOutTime = currentTime + tickCount;
+    PlatformTickType breakOutTime = currentTime + gPlatform.Timer.MicrosecondsToTickCount(millisecondsToRun * 1000);
 
     _timer.QuickCheckTimers(currentTime);
 

--- a/source/core/vireo.loader.js
+++ b/source/core/vireo.loader.js
@@ -1,6 +1,8 @@
 // Using a modified UMD module format. Specifically a modified returnExports (with dependencies) version
 (function (root, globalName, factory) {
     'use strict';
+    var vireoCore;
+
     var buildGlobalNamespace = function () {
         var buildArgs = Array.prototype.slice.call(arguments);
         return globalName.split('.').reduce(function (currObj, subNamespace, currentIndex, globalNameParts) {
@@ -19,8 +21,14 @@
         ], factory);
     } else if (typeof module === 'object' && module.exports) {
         // Node. "CommonJS-like" for environments like Node but not strict CommonJS
+        try {
+            vireoCore = require('../../dist/asmjs-unknown-emscripten/release/vireo.js');
+        } catch (ex) {
+            console.error('\n\nFailed to load Vireo core, make sure that vireo.js is built first\n\n');
+            throw ex;
+        }
         module.exports = factory(
-            require('../../dist/asmjs-unknown-emscripten/release/vireo.js'),
+            vireoCore,
             require('../../source/core/module_coreHelpers.js'),
             require('../../source/io/module_eggShell.js'),
             require('../../source/io/module_httpClient.js')

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -14,7 +14,7 @@ SDG
 namespace Vireo {
 
 //------------------------------------------------------------
-// Keep in sync with module_eggShell.js
+// Keep in sync with eggShellResultEnum in module_eggShell.js
 typedef enum {
     kEggShellResult_Success = 0,
     kEggShellResult_ObjectNotFoundAtPath = 1,

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -28,7 +28,7 @@ VIREO_EXPORT Int32 Vireo_Version();
 VIREO_EXPORT Int32 Vireo_MaxExecWakeUpTime();
 VIREO_EXPORT void* EggShell_Create(TypeManagerRef tm);
 VIREO_EXPORT NIError EggShell_REPL(TypeManagerRef tm, const Utf8Char* commands, Int32 length);
-VIREO_EXPORT Int32 EggShell_ExecuteSlices(TypeManagerRef tm, Int32 numSlices);
+VIREO_EXPORT Int32 EggShell_ExecuteSlices(TypeManagerRef tm, Int32 numSlices, Int32 millisecondsToRun);
 VIREO_EXPORT TypeRef EggShell_GetTypeList(TypeManagerRef tm);
 VIREO_EXPORT void EggShell_Delete(TypeManagerRef tm);
 VIREO_EXPORT Int32 EggShell_PeekMemory(TypeManagerRef tm, const char* viName, const char* eltName,

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -25,6 +25,7 @@ typedef enum {
 //------------------------------------------------------------
 //! TypeManager functions
 VIREO_EXPORT Int32 Vireo_Version();
+VIREO_EXPORT Int32 Vireo_MaxExecWakeUpTime();
 VIREO_EXPORT void* EggShell_Create(TypeManagerRef tm);
 VIREO_EXPORT NIError EggShell_REPL(TypeManagerRef tm, const Utf8Char* commands, Int32 length);
 VIREO_EXPORT Int32 EggShell_ExecuteSlices(TypeManagerRef tm, Int32 numSlices);

--- a/source/include/DataTypes.h
+++ b/source/include/DataTypes.h
@@ -123,6 +123,7 @@ inline IntIndex TemplateDimIndex(IntIndex dim)
 
 
 //------------------------------------------------------------
+// Keep in sync with niErrorEnum in module_eggShell.js
 typedef enum {
     kNIError_Success = 0,
     kNIError_kInsufficientResources = 1,  // Typically memory
@@ -132,7 +133,7 @@ typedef enum {
     kNIError_kCantDecode = 4,             // Data in stream does not fit grammar
     kNIError_kCantEncode = 5,             // Data type not supported by encoder
     kNIError_kLogicFailure = 6,
-    kNIError_ValueTruncated = 7,
+    kNIError_kValueTruncated = 7,
 } NIError;
 
 typedef enum {

--- a/source/include/ExecutionContext.h
+++ b/source/include/ExecutionContext.h
@@ -111,7 +111,7 @@ class ExecutionContext
     ECONTEXT    void            ExecuteFunction(FunctionClump* fclump);  // Run a simple function to completion.
 
     // Run the concurrent execution system for a short period of time
-    ECONTEXT    Int32 /*ExecSlicesResult*/ ExecuteSlices(Int32 numSlices, PlatformTickType tickCount);
+    ECONTEXT    Int32 /*ExecSlicesResult*/ ExecuteSlices(Int32 numSlices, Int32 millisecondsToRun);
     ECONTEXT    InstructionCore* SuspendRunningQueueElt(InstructionCore* whereToWakeUp);
     ECONTEXT    InstructionCore* Stop();
     ECONTEXT    void            ClearBreakout() { _breakoutCount = 0; }

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -454,21 +454,15 @@
         // If a callback (stdout, stderr) is provided, it will be run asynchronously to completion
         Module.eggShell.executeSlicesUntilClumpsFinished = publicAPI.eggShell.executeSlicesUntilClumpsFinished = function (callback) {
             var MAXIMUM_VIREO_EXECUTION_TIME_MS = 4;
-            var printText = '';
-            var printTextErr = '';
-            var timerToken;
 
-            var origPrint = Module.print;
-            var origPrintErr = Module.printErr;
+            var timerToken;
             var origExecuteSlicesWakeupCallback = Module.eggShell.executeSlicesWakeupCallback;
 
             var vireoFinished = function () {
-                Module.print = origPrint;
-                Module.printErr = origPrintErr;
                 Module.eggShell.executeSlicesWakeupCallback = origExecuteSlicesWakeupCallback;
 
                 if (typeof callback === 'function') {
-                    callback(printText, printTextErr);
+                    callback();
                 }
             };
 
@@ -493,16 +487,6 @@
                     timerToken = undefined;
                     setTimeout(vireoFinished, 0);
                 }
-            };
-
-            Module.print = function (text) {
-                printText += text + '\n';
-                origPrint(text);
-            };
-
-            Module.printErr = function (textErr) {
-                printTextErr += textErr + '\n';
-                origPrintErr(textErr);
             };
 
             Module.eggShell.executeSlicesWakeupCallback = function () {

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -415,6 +415,7 @@
         };
 
         Module.eggShell.executeSlicesUntilWait = publicAPI.eggShell.executeSlicesUntilWait = function (slices) {
+            // Returns an ExecSlicesResult:
             // returns < 0 if should be called again ASAP, 0 if nothing to run, or positive value N if okay
             // to delay up to N milliseconds before calling again
             return EggShell_ExecuteSlices(v_userShell, slices);
@@ -451,7 +452,7 @@
         // Runs synchronously for a maximum of 4ms at a time to cooperate with most browser execution environments
         // A good starting point for most vireo uses but can be copied and modified as needed
         // callback (stdout, stderr)
-        Module.eggShell.executeSlicesToCompletion = publicAPI.eggShell.executeSlicesToCompletion = function (callback) {
+        Module.eggShell.executeSlicesUntilClumpsFinished = publicAPI.eggShell.executeSlicesUntilClumpsFinished = function (callback) {
             var printText = '';
             var printTextErr = '';
             var timerToken;
@@ -468,22 +469,22 @@
             };
 
             var runExecuteSlicesAsync = function () {
-                var execState, elapsedTime;
+                var execSlicesResult, elapsedTime;
                 var startTime = performanceNow();
 
                 do {
-                    execState = Module.eggShell.executeSlicesUntilWait(100000);
+                    execSlicesResult = Module.eggShell.executeSlicesUntilWait(100000);
 
-                    if (execState >= 0) {
+                    if (execSlicesResult >= 0) {
                         break;
                     }
 
                     elapsedTime = performanceNow() - startTime;
                 } while (elapsedTime < 4000);
 
-                if (execState > 0) {
-                    timerToken = setTimeout(runExecuteSlicesAsync, execState);
-                } else if (execState < 0) {
+                if (execSlicesResult > 0) {
+                    timerToken = setTimeout(runExecuteSlicesAsync, execSlicesResult);
+                } else if (execSlicesResult < 0) {
                     timerToken = setTimeout(runExecuteSlicesAsync, 0);
                 } else {
                     timerToken = undefined;

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -81,7 +81,7 @@
 
         // Exported functions
         Module.print = function (text) {
-            console.debug(text);
+            console.log(text);
         };
 
         Module.printErr = function (text) {

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -106,6 +106,18 @@
             Module.printErr = fn;
         };
 
+        Module.eggShell.executeSlicesWakeupCallback = function () {
+            // By default do no action
+        };
+
+        publicAPI.eggShell.setExecuteSlicesWakeupCallback = function (fn) {
+            if (typeof fn !== 'function') {
+                throw new Error('Execute slices wakeup callback must be a callable function');
+            }
+
+            Module.eggShell.executeSlicesWakeupCallback = fn;
+        };
+
         publicAPI.eggShell.internal_module_do_not_use_or_you_will_be_fired = Module;
 
         // Exporting functions to both Module.eggShell and publicAPI.eggShell is not normal
@@ -384,6 +396,7 @@
             // to improve performance in the future
             setTimeout(function () {
                 Occurrence_Set(occurrence);
+                Module.eggShell.executeSlicesWakeupCallback.call(undefined);
             }, 0);
         };
     };

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -430,11 +430,11 @@
                 return (hrtime[0] * 1000) + (hrtime[1] / 1e6);
             };
 
-            if (performance !== undefined) {
+            if (typeof performance !== 'undefined') {
                 result = function () {
                     return performance.now();
                 };
-            } else if (process !== undefined) {
+            } else if (typeof process !== 'undefined') {
                 nodeStartTimeMS = nodeTimeMS();
                 result = function () {
                     return nodeTimeMS() - nodeStartTimeMS;

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -390,6 +390,35 @@
             return EggShell_ExecuteSlices(v_userShell, slices);
         };
 
+        var nodeTimeMS = function () {
+            var hrtime = process.hrtime();
+            return (hrtime[0] * 1000) + (hrtime[1] / 1e6);
+        };
+
+        var nodeStartTimeMS;
+        if (Performance !== undefined) {
+            Module.eggShell.performanceNow = function () {
+                return Performance.now();
+            };
+        } else if (process !== undefined) {
+            nodeStartTimeMS = nodeTimeMS();
+            Module.eggShell.performanceNow = function () {
+                return nodeTimeMS() - nodeStartTimeMS;
+            };
+        } else {
+            Module.eggShell.performanceNow = function () {
+                throw new Error('Platform unsupported, require either Performance.now or process.hrtime timing api');
+            };
+        }
+
+        // Pumps vireo asynchronously until the currently loaded via is completed
+        // Runs synchronously for a maximum of 4ms at a time to cooperate with most browser execution environments
+        // A good starting point for most vireo uses but can be copied and modified as needed
+        // callback (stdout, stderr, ex)
+        Module.eggShell.executeSlicesToCompletion = function (callback) {
+
+        };
+
         Module.eggShell.setOccurrenceAsync = function (occurrence) {
             // TODO mraj currently setOccurrenceAsync is only called
             // by relatively slow operation, may need to change from setTimeout

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -106,16 +106,16 @@
             Module.printErr = fn;
         };
 
-        Module.eggShell.executeSlicesWakeupCallback = function () {
+        Module.eggShell.executeSlicesWakeUpCallback = function () {
             // By default do no action
         };
 
-        publicAPI.eggShell.setExecuteSlicesWakeupCallback = function (fn) {
+        publicAPI.eggShell.setExecuteSlicesWakeUpCallback = function (fn) {
             if (typeof fn !== 'function') {
-                throw new Error('Execute slices wakeup callback must be a callable function');
+                throw new Error('Execute slices wake-up callback must be a callable function');
             }
 
-            Module.eggShell.executeSlicesWakeupCallback = fn;
+            Module.eggShell.executeSlicesWakeUpCallback = fn;
         };
 
         publicAPI.eggShell.internal_module_do_not_use_or_you_will_be_fired = Module;
@@ -459,10 +459,10 @@
             var MAXIMUM_VIREO_EXECUTION_TIME_MS = 4;
 
             var timerToken;
-            var origExecuteSlicesWakeupCallback = Module.eggShell.executeSlicesWakeupCallback;
+            var origExecuteSlicesWakeUpCallback = Module.eggShell.executeSlicesWakeUpCallback;
 
             var vireoFinished = function () {
-                Module.eggShell.executeSlicesWakeupCallback = origExecuteSlicesWakeupCallback;
+                Module.eggShell.executeSlicesWakeUpCallback = origExecuteSlicesWakeUpCallback;
 
                 if (typeof callback === 'function') {
                     callback();
@@ -492,8 +492,8 @@
                 }
             };
 
-            Module.eggShell.executeSlicesWakeupCallback = function () {
-                origExecuteSlicesWakeupCallback();
+            Module.eggShell.executeSlicesWakeUpCallback = function () {
+                origExecuteSlicesWakeUpCallback();
                 if (timerToken === undefined) {
                     console.error('Attempted to wake up Vireo runtime but Vireo is not waiting');
                 } else {
@@ -512,7 +512,7 @@
             // to improve performance in the future
             setTimeout(function () {
                 Occurrence_Set(occurrence);
-                Module.eggShell.executeSlicesWakeupCallback.call(undefined);
+                Module.eggShell.executeSlicesWakeUpCallback.call(undefined);
             }, 0);
         };
     };

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -29,6 +29,7 @@
         // Disable new-cap for the cwrap functions so the names can be the same in C and JS
         /* eslint 'new-cap': ['error', {'capIsNewExceptions': [
             'Vireo_Version',
+            'Vireo_MaxExecWakeUpTime',
             'EggShell_Create',
             'EggShell_Delete',
             'EggShell_ReadDouble',
@@ -57,6 +58,7 @@
         // Private Instance Variables (per vireo instance)
         var NULL = 0;
         var Vireo_Version = Module.cwrap('Vireo_Version', 'number', []);
+        var Vireo_MaxExecWakeUpTime = Module.cwrap('Vireo_MaxExecWakeUpTime', 'number', []);
         var EggShell_Create = Module.cwrap('EggShell_Create', 'number', ['number']);
         var EggShell_Delete = Module.cwrap('EggShell_Delete', 'number', ['number']);
         var EggShell_ReadDouble = Module.cwrap('EggShell_ReadDouble', 'number', ['number', 'string', 'string']);
@@ -121,6 +123,7 @@
         // Exporting functions to both Module.eggShell and publicAPI.eggShell is not normal
         // This is unique to the eggShell API as it is consumed by other modules as well as users
         Module.eggShell.version = publicAPI.eggShell.version = Vireo_Version;
+        Module.eggShell.maxExecWakeUpTime = publicAPI.eggShell.maxExecWakeUpTime = Vireo_MaxExecWakeUpTime;
 
         Module.eggShell.reboot = publicAPI.eggShell.reboot = function () {
             EggShell_Delete(v_userShell);

--- a/source/io/module_httpClient.js
+++ b/source/io/module_httpClient.js
@@ -720,9 +720,15 @@
             var buffer, typedArrayBuffer;
             if (bufferPointer !== NULL) {
                 typedArrayBuffer = Module.eggShell.dataReadStringAsArray_NoCopy(bufferPointer);
-                // TODO(mraj) would like to use the typed array directly but not supported in iOS and PhantomJS
-                // Blob type not set to determine Content-Type for XHR as IE and Edge seem to ignore it.
-                buffer = new Blob([typedArrayBuffer]);
+
+                // Blob API does not exist in node.js
+                if (typeof Blob === 'undefined') {
+                    buffer = typedArrayBuffer;
+                } else {
+                    // TODO(mraj) would like to use the typed array in all browsers but not supported in iOS and PhantomJS with XHR.send
+                    // Blob type property not set to determine Content-Type for XHR as IE and Edge seem to ignore it.
+                    buffer = new Blob([typedArrayBuffer]);
+                }
             }
 
             var httpClient;

--- a/source/io/module_httpClient.js
+++ b/source/io/module_httpClient.js
@@ -451,12 +451,12 @@
             this._httpClients = new Map();
             this._runningRequestsTracker = new RunningRequestsTracker();
 
-            if (typeof XMLHttpRequest === 'function') {
-                this._xmlHttpRequestImplementation = XMLHttpRequest;
-            } else {
+            if (typeof XMLHttpRequest === 'undefined') {
                 this._xmlHttpRequestImplementation = function () {
                     throw new Error('Vireo could not find a global implementation of XMLHttpRequest Level 2. Please provide one to vireo.httpClient.setXMLHttpRequestImplementation to use the Vireo HTTP Client');
                 };
+            } else {
+                this._xmlHttpRequestImplementation = XMLHttpRequest;
             }
         };
 

--- a/test-it/ExpectedResults/HttpBinGet.vtr
+++ b/test-it/ExpectedResults/HttpBinGet.vtr
@@ -1,0 +1,2 @@
+(('helloworldhttpgetfromvireo'))
+(false 0 '')

--- a/test-it/ExpectedResults/HttpBinPost.vtr
+++ b/test-it/ExpectedResults/HttpBinPost.vtr
@@ -1,0 +1,2 @@
+(('helloworldhttppostfromvireo'))
+(false 0 '')

--- a/test-it/HelloNode.js
+++ b/test-it/HelloNode.js
@@ -1,32 +1,22 @@
 (function () {
     'use strict';
 
-    var vireo = {};
-    var actualVireo;
-
-    var setupVJS = function () {
-        var Vireo;
-        try {
-            Vireo = require('../');
-
-            actualVireo = new Vireo();
-            vireo = actualVireo.eggShell;
-        } catch (err) {
-            if (err.code === 'MODULE_NOT_FOUND') {
-                console.log('Error: vireo.js not found (Maybe build it first?)');
-                process.exit(1);
-            } else {
-                throw err;
-            }
+    var Vireo;
+    try {
+        Vireo = require('../');
+    } catch (err) {
+        if (err.code === 'MODULE_NOT_FOUND') {
+            console.log('Error: vireo.js not found (Maybe build it first?)');
+            process.exit(1);
+        } else {
+            throw err;
         }
-        // svireo.stdout = '';
-        vireo.setPrintFunction(function (text) {
-            console.log('console: ' + text);
-        });
-    };
+    }
 
-    setupVJS();
-
+    var vireo = new Vireo();
+    vireo.eggShell.setPrintFunction(function (text) {
+        console.log('console: ' + text);
+    });
     var text =
         'define(c0 dv(.String "wubbalubbadubdub"))\n' +
         'define(HelloWorld dv(.VirtualInstrument (\n' +
@@ -42,12 +32,12 @@
 
     var currFPID = '';
 
-    actualVireo.coreHelpers.setFPSyncFunction(function (fpId) {
+    vireo.coreHelpers.setFPSyncFunction(function (fpId) {
         currFPID = 'fpsync called with (' + fpId + ')';
     });
 
-    vireo.loadVia(text);
-    vireo.executeSlicesUntilWait(1);
+    vireo.eggShell.loadVia(text);
+    vireo.eggShell.executeSlicesUntilWait(1);
 
     var testResult = false;
     var testString = '';
@@ -60,43 +50,43 @@
 
     console.log('test2');
     testString = 'Hello, world. I can fly.';
-    testResult = JSON.parse(vireo.readJSON('HelloWorld', 'variable1')) === testString;
+    testResult = JSON.parse(vireo.eggShell.readJSON('HelloWorld', 'variable1')) === testString;
     console.assert(testResult, 'Read a value after execution is done');
 
     console.log('test3');
     testString = 'Hello, world. I can fly.你好世界。我能飛。';
-    vireo.writeJSON('HelloWorld', 'variable1', JSON.stringify(testString));
-    testResult = JSON.parse(vireo.readJSON('HelloWorld', 'variable1')) === testString;
+    vireo.eggShell.writeJSON('HelloWorld', 'variable1', JSON.stringify(testString));
+    testResult = JSON.parse(vireo.eggShell.readJSON('HelloWorld', 'variable1')) === testString;
     console.assert(testResult, 'Read a value with unicode characters');
 
     console.log('test4');
     testString = 'May it be a good Day!';
-    vireo.writeJSON('HelloWorld', 'variable1', JSON.stringify(testString));
-    testResult = JSON.parse(vireo.readJSON('HelloWorld', 'variable1')) === testString;
+    vireo.eggShell.writeJSON('HelloWorld', 'variable1', JSON.stringify(testString));
+    testResult = JSON.parse(vireo.eggShell.readJSON('HelloWorld', 'variable1')) === testString;
     console.assert(testResult, 'Write a value and get it back');
 
     console.log('test5');
     testString = 'multi\nline with \'single\' and "double" quotes';
-    vireo.writeJSON('HelloWorld', 'variable1', JSON.stringify(testString));
-    testResult = JSON.parse(vireo.readJSON('HelloWorld', 'variable1')) === testString;
+    vireo.eggShell.writeJSON('HelloWorld', 'variable1', JSON.stringify(testString));
+    testResult = JSON.parse(vireo.eggShell.readJSON('HelloWorld', 'variable1')) === testString;
     console.assert(testResult, 'Write some special characters');
 
     console.log('test6');
     preTestString = 'multi\nline with \'single\' and "double" quotes';
-    vireo.writeJSON('HelloWorld', 'variable1', JSON.stringify(preTestString));
-    console.assert(JSON.parse(vireo.readJSON('HelloWorld', 'variable1')) === preTestString, 'The initial valid JSON is written');
+    vireo.eggShell.writeJSON('HelloWorld', 'variable1', JSON.stringify(preTestString));
+    console.assert(JSON.parse(vireo.eggShell.readJSON('HelloWorld', 'variable1')) === preTestString, 'The initial valid JSON is written');
     testString = 'Buenas Dias';
-    vireo.writeJSON('HelloWorld', 'variable1', testString); // JSON.stringify intentionally left off
-    testResult = JSON.parse(vireo.readJSON('HelloWorld', 'variable1')) === preTestString;
+    vireo.eggShell.writeJSON('HelloWorld', 'variable1', testString); // JSON.stringify intentionally left off
+    testResult = JSON.parse(vireo.eggShell.readJSON('HelloWorld', 'variable1')) === preTestString;
     console.assert(testResult, 'Write string that is not in JSON format is ignored');
 
     console.log('test7');
     preTestString = 'multi\nline with \'single\' and "double" quotes';
-    vireo.writeJSON('HelloWorld', 'variable1', JSON.stringify(preTestString));
-    console.assert(JSON.parse(vireo.readJSON('HelloWorld', 'variable1')) === preTestString, 'The initial valid JSON is written');
+    vireo.eggShell.writeJSON('HelloWorld', 'variable1', JSON.stringify(preTestString));
+    console.assert(JSON.parse(vireo.eggShell.readJSON('HelloWorld', 'variable1')) === preTestString, 'The initial valid JSON is written');
     testString = 'Buenas Dias';
-    vireo.writeJSON('HelloWorld', 'variable1', JSON.stringify(testString)); // JSON.stringify intentionally added
-    testResult = JSON.parse(vireo.readJSON('HelloWorld', 'variable1')) === testString;
+    vireo.eggShell.writeJSON('HelloWorld', 'variable1', JSON.stringify(testString)); // JSON.stringify intentionally added
+    testResult = JSON.parse(vireo.eggShell.readJSON('HelloWorld', 'variable1')) === testString;
     console.assert(testResult, 'Write string that has been fixed');
 
     console.log('test end');

--- a/test-it/HelloNode.js
+++ b/test-it/HelloNode.js
@@ -3,9 +3,6 @@
     var Vireo = require('../');
 
     var vireo = new Vireo();
-    vireo.eggShell.setPrintFunction(function (text) {
-        console.log('console: ' + text);
-    });
     var text =
         'define(c0 dv(.String "wubbalubbadubdub"))\n' +
         'define(HelloWorld dv(.VirtualInstrument (\n' +

--- a/test-it/HelloNode.js
+++ b/test-it/HelloNode.js
@@ -1,17 +1,6 @@
 (function () {
     'use strict';
-
-    var Vireo;
-    try {
-        Vireo = require('../');
-    } catch (err) {
-        if (err.code === 'MODULE_NOT_FOUND') {
-            console.log('Error: vireo.js not found (Maybe build it first?)');
-            process.exit(1);
-        } else {
-            throw err;
-        }
-    }
+    var Vireo = require('../');
 
     var vireo = new Vireo();
     vireo.eggShell.setPrintFunction(function (text) {

--- a/test-it/HelloNode.js
+++ b/test-it/HelloNode.js
@@ -23,7 +23,7 @@
     });
 
     vireo.eggShell.loadVia(text);
-    vireo.eggShell.executeSlicesUntilWait(1);
+    vireo.eggShell.executeSlicesUntilWait();
 
     var testResult = false;
     var testString = '';

--- a/test-it/ViaTests/HttpBinGet.via
+++ b/test-it/ViaTests/HttpBinGet.via
@@ -1,0 +1,32 @@
+define(MyVI dv(VirtualInstrument (
+    Locals: c(
+        e(dv(.UInt32 0) handle)
+        e('http://127.0.0.1:64526/get?test=helloworldhttpgetfromvireo' url)
+        e('' outputFile)
+        // no buffer to send
+        e(10000 timeout)
+        e('' headers)
+        e('' body)
+        e(dv(.UInt32 0) statusCode)
+        e(c(
+            e(.Boolean status)
+            e(.Int32 code)
+            e(.String source)
+        ) error)
+        e(c(
+            e(c(
+                e(.String test)
+            ) args)
+        ) clusterRepresentation)
+    )
+    clump (
+        HttpClientGet(handle url outputFile timeout headers body statusCode error)
+
+        // string lvtype pathIntoJSON lvExtensionsBool strictValidationBool defaultNullBool errorCluster
+        UnflattenFromJSON(body clusterRepresentation * false false false error)
+        Println(clusterRepresentation)
+        Println(error)
+    )
+) ) )
+
+enqueue(MyVI)

--- a/test-it/ViaTests/HttpBinPost.via
+++ b/test-it/ViaTests/HttpBinPost.via
@@ -1,0 +1,32 @@
+define(MyVI dv(VirtualInstrument (
+    Locals: c(
+        e(dv(.UInt32 0) handle)
+        e('http://127.0.0.1:64526/post' url)
+        e('' outputFile)
+        e('test=helloworldhttppostfromvireo' buffer)
+        e(10000 timeout)
+        e('' headers)
+        e('' body)
+        e(dv(.UInt32 0) statusCode)
+        e(c(
+            e(.Boolean status)
+            e(.Int32 code)
+            e(.String source)
+        ) error)
+        e(c(
+            e(c(
+                e(.String test)
+            ) form)
+        ) clusterRepresentation)
+    )
+    clump (
+        HttpClientPost(handle url outputFile buffer timeout headers body statusCode error)
+
+        // string lvtype pathIntoJSON lvExtensionsBool strictValidationBool defaultNullBool errorCluster
+        UnflattenFromJSON(body clusterRepresentation * false false false error)
+        Println(clusterRepresentation)
+        Println(error)
+    )
+) ) )
+
+enqueue(MyVI)

--- a/test-it/esh.js
+++ b/test-it/esh.js
@@ -4,6 +4,7 @@
     'use strict';
     var Vireo = require('../');
     var fs = require('fs');
+    var xhr2 = require('xhr2');
 
     var argv = process.argv.slice();
     argv.shift();
@@ -22,6 +23,7 @@
     }
 
     var vireo = new Vireo();
+    vireo.httpClient.setXMLHttpRequestImplementation(xhr2);
     vireo.eggShell.loadVia(text);
     vireo.eggShell.executeSlicesUntilClumpsFinished();
 }());

--- a/test-it/esh.js
+++ b/test-it/esh.js
@@ -7,49 +7,35 @@
     argv.shift();
     var command = argv.shift();
     var arg = argv[0];
-    var vireo = {};
-    var actualVireo;
 
-    var setupVJS = function () {
-        var Vireo;
-        try {
-            Vireo = require('../');
-
-            actualVireo = new Vireo();
-            vireo = actualVireo.eggShell;
-        } catch (err) {
-            if (err.code === 'MODULE_NOT_FOUND') {
-                console.log('Error: vireo.js not found (Maybe build it first?)');
-                process.exit(1);
-            } else {
-                throw err;
-            }
+    var Vireo;
+    try {
+        Vireo = require('../');
+    } catch (err) {
+        if (err.code === 'MODULE_NOT_FOUND') {
+            console.error('Error: vireo.js not found (Maybe build it first?)');
+            process.exit(1);
+        } else {
+            throw err;
         }
-        vireo.setPrintFunction(function (text) {
-            console.log(text);
-        });
-    };
-
-    setupVJS();
+    }
 
     var fs = require('fs');
+    var text;
     try {
-        var text = fs.readFileSync(arg).toString();
-        vireo.loadVia(text);
+        text = fs.readFileSync(arg).toString();
     } catch (e) {
         console.log('Usage: ' + command + ' [file.via]...');
         if (arg.substring(0, 1) !== '-') {
-            console.log('Cannot open ' + arg);
+            console.error('Cannot open ' + arg);
         }
         process.exit(1);
     }
 
-    (function executeVireo () {
-        var timeDelay = vireo.executeSlicesUntilWait(100000);
-        if (timeDelay > 0) {
-            setTimeout(executeVireo, timeDelay);
-        } else if (timeDelay < 0) {
-            setImmediate(executeVireo);
-        }
-    }());
+    var vireo = new Vireo();
+    vireo.eggShell.setPrintFunction(function (text) {
+        console.log(text);
+    });
+    vireo.eggShell.loadVia(text);
+    vireo.eggShell.executeSlicesUntilClumpsFinished();
 }());

--- a/test-it/esh.js
+++ b/test-it/esh.js
@@ -22,9 +22,6 @@
     }
 
     var vireo = new Vireo();
-    vireo.eggShell.setPrintFunction(function (text) {
-        console.log(text);
-    });
     vireo.eggShell.loadVia(text);
     vireo.eggShell.executeSlicesUntilClumpsFinished();
 }());

--- a/test-it/esh.js
+++ b/test-it/esh.js
@@ -2,25 +2,14 @@
 // Simple command line Vireo shell
 (function () {
     'use strict';
+    var Vireo = require('../');
+    var fs = require('fs');
 
     var argv = process.argv.slice();
     argv.shift();
     var command = argv.shift();
     var arg = argv[0];
 
-    var Vireo;
-    try {
-        Vireo = require('../');
-    } catch (err) {
-        if (err.code === 'MODULE_NOT_FOUND') {
-            console.error('Error: vireo.js not found (Maybe build it first?)');
-            process.exit(1);
-        } else {
-            throw err;
-        }
-    }
-
-    var fs = require('fs');
     var text;
     try {
         text = fs.readFileSync(arg).toString();

--- a/test-it/httptest1/hostwebworker.js
+++ b/test-it/httptest1/hostwebworker.js
@@ -9,7 +9,6 @@
 
     handlers.loadAndRun = function (viaCode) {
         var vireo = new self.NationalInstruments.Vireo.Vireo();
-        vireo.eggShell.setPrintFunction(console.log.bind(console));
         vireo.eggShell.loadVia(viaCode);
         vireo.eggShell.executeSlicesUntilClumpsFinished();
     };

--- a/test-it/httptest1/hostwebworker.js
+++ b/test-it/httptest1/hostwebworker.js
@@ -11,14 +11,8 @@
         var vireo = new self.NationalInstruments.Vireo.Vireo();
         vireo.eggShell.setPrintFunction(console.log.bind(console));
         vireo.eggShell.loadVia(viaCode);
-        (function runUntildone () {
-            var execResult = vireo.eggShell.executeSlicesUntilWait(1000000);
-            if (execResult !== 0) {
-                setTimeout(runUntildone, execResult > 0 ? execResult : 0);
-            }
-        }());
+        vireo.eggShell.executeSlicesUntilClumpsFinished();
     };
-
 
     self.addEventListener('message', function (evt) {
         handlers[evt.data.type].call(undefined, evt.data.data);

--- a/test-it/httptest1/hostwebworker.js
+++ b/test-it/httptest1/hostwebworker.js
@@ -7,7 +7,7 @@
         self.importScripts.apply(self, scripts);
     };
 
-    handlers.loadAndRunSync = function (viaCode) {
+    handlers.loadAndRun = function (viaCode) {
         var vireo = new self.NationalInstruments.Vireo.Vireo();
         vireo.eggShell.setPrintFunction(console.log.bind(console));
         vireo.eggShell.loadVia(viaCode);

--- a/test-it/httptest1/loaderamd.js
+++ b/test-it/httptest1/loaderamd.js
@@ -12,7 +12,7 @@
     });
 
     requirejs(['NationalInstruments.Vireo.Vireo'], function (Vireo) {
-        var eggShell;
+        var vireo;
 
         var domReady = function (callback) {
             if (document.readyState === 'loading') {
@@ -22,23 +22,15 @@
             }
         };
 
-        var continueUntilDone = function () {
-            var execResult = eggShell.executeSlicesUntilWait(1000);
-
-            if (execResult !== 0) {
-                setTimeout(continueUntilDone, execResult > 0 ? execResult : 0);
-            } else {
-                console.log('finished :D');
-            }
-        };
-
         var runTest = function () {
             var viaCode = document.getElementById('viacode').textContent;
-            eggShell = new Vireo().eggShell;
-            eggShell.setPrintFunction(console.log);
-            eggShell.setPrintErrorFunction(console.error);
-            eggShell.loadVia(viaCode);
-            setTimeout(continueUntilDone, 0);
+            vireo = new Vireo();
+            vireo.eggShell.setPrintFunction(console.log);
+            vireo.eggShell.setPrintErrorFunction(console.error);
+            vireo.eggShell.loadVia(viaCode);
+            vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
+                console.log('finished :D');
+            });
         };
 
         domReady(runTest);

--- a/test-it/httptest1/loaderamd.js
+++ b/test-it/httptest1/loaderamd.js
@@ -23,8 +23,6 @@
         var runTest = function () {
             var viaCode = document.getElementById('viacode').textContent;
             var vireo = new Vireo();
-            vireo.eggShell.setPrintFunction(console.log);
-            vireo.eggShell.setPrintErrorFunction(console.error);
             vireo.eggShell.loadVia(viaCode);
             vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
                 console.log('finished :D');

--- a/test-it/httptest1/loaderamd.js
+++ b/test-it/httptest1/loaderamd.js
@@ -12,8 +12,6 @@
     });
 
     requirejs(['NationalInstruments.Vireo.Vireo'], function (Vireo) {
-        var vireo;
-
         var domReady = function (callback) {
             if (document.readyState === 'loading') {
                 document.addEventListener('DOMContentLoaded', callback);
@@ -24,7 +22,7 @@
 
         var runTest = function () {
             var viaCode = document.getElementById('viacode').textContent;
-            vireo = new Vireo();
+            var vireo = new Vireo();
             vireo.eggShell.setPrintFunction(console.log);
             vireo.eggShell.setPrintErrorFunction(console.error);
             vireo.eggShell.loadVia(viaCode);

--- a/test-it/httptest1/loaderglobal.js
+++ b/test-it/httptest1/loaderglobal.js
@@ -12,8 +12,6 @@
 
     var createAndRun = function (Vireo, viaCode) {
         var vireo = new Vireo();
-        vireo.eggShell.setPrintFunction(console.log);
-        vireo.eggShell.setPrintErrorFunction(console.error);
         vireo.eggShell.loadVia(viaCode);
         vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
             console.log('finished :D');

--- a/test-it/httptest1/loaderglobal.js
+++ b/test-it/httptest1/loaderglobal.js
@@ -2,7 +2,7 @@
 (function () {
     'use strict';
 
-    var eggShell;
+    var vireo;
 
     var domReady = function (callback) {
         if (document.readyState === 'loading') {
@@ -12,22 +12,14 @@
         }
     };
 
-    var continueUntilDone = function () {
-        var execResult = eggShell.executeSlicesUntilWait(1000);
-
-        if (execResult !== 0) {
-            setTimeout(continueUntilDone, execResult > 0 ? execResult : 0);
-        } else {
-            console.log('finished :D');
-        }
-    };
-
     var createAndRun = function (Vireo, viaCode) {
-        eggShell = new Vireo().eggShell;
-        eggShell.setPrintFunction(console.log);
-        eggShell.setPrintErrorFunction(console.error);
-        eggShell.loadVia(viaCode);
-        setTimeout(continueUntilDone, 0);
+        vireo = new Vireo();
+        vireo.eggShell.setPrintFunction(console.log);
+        vireo.eggShell.setPrintErrorFunction(console.error);
+        vireo.eggShell.loadVia(viaCode);
+        vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
+            console.log('finished :D');
+        });
     };
 
     var runTest = function () {

--- a/test-it/httptest1/loaderglobal.js
+++ b/test-it/httptest1/loaderglobal.js
@@ -2,8 +2,6 @@
 (function () {
     'use strict';
 
-    var vireo;
-
     var domReady = function (callback) {
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', callback);
@@ -13,7 +11,7 @@
     };
 
     var createAndRun = function (Vireo, viaCode) {
-        vireo = new Vireo();
+        var vireo = new Vireo();
         vireo.eggShell.setPrintFunction(console.log);
         vireo.eggShell.setPrintErrorFunction(console.error);
         vireo.eggShell.loadVia(viaCode);

--- a/test-it/httptest1/loaderglobalperf.js
+++ b/test-it/httptest1/loaderglobalperf.js
@@ -12,8 +12,6 @@
     var runTest = function () {
         var viaCode = document.getElementById('viacode').textContent;
         var vireo = new window.NationalInstruments.Vireo.Vireo();
-        vireo.eggShell.setPrintFunction(console.log);
-        vireo.eggShell.setPrintErrorFunction(console.error);
         vireo.eggShell.loadVia(viaCode);
         vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
             console.log('finished :D');

--- a/test-it/httptest1/loaderglobalperf.js
+++ b/test-it/httptest1/loaderglobalperf.js
@@ -11,23 +11,15 @@
         }
     };
 
-    var continueUntilDone = function () {
-        var execResult = vireo.eggShell.executeSlicesUntilWait(1000);
-
-        if (execResult !== 0) {
-            setTimeout(continueUntilDone, execResult > 0 ? execResult : 0);
-        } else {
-            console.log('finished :D');
-        }
-    };
-
     var runTest = function () {
         var viaCode = document.getElementById('viacode').textContent;
         vireo = new window.NationalInstruments.Vireo.Vireo();
         vireo.eggShell.setPrintFunction(console.log);
         vireo.eggShell.setPrintErrorFunction(console.error);
         vireo.eggShell.loadVia(viaCode);
-        setTimeout(continueUntilDone, 0);
+        vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
+            console.log('finished :D');
+        });
     };
 
     domReady(runTest);

--- a/test-it/httptest1/loaderglobalperf.js
+++ b/test-it/httptest1/loaderglobalperf.js
@@ -1,8 +1,6 @@
 (function () {
     'use strict';
 
-    var vireo;
-
     var domReady = function (callback) {
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', callback);
@@ -13,7 +11,7 @@
 
     var runTest = function () {
         var viaCode = document.getElementById('viacode').textContent;
-        vireo = new window.NationalInstruments.Vireo.Vireo();
+        var vireo = new window.NationalInstruments.Vireo.Vireo();
         vireo.eggShell.setPrintFunction(console.log);
         vireo.eggShell.setPrintErrorFunction(console.error);
         vireo.eggShell.loadVia(viaCode);

--- a/test-it/httptest1/loadernode.js
+++ b/test-it/httptest1/loadernode.js
@@ -1,8 +1,8 @@
 (function () {
     'use strict';
+    var Vireo = require('../../');
     var fs = require('fs');
 
-    var Vireo = require('../../source/core/vireo.loader.js');
     var viaCode = fs.readFileSync('./loadernode.via', 'utf8');
 
     var vireo = new Vireo();

--- a/test-it/httptest1/loadernode.js
+++ b/test-it/httptest1/loadernode.js
@@ -1,15 +1,15 @@
-var fs = require('fs');
+(function () {
+    'use strict';
+    var fs = require('fs');
 
-var Vireo = require('../../source/core/vireo.loader.js');
-var viaCode = fs.readFileSync('./loadernode.via', 'utf8');
+    var Vireo = require('../../source/core/vireo.loader.js');
+    var viaCode = fs.readFileSync('./loadernode.via', 'utf8');
 
-var eggShell = new Vireo().eggShell;
-
-eggShell.loadVia(viaCode);
-
-var execResult = eggShell.executeSlicesUntilWait(1000);
-while (execResult !== 0) {
-    execResult = eggShell.executeSlicesUntilWait(1000);
-}
-
-console.log('done :D');
+    var vireo = new Vireo();
+    vireo.eggShell.setPrintFunction(console.log);
+    vireo.eggShell.setPrintErrorFunction(console.error);
+    vireo.eggShell.loadVia(viaCode);
+    vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
+        console.log('done :D');
+    });
+}());

--- a/test-it/httptest1/loadernode.js
+++ b/test-it/httptest1/loadernode.js
@@ -6,8 +6,6 @@
     var viaCode = fs.readFileSync('./loadernode.via', 'utf8');
 
     var vireo = new Vireo();
-    vireo.eggShell.setPrintFunction(console.log);
-    vireo.eggShell.setPrintErrorFunction(console.error);
     vireo.eggShell.loadVia(viaCode);
     vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
         console.log('done :D');

--- a/test-it/httptest1/loaderwebworker.js
+++ b/test-it/httptest1/loaderwebworker.js
@@ -26,12 +26,12 @@
         });
 
         worker.postMessage({
-            type: 'loadAndRunSync',
+            type: 'loadAndRun',
             data: viaCode
         });
 
         worker.postMessage({
-            type: 'loadAndRunSync',
+            type: 'loadAndRun',
             data: viaCodeHttp
         });
     };

--- a/test-it/httptest1/testhttp.js
+++ b/test-it/httptest1/testhttp.js
@@ -11,9 +11,6 @@
 
     var createAndRun = function (Vireo, viaCode) {
         var vireo = new Vireo();
-
-        vireo.eggShell.setPrintFunction(console.log);
-        vireo.eggShell.setPrintErrorFunction(console.error);
         vireo.eggShell.loadVia(viaCode);
         vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
             console.log(JSON.parse(vireo.eggShell.readJSON('%3AWeb%20Server%3AInteractive%3AApplication%3AMain%2Egviweb', 'dataItem_Body')));

--- a/test-it/httptest1/testhttp.js
+++ b/test-it/httptest1/testhttp.js
@@ -1,7 +1,7 @@
 (function () {
     'use strict';
 
-    var eggShell;
+    var vireo;
 
     var domReady = function (callback) {
         if (document.readyState === 'loading') {
@@ -11,25 +11,16 @@
         }
     };
 
-    var continueUntilDone = function () {
-        var execResult = eggShell.executeSlicesUntilWait(1000);
-
-        if (execResult !== 0) {
-            setTimeout(continueUntilDone, execResult > 0 ? execResult : 0);
-        } else {
-            console.log(JSON.parse(eggShell.readJSON('%3AWeb%20Server%3AInteractive%3AApplication%3AMain%2Egviweb', 'dataItem_Body')));
-            console.log('finished :D');
-        }
-    };
-
     var createAndRun = function (Vireo, viaCode) {
-        var vireo = new Vireo();
+        vireo = new Vireo();
 
-        eggShell = vireo.eggShell;
-        eggShell.setPrintFunction(console.log);
-        eggShell.setPrintErrorFunction(console.error);
-        eggShell.loadVia(viaCode);
-        setTimeout(continueUntilDone, 0);
+        vireo.eggShell.setPrintFunction(console.log);
+        vireo.eggShell.setPrintErrorFunction(console.error);
+        vireo.eggShell.loadVia(viaCode);
+        vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
+            console.log(JSON.parse(vireo.eggShell.readJSON('%3AWeb%20Server%3AInteractive%3AApplication%3AMain%2Egviweb', 'dataItem_Body')));
+            console.log('finished :D');
+        });
     };
 
     var runTest = function () {

--- a/test-it/httptest1/testhttp.js
+++ b/test-it/httptest1/testhttp.js
@@ -1,8 +1,6 @@
 (function () {
     'use strict';
 
-    var vireo;
-
     var domReady = function (callback) {
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', callback);
@@ -12,7 +10,7 @@
     };
 
     var createAndRun = function (Vireo, viaCode) {
-        vireo = new Vireo();
+        var vireo = new Vireo();
 
         vireo.eggShell.setPrintFunction(console.log);
         vireo.eggShell.setPrintErrorFunction(console.error);

--- a/test-it/karma/fixtures/publicapi/ExecuteLongWait.via
+++ b/test-it/karma/fixtures/publicapi/ExecuteLongWait.via
@@ -1,0 +1,10 @@
+define (MyVI dv(.VirtualInstrument (
+    Locals: c(
+        e(dv(.UInt32 0) waitTime)
+    )
+    clump(
+        WaitMilliseconds(waitTime *)
+    )
+)))
+
+enqueue (MyVI)

--- a/test-it/karma/fixtures/publicapi/ExecuteManyHTTPGet.via
+++ b/test-it/karma/fixtures/publicapi/ExecuteManyHTTPGet.via
@@ -1,0 +1,30 @@
+define (MyVI dv(.VirtualInstrument (
+    Locals: c(
+        e(dv(.UInt32 0) handle)
+        e('fakeurl' url)
+        e('' outputFile)
+        // no buffer to send
+        e(10000 timeout)
+        e('' headers)
+        e('' body)
+        e(dv(.UInt32 0) statusCode)
+        e(c(
+            e(.Boolean status)
+            e(.Int32 code)
+            e(.String source)
+        ) error)
+
+        e(dv(.Int32 0) numIterations)
+        e(.Int32 currIterations)
+    )
+    clump(
+        Perch(0)
+        BranchIfGE(1 currIterations numIterations)
+        HttpClientGet(handle url outputFile timeout headers body statusCode error)
+        Add(currIterations 1 currIterations)
+        Branch(0)
+        Perch(1)
+    )
+)))
+
+enqueue (MyVI)

--- a/test-it/karma/helloworld/HelloWorld.Test.js
+++ b/test-it/karma/helloworld/HelloWorld.Test.js
@@ -24,7 +24,7 @@ describe('Vireo loaded as a global in the browser', function () {
         });
 
         vireo.eggShell.loadVia(viaCode);
-        vireo.eggShell.executeSlicesUntilWait(1);
+        vireo.eggShell.executeSlicesUntilWait();
         expect(result).toBe('Hello, sky. I can fly.\n');
     });
 

--- a/test-it/karma/helloworld/HelloWorld.Test.js
+++ b/test-it/karma/helloworld/HelloWorld.Test.js
@@ -27,4 +27,21 @@ describe('Vireo loaded as a global in the browser', function () {
         vireo.eggShell.executeSlicesUntilWait(1);
         expect(result).toBe('Hello, sky. I can fly.\n');
     });
+
+    it('can run HelloWorld Async', function (done) {
+        var Vireo = window.NationalInstruments.Vireo.Vireo;
+        var vireo = new Vireo();
+        var viaCode = 'start( VI<( clump( Println("Hello, sky. I can fly.") ) ) > )';
+
+        var result = '';
+        vireo.eggShell.setPrintFunction(function (text) {
+            result += text + '\n';
+        });
+
+        vireo.eggShell.loadVia(viaCode);
+        vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
+            expect(result).toBe('Hello, sky. I can fly.\n');
+            done();
+        });
+    });
 });

--- a/test-it/karma/http/HttpGet.Test.js
+++ b/test-it/karma/http/HttpGet.Test.js
@@ -14,6 +14,7 @@ describe('Performing a GET request', function () {
     var WEBVI_INVALID_URL = 363500;
     var WEBVI_INVALID_HEADER = 363651;
     var WEBVI_NETWORK_ERROR = 363650;
+    var WEBVI_TIMEOUT = 56;
     var vireo;
 
     var httpGetMethodViaUrl = fixtures.convertToAbsoluteFromFixturesDir('http/GetMethod.via');
@@ -134,7 +135,7 @@ describe('Performing a GET request', function () {
             expect(viPathParser('body')).toBeEmptyString();
             expect(viPathParser('statusCode')).toBe(0);
             expect(viPathParser('error.status')).toBeTrue();
-            expect([WEBVI_NETWORK_ERROR, kNIHttpResultInternalUndefinedError]).toContain(viPathParser('error.code'));
+            expect([WEBVI_TIMEOUT, WEBVI_NETWORK_ERROR, kNIHttpResultInternalUndefinedError]).toContain(viPathParser('error.code'));
             expect(viPathParser('error.source')).toMatch(/HttpClientGet in MyVI/);
             done();
         });

--- a/test-it/karma/http/HttpPost.Test.js
+++ b/test-it/karma/http/HttpPost.Test.js
@@ -13,6 +13,7 @@ describe('Performing a POST request', function () {
     var WEBVI_INVALID_URL = 363500;
     var WEBVI_INVALID_HEADER = 363651;
     var WEBVI_NETWORK_ERROR = 363650;
+    var WEBVI_TIMEOUT = 56;
     var vireo;
 
     var httpPostMethodViaUrl = fixtures.convertToAbsoluteFromFixturesDir('http/PostMethod.via');
@@ -130,7 +131,7 @@ describe('Performing a POST request', function () {
             expect(viPathParser('body')).toBeEmptyString();
             expect(viPathParser('statusCode')).toBe(0);
             expect(viPathParser('error.status')).toBeTrue();
-            expect([WEBVI_NETWORK_ERROR, kNIHttpResultInternalUndefinedError]).toContain(viPathParser('error.code'));
+            expect([WEBVI_TIMEOUT, WEBVI_NETWORK_ERROR, kNIHttpResultInternalUndefinedError]).toContain(viPathParser('error.code'));
             expect(viPathParser('error.source')).toMatch(/HttpClientPost in MyVI/);
             done();
         });

--- a/test-it/karma/publicapi/ExecuteSlicesUntilClumpsFinshed.Test.js
+++ b/test-it/karma/publicapi/ExecuteSlicesUntilClumpsFinshed.Test.js
@@ -60,15 +60,15 @@ describe('The Vireo EggShell executeSlicesUntilClumpsFinished api', function () 
 
         var maxTimewithBuffer = maxExecWakeUpTime * numIterations * 0.5;
 
-        var wakeupspy = jasmine.createSpy();
-        vireo.eggShell.setExecuteSlicesWakeupCallback(wakeupspy);
+        var wakeUpSpy = jasmine.createSpy();
+        vireo.eggShell.setExecuteSlicesWakeUpCallback(wakeUpSpy);
 
         var startTime = performance.now();
         vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
             var totalTime = performance.now() - startTime;
             expect(totalTime).toBeLessThan(maxTimewithBuffer);
             expect(result).toBeEmptyString();
-            expect(wakeupspy.calls.count()).toBeGreaterThanOrEqualTo(numIterations);
+            expect(wakeUpSpy.calls.count()).toBeGreaterThanOrEqualTo(numIterations);
             done();
         });
     });

--- a/test-it/karma/publicapi/ExecuteSlicesUntilClumpsFinshed.Test.js
+++ b/test-it/karma/publicapi/ExecuteSlicesUntilClumpsFinshed.Test.js
@@ -1,0 +1,104 @@
+describe('The Vireo EggShell executeSlicesUntilClumpsFinished api', function () {
+    'use strict';
+
+    var fixtures = window.testHelpers.fixtures;
+    var publicApiExecuteManyHTTPGetUrl = fixtures.convertToAbsoluteFromFixturesDir('publicapi/ExecuteManyHTTPGet.via');
+
+    var XHRShimResolveImmediatelyAsync = function () {
+        var noop = function () {
+            // Intentionally blank
+        };
+        var loadCallback;
+        return {
+            abort: noop,
+            addEventListener: function (name, cb) {
+                if (name === 'load') {
+                    loadCallback = cb;
+                }
+            },
+            removeEventListener: noop,
+            status: 200,
+            statusText: 'OK',
+            getAllResponseHeaders: function () {
+                return '';
+            },
+            response: new ArrayBuffer(0),
+            open: noop,
+            setRequestHeader: noop,
+            withCredentials: false,
+            responseType: 'arraybuffer',
+            timeout: 10000,
+            send: function () {
+                setTimeout(loadCallback, 0);
+            }
+        };
+    };
+
+    beforeAll(function (done) {
+        fixtures.preloadAbsoluteUrls([
+            publicApiExecuteManyHTTPGetUrl
+        ], done);
+    });
+
+    it('can run many HTTP requests quickly when HTTP is resolved immediately', function (done) {
+        var Vireo = window.NationalInstruments.Vireo.Vireo;
+        var viaCode = fixtures.loadAbsoluteUrl(publicApiExecuteManyHTTPGetUrl);
+
+        var vireo = new Vireo();
+        vireo.httpClient.setXMLHttpRequestImplementation(XHRShimResolveImmediatelyAsync);
+        var result = '';
+        vireo.eggShell.setPrintFunction(function (text) {
+            result += text + '\n';
+        });
+
+        vireo.eggShell.loadVia(viaCode);
+        var maxExecWakeUpTime = vireo.eggShell.maxExecWakeUpTime();
+        var numIterations = 100;
+        vireo.eggShell.writeJSON('MyVI', 'numIterations', JSON.stringify(numIterations));
+
+        var maxTimewithBuffer = maxExecWakeUpTime * numIterations * 0.5;
+
+        var wakeupspy = jasmine.createSpy();
+        vireo.eggShell.setExecuteSlicesWakeupCallback(wakeupspy);
+
+        var startTime = performance.now();
+        vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
+            var totalTime = performance.now() - startTime;
+            expect(totalTime).toBeLessThan(maxTimewithBuffer);
+            expect(result).toBeEmptyString();
+            expect(wakeupspy.calls.count()).toBeGreaterThanOrEqualTo(numIterations);
+            done();
+        });
+    });
+
+    // it('can run many HTTP requests quickly when HTTP is resolved immediately', function (done) {
+    //     var Vireo = window.NationalInstruments.Vireo.Vireo;
+    //     var viaCode = fixtures.loadAbsoluteUrl(publicApiExecuteManyHTTPGetUrl);
+
+    //     var vireo = new Vireo();
+    //     vireo.httpClient.setXMLHttpRequestImplementation(XHRShimResolveImmediatelyAsync);
+    //     var result = '';
+    //     vireo.eggShell.setPrintFunction(function (text) {
+    //         result += text + '\n';
+    //     });
+
+    //     vireo.eggShell.loadVia(viaCode);
+    //     var maxExecWakeUpTime = vireo.eggShell.maxExecWakeUpTime();
+    //     var numIterations = 100;
+    //     vireo.eggShell.writeJSON('MyVI', 'numIterations', JSON.stringify(numIterations));
+
+    //     var maxTimewithBuffer = maxExecWakeUpTime * numIterations * 0.5;
+
+    //     var wakeupspy = jasmine.createSpy();
+    //     vireo.eggShell.setExecuteSlicesWakeupCallback(wakeupspy);
+
+    //     var startTime = performance.now();
+    //     vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
+    //         var totalTime = performance.now() - startTime;
+    //         expect(totalTime).toBeLessThan(maxTimewithBuffer);
+    //         expect(result).toBeEmptyString();
+    //         expect(wakeupspy.calls.count()).toBeGreaterThanOrEqualTo(numIterations);
+    //         done();
+    //     });
+    // });
+});

--- a/test-it/karma/utilities/TestHelpers.VireoRunner.js
+++ b/test-it/karma/utilities/TestHelpers.VireoRunner.js
@@ -42,7 +42,7 @@
             if (loadErrorOccurred) {
                 complete();
             } else {
-                vireo.eggShell.executeSlicesToCompletion(complete);
+                vireo.eggShell.executeSlicesUntilClumpsFinished(complete);
             }
         };
 

--- a/test-it/karma/utilities/TestHelpers.VireoRunner.js
+++ b/test-it/karma/utilities/TestHelpers.VireoRunner.js
@@ -24,24 +24,26 @@
             rawPrintError += text + '\n';
         });
 
-        var loadError = false;
+        var loadErrorOccurred = false;
         try {
             vireo.eggShell.loadVia(viaText);
         } catch (ex) {
-            console.log(ex);
-            loadError = true;
+            loadErrorOccurred = true;
         }
 
         var runSlicesAsync = function (cb) {
             // Jasmine Matchers library is not always ready in beforeAll so use jasmine core functions
             expect(typeof cb).toBe('function');
 
-            if (loadError) {
+            var complete = function () {
                 cb(rawPrint, rawPrintError);
-                return;
-            }
+            };
 
-            vireo.eggShell.executeSlicesToCompletion(cb);
+            if (loadErrorOccurred) {
+                complete();
+            } else {
+                vireo.eggShell.executeSlicesToCompletion(complete);
+            }
         };
 
         return runSlicesAsync;

--- a/test-it/karma/vtrsuite/VtrTestSuite.Test.js
+++ b/test-it/karma/vtrsuite/VtrTestSuite.Test.js
@@ -1,4 +1,4 @@
-describe('The Vireo VTR test suite', function () {
+fdescribe('The Vireo VTR test suite', function () {
     'use strict';
 
     // Reference aliases

--- a/test-it/karma/vtrsuite/VtrTestSuite.Test.js
+++ b/test-it/karma/vtrsuite/VtrTestSuite.Test.js
@@ -1,4 +1,4 @@
-fdescribe('The Vireo VTR test suite', function () {
+describe('The Vireo VTR test suite', function () {
     'use strict';
 
     // Reference aliases

--- a/test-it/test.js
+++ b/test-it/test.js
@@ -275,19 +275,8 @@
 
     // Setup the vireo.js runtime for instruction execution
     var setupVJS = function () {
-        var Vireo;
-
-        try {
-            Vireo = require('../');
-            vireo = new Vireo();
-        } catch (err) {
-            if (err.code === 'MODULE_NOT_FOUND') {
-                console.log('Error: vireo.js not found (Maybe build it first?)');
-                process.exit(1);
-            } else {
-                throw err;
-            }
-        }
+        var Vireo = require('../');
+        vireo = new Vireo();
     };
 
     // Testing functions for processing the tests against vireo.js or esh binary

--- a/test-it/test.js
+++ b/test-it/test.js
@@ -238,26 +238,29 @@
             testOutput = testOutput + text + '\n';
         });
 
-        if (viaCode !== '' && vireo.loadVia(viaCode) === 0) {
-            // TODO mraj because this is running synchronously we cannot do tests that rely on asynchronous results like http
-            // TODO spathiwa I think we can now...
-            var execVireo = function () {
-                var state;
-                while ((state = vireo.executeSlicesUntilWait(1000000)) !== 0) {
-                    var timeDelay = state > 0 ? state : 0;
-                    if (timeDelay > 0) {
-                        setTimeout(execVireo, timeDelay);
-                        break;
-                    }
-                }
-                if (state === 0) {
-                    testFinishedCB(testOutput);
-                }
-            };
-            execVireo(testFinishedCB);
-        } else {
+        try {
+            vireo.loadVia(viaCode);
+        } catch (ex) {
             testFinishedCB(testOutput);
+            return;
         }
+
+        // TODO mraj because this is running synchronously we cannot do tests that rely on asynchronous results like http
+        // TODO spathiwa I think we can now...
+        var execVireo = function () {
+            var state;
+            while ((state = vireo.executeSlicesUntilWait(1000000)) !== 0) {
+                var timeDelay = state > 0 ? state : 0;
+                if (timeDelay > 0) {
+                    setTimeout(execVireo, timeDelay);
+                    break;
+                }
+            }
+            if (state === 0) {
+                testFinishedCB(testOutput);
+            }
+        };
+        execVireo();
     };
 
     // Setup the esh binary for via execution

--- a/test-it/test.js
+++ b/test-it/test.js
@@ -246,9 +246,6 @@
             return;
         }
 
-        // TODO mraj because this is running synchronously we cannot do tests that rely on asynchronous results like http
-        // TODO spathiwa I think we can now...
-        // TODO mraj I think so too! Only thing left is deciding if we want an XHR polyfill available in the runner for http tests specifically...
         vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
             testFinishedCB(testOutput);
         });

--- a/test-it/test.js
+++ b/test-it/test.js
@@ -10,6 +10,7 @@
         jsdiff = require('diff'),
         path = require('path'),
         cp = require('child_process'),
+        xhr2 = require('xhr2'),
         vireo;
 
     var dots = false;
@@ -277,6 +278,7 @@
     var setupVJS = function () {
         var Vireo = require('../');
         vireo = new Vireo();
+        vireo.httpClient.setXMLHttpRequestImplementation(xhr2);
     };
 
     // Testing functions for processing the tests against vireo.js or esh binary

--- a/test-it/test.js
+++ b/test-it/test.js
@@ -235,7 +235,7 @@
         }
         var testOutput = '';
         vireo.eggShell.setPrintFunction(function (text) {
-            testOutput = testOutput + text + '\n';
+            testOutput += text + '\n';
         });
 
         try {

--- a/test-it/test.js
+++ b/test-it/test.js
@@ -10,7 +10,7 @@
         jsdiff = require('diff'),
         path = require('path'),
         cp = require('child_process'),
-        vireo = {};
+        vireo;
 
     var dots = false;
     var app = {};
@@ -217,7 +217,7 @@
     var RunVJSTest = function (testName, testFinishedCB) {
         var viaCode;
         var viaPath = 'ViaTests/' + testName;
-        vireo.reboot();
+        vireo.eggShell.reboot();
         try {
             viaCode = fs.readFileSync(viaPath).toString();
         } catch (e) {
@@ -234,12 +234,12 @@
             }
         }
         var testOutput = '';
-        vireo.setPrintFunction(function (text) {
+        vireo.eggShell.setPrintFunction(function (text) {
             testOutput = testOutput + text + '\n';
         });
 
         try {
-            vireo.loadVia(viaCode);
+            vireo.eggShell.loadVia(viaCode);
         } catch (ex) {
             testFinishedCB(testOutput);
             return;
@@ -249,7 +249,7 @@
         // TODO spathiwa I think we can now...
         var execVireo = function () {
             var state;
-            while ((state = vireo.executeSlicesUntilWait(1000000)) !== 0) {
+            while ((state = vireo.eggShell.executeSlicesUntilWait(1000000)) !== 0) {
                 var timeDelay = state > 0 ? state : 0;
                 if (timeDelay > 0) {
                     setTimeout(execVireo, timeDelay);
@@ -289,7 +289,7 @@
 
         try {
             Vireo = require('../');
-            vireo = new Vireo().eggShell;
+            vireo = new Vireo();
         } catch (err) {
             if (err.code === 'MODULE_NOT_FOUND') {
                 console.log('Error: vireo.js not found (Maybe build it first?)');

--- a/test-it/test.js
+++ b/test-it/test.js
@@ -247,20 +247,10 @@
 
         // TODO mraj because this is running synchronously we cannot do tests that rely on asynchronous results like http
         // TODO spathiwa I think we can now...
-        var execVireo = function () {
-            var state;
-            while ((state = vireo.eggShell.executeSlicesUntilWait(1000000)) !== 0) {
-                var timeDelay = state > 0 ? state : 0;
-                if (timeDelay > 0) {
-                    setTimeout(execVireo, timeDelay);
-                    break;
-                }
-            }
-            if (state === 0) {
-                testFinishedCB(testOutput);
-            }
-        };
-        execVireo();
+        // TODO mraj I think so too! Only thing left is deciding if we want an XHR polyfill available in the runner for http tests specifically...
+        vireo.eggShell.executeSlicesUntilClumpsFinished(function () {
+            testFinishedCB(testOutput);
+        });
     };
 
     // Setup the esh binary for via execution

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -31,6 +31,12 @@
                 "HttpHandles.via"
             ]
         },
+        "httpbin": {
+            "tests": [
+                "HttpBinGet.via",
+                "HttpBinPost.via"
+            ]
+        },
         "queue": {
             "tests": [
                 "QueueBug.via",


### PR DESCRIPTION
# JS API Changes

- Added `vireo.eggShell.maxExecWakeUpTime()` which returns the `kMaxExecWakeUpTime` value. Used by tests to parameterize expectations and may be valuable to advanced Vireo integrators (but just used for testing so far).

- Added `vireo.eggShell.setExecuteSlicesWakeUpCallback()` for a user to listen for wake-up events

- Added `vireo.eggShell.executeSlicesUntilClumpsFinished()` which runs Vireo async to completion

- Modified `vireo.eggShell.loadVia()` to throw on error instead of return a status code (almost no one except the karma and test.js test runners checked the status code amongst all the usages in Travis and TFS)

- Modified `vireo.httpClient.abortAllRunningRequests()` which was a per instance vireo method but incorrectly affected all running instances

- Added `vireo.httpClient.setXMLHttpRequestImplementation()` which allows a user to provide their own XHR Level 2 implementation per vireo instance. This is valuable in node.js to allow the user to provide an XHR implementation and during tests to simulate certain behaviors (ie quick network resolution, simulate network errors)

- Modified the Vireo loader script to provide a warning suggesting the need to compile Vireo when an exception occurs loading vireo.js

- Modified the default print behavior to perform console.log instead of console.debug. This is a better default as pretty much every user in TFS and Travis was overriding the default print to use console.log. It is also a better default as node.js does not support console.debug and Chrome 58+ started hiding console.debug messages.

- Fixed usage of HttpClient methods on node.js that include a body. The optimization was introduced to use Blobs and ArrayBuffers for XHR requests instead of converting to DOMStrings and was incompatible with node.js making not possible to use the HttpClient in node.js even with a hacked global polyfill. This change and added tests will help prevent breaking node.js in the future.

# Test Infrastructure Changes

- Modified test.js and esh.js to use the xhr2 node library to enable the HttpClient in the node.js environment

- Added two example HttpClient VTR tests and a new test group called httpbin to testList.json. This test group requires HttpBin to run locally and was enabled on both AppVeyor and Travis

# Version Recommendation

I think this should be a minor version bump. Most of the API changes are API additions or are modifications on uncommon code paths (it is uncommon to have good error checking for loadVia).