### PR TITLE
Allow providing a custom module object

### DIFF
--- a/source/core/vireo.loader.js
+++ b/source/core/vireo.loader.js
@@ -49,10 +49,19 @@
     var moduleBuilders = Array.prototype.slice.call(arguments, 1);
 
     // Vireo Class
-    var Vireo = function () {
+    var Vireo = function (config) {
         var that = this;
 
-        var Module = {};
+        var isObject = function (obj) {
+            return typeof obj === 'object' && obj !== null;
+        };
+
+        var Module;
+        if (isObject(config) && isObject(config.customModule)) {
+            Module = config.customModule;
+        } else {
+            Module = {};
+        }
 
         // Functions that must be on Module prior to construction
         var ttyout = [];

--- a/test-it/karma/publicapi/VireoConstructor.Test.js
+++ b/test-it/karma/publicapi/VireoConstructor.Test.js
@@ -1,0 +1,21 @@
+describe('The Vireo constructor', function () {
+    'use strict';
+
+    it('can execute without parameters and creates a default 16 MB Heap', function () {
+        var Vireo = window.NationalInstruments.Vireo.Vireo;
+        var vireo = new Vireo();
+        var heapLength = vireo.eggShell.internal_module_do_not_use_or_you_will_be_fired.HEAP8.length;
+        expect(heapLength).toBe(16 * 1024 * 1024);
+    });
+
+    it('can execute with a custom module to create a 32 MB Heap', function () {
+        var Vireo = window.NationalInstruments.Vireo.Vireo;
+        var vireo = new Vireo({
+            customModule: {
+                TOTAL_MEMORY: 32 * 1024 * 1024
+            }
+        });
+        var heapLength = vireo.eggShell.internal_module_do_not_use_or_you_will_be_fired.HEAP8.length;
+        expect(heapLength).toBe(32 * 1024 * 1024);
+    });
+});


### PR DESCRIPTION
Enables a user to provide a [module object](https://kripken.github.io/emscripten-site/docs/api_reference/module.html) and set some settings like [TOTAL_MEMORY](https://github.com/kripken/emscripten/blob/38eb8983f4a5659728557f9e07a8a84a20c01bb0/src/settings.js#L59).