### PR TITLE
Add tox support for http bin

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,8 @@ install:
   - chocolatey install make
   - chocolatey install gnuwin32-coreutils.portable
   - npm install
-  - pip install --user -r requirements.txt
+  - pip install tox
+  - ps: Start-Process npm "run httpbin" -PassThru
   - git clone https://github.com/juj/emsdk.git
   - cd emsdk && git checkout b2ebcffbbbc2ba64d5697dc5c37fed530bafecda && cd ..
   - emsdk\emsdk install sdk-1.37.9-64bit
@@ -24,7 +25,6 @@ platform:
 configuration:
   - Debug
 before_build:
-  - ps: Start-Process npm "run httpbin" -PassThru
 # TODO capture standard out and error to log at the end?
 # TODO script needed to wait for server startup?
   - make lint

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ make-it/linktest
 make-it/compile.bat
 make-it/make.exe
 env/
+.tox/
 *.tgz
 coverage/
 emscripten-sdk/

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ before_install:
 - doxygen --version
 install:
 - npm install
-- pip install --user -r requirements.txt
+- pip install tox
+- nohup npm run httpbin &
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
 - if ! git clone --depth 1 https://github.com/ni-kismet/emscripten-sdk.git; then cd emscripten-sdk && git remote update -p && git merge --ff-only origin/master && cd ..; fi
 - emscripten-sdk/emsdk activate --build=Release sdk-master-64bit
@@ -33,7 +34,6 @@ install:
 - emcc -v
 - gcc -v
 before_script:
-- nohup npm run httpbin &
 - while ! nc -q 1 127.0.0.1 64526 </dev/null; do sleep 2; done
 - curl http://127.0.0.1:64526/get?show_env=1
 - make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 - doxygen --version
 install:
 - npm install
-- pip install tox
+- pip install --user tox
 - nohup npm run httpbin &
 - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
 - if ! git clone --depth 1 https://github.com/ni-kismet/emscripten-sdk.git; then cd emscripten-sdk && git remote update -p && git merge --ff-only origin/master && cd ..; fi

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ $ ./test.js -n -t rpi
 ## Running the HTTP test server
 
 ### Overview
-Vireo utilizes [httpbin](https://httpbin.org/) for testing the HTTP Client functionality. The tests rely on a locally running instance of the httpbin server to perform the tests. The test suite will skip tests (without failing) that rely on the httpbin server running locally if the server is not running. However, if you would like to run the HTTP client tests locally these instructions will help you get configured.
+Vireo utilizes [httpbin](https://httpbin.org/) for testing the HTTP Client functionality. The tests rely on a locally running instance of the httpbin server. The test suite will skip tests (without failing) that rely on the httpbin server running locally if the server is not running. However, if you would like to run the HTTP client tests locally these instructions will help you get configured.
 
 ### Requirements
 - Python 2.7.9 or later (primarily for pip availability)
@@ -150,17 +150,14 @@ Vireo utilizes [httpbin](https://httpbin.org/) for testing the HTTP Client funct
 
 ### Setup
 1. Ensure that python (correct version) and pip are available on the path
-2. From a command line in the VireoSDK directory or elsewhere do `pip install virtualenv` to globally install the [virtualenv](https://virtualenv.pypa.io/en/stable/) tool
-3. From a command line in the VireoSDK directory run `virtualenv env`. This will create a directory named `env` in the VireoSDK directory
-4. Depending on your platform activate the virtualenv `env` that was created. For Windows this means running the command `.\env\Scripts\activate` from the VireoSDK directory.
-5. With the env activated you can now install httpbin using the command `npm run httpbin-install` for the VireoSDK directory
+2. From a command line in the VireoSDK directory or elsewhere do `pip install tox` to globally install the [tox](http://tox.readthedocs.io/en/latest/) tool
 
 ### Starting the Server
 1. Open a command prompt in the VireoSDK directory
-2. On Windows you can execute `npm run httpbin-win` to start the httpbin server in a new window. The command will start a virtualenv for you based on the `env` directory on the windows platform.
-3. With the server running in a new window now you can run the tests that rely on the HTTP client (ie `npm run karma`)
+2. Run the `npm run httpbin` command. This will install dependencies of httpbin if necessary and start the httpbin server locally.
 
-If you used a different name for the virtualenv directory or are running on a different platform you can reference the `httpbin` script in package.json to see how the httpbin server is launched (port configuration, etc) 
+   Note: On Windows you can alternatively execute `npm run httpbin-start` to start the httpbin server in a new console window.
+3. With the server running in a new window now you can run the tests that rely on the HTTP client (ie `npm run karma` and `make testhttpbin`)
 
 # Updating Vireo Documentation
 We are using the [Doxygen](http://www.stack.nl/~dimitri/doxygen/) tool to generate our documentation. The tool allows to annotate our source code and generate documents from there. We are currently using version *1.8.6*.
@@ -179,4 +176,3 @@ The main html file in the `gh-pages` is called: index.html
 
 # Legal
 Features beyond that core set, that can be accessed directly from VIA source written by hand, should be considered experimental, and subject to change at any time. A complete list of disclaimers and terms is described in LICENSE.txt
-

--- a/package.json
+++ b/package.json
@@ -34,10 +34,9 @@
     "karma-coverage": "karma start karma.coverage.conf.js",
     "karma-chrome": "karma start --single-run --browsers Chrome --skip-tags Slow",
     "karma-phantomjs-debug": "karma start --single-run --browsers PhantomJS_Debug",
-    "prehttpbin-install": "python -V && pip -V && virtualenv --version",
-    "httpbin-install": "pip install --require-virtualenv -r requirements.txt",
-    "httpbin": "python -m httpbin.core --port 64526 --host 0.0.0.0",
-    "httpbin-win": "start cmd /c \"env\\Scripts\\activate && npm run httpbin\"",
+    "prehttpbin": "python -V && pip -V && virtualenv --version && tox --version",
+    "httpbin": "tox",
+    "httpbin-start": "start cmd /c npm run httpbin",
     "doxygen": "cd source && doxygen",
     "postdoxygen": "shx cp \"Documents/DocumentsRoot/.*\" \"Documents/DocumentsRoot/*\" gh-pages"
   },

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+skipsdist = True
+
+[testenv]
+deps = -rrequirements.txt
+commands=python -m httpbin.core --port 64526 --host 0.0.0.0


### PR DESCRIPTION
Added a tox.ini for setting up httpbin. Allows users to have a non-global httpbin install in a cross-platform manner much easier.