### PR TITLE
Fix to handle data values for optional arguments.

### DIFF
--- a/source/core/NumericString.cpp
+++ b/source/core/NumericString.cpp
@@ -1890,7 +1890,7 @@ static void MakeFormatString(StringRef format, ErrorCluster *error, Int32 argCou
             break;
         }
     }
-    if (error && !error->status) {
+    if (!error || !error->status) {
         int len = format->Length();
         if (len > 0) {
             format->Remove1D(len - 1, 1);
@@ -1915,7 +1915,10 @@ struct StringScanParamBlock : public VarArgInstruction
 VIREO_FUNCTION_SIGNATUREV(StringScan, StringScanParamBlock)
 {
     SubString input = _Param(StringInput)->MakeSubStringAlias();
-    SubString format = _Param(StringFormat)->MakeSubStringAlias();
+    SubString format;
+    if (_ParamPointer(StringFormat)) {
+        format = _Param(StringFormat)->MakeSubStringAlias();
+    }
     input.AliasAssign(input.Begin() + _Param(InitialPos), input.End());
     UInt32 newOffset = _Param(InitialPos);
     StaticTypeAndData *arguments =  _ParamImmediate(argument1);

--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -2400,7 +2400,14 @@ VIREO_FUNCTION_SIGNATURE4(FromString, StringRef, StaticType, void, StringRef)
     TypeRef type = _ParamPointer(1);
 
     SubString str = _Param(0)->MakeSubStringAlias();
-    EventLog log(_Param(3));
+
+    StringRef strRef;
+    if (_ParamPointer(3)) {
+        strRef = _Param(3);
+    } else {
+        strRef = EventLog::DevNull;
+    }
+    EventLog log(strRef);
 
     TDViaParser parser(THREAD_TADM(), &str, &log, 1);
     parser._loadVIsImmediately = true;

--- a/source/core/VirtualInstrument.cpp
+++ b/source/core/VirtualInstrument.cpp
@@ -531,18 +531,8 @@ void ClumpParseState::ResolveActualArgument(SubString* argument, void** ppData, 
     // See if actual argument is '*' meaning use the default/unwired behavior.
     if (argument->CompareCStr(tsWildCard)) {
         _actualArgumentType = FormalParameterType();
-        if (!_actualArgumentType->IsFlat()) {
-            // Define a DefaultValue type. As a DV it will never merge to another instance.
-            // Since it has no name it cannot be looked up, but it will be freed once the TADM/ExecutionContext is freed up.
-            DefaultValueType *cdt = DefaultValueType::New(_clump->TheTypeManager(), _actualArgumentType, false);
-            cdt = cdt->FinalizeDVT();
-            if (needsAddress) {
-                *ppData = (AQBlock1*)cdt->Begin(kPARead);  // * passed as a param means null
-            }
-        } else {
-            // For flat data, the call instruction logic for VIs will initialize the callee parameter
-            // to the default value. For native instructions a null parameter value is passed.
-        }
+        // Regardless of whether the optional argument is flat or not, do not allocate data value
+        // and use null-pointer and let the prims handle the optional arguments correctly
         _argumentState = kArgumentResolvedToDefault;
         return;
     }

--- a/test-it/ExpectedResults/WildCardArgumentsSubVICalls.vtr
+++ b/test-it/ExpectedResults/WildCardArgumentsSubVICalls.vtr
@@ -1,0 +1,18 @@
+------- SubVI_Input -------------
+inputString = xxxxx inputInt=88888
+str1 = aaaaa, int1 = 11111
+inputString = aaaaa inputInt=11111
+str1 = aaaaa, int1 = 11111
+inputString = xxxxx inputInt=88888
+------- SubVI_Output -------------
+outputString = xxxxx outputInt=88888
+str1 = aaaaa, int1 = 11111
+outputString = xxxxx outputInt=88888
+str1 = yyyyy, int1 = 99999
+outputString = xxxxx outputInt=88888
+------- SubVI_InputOutput -------------
+ioString = xxxxx ioInt=88888
+str1 = aaaaa, int1 = 11111
+ioString = xxxxx ioInt=88888
+str1 = yyyyy, int1 = 99999
+ioString = xxxxx ioInt=88888

--- a/test-it/ExpectedResults/WildcardArguments.vtr
+++ b/test-it/ExpectedResults/WildcardArguments.vtr
@@ -1,0 +1,4 @@
+String=[] Scanned Value=[0]
+String=[1] Scanned Value=[1]
+String=[] Scanned Value=[0]
+String=[1] Scanned Value=[1]

--- a/test-it/ExpectedResults/WildcardArguments.vtr
+++ b/test-it/ExpectedResults/WildcardArguments.vtr
@@ -2,3 +2,4 @@ String=[] Scanned Value=[0]
 String=[1] Scanned Value=[1]
 String=[] Scanned Value=[0]
 String=[1] Scanned Value=[1]
+Timestamps equal = false

--- a/test-it/ViaTests/InlineConstants.via
+++ b/test-it/ViaTests/InlineConstants.via
@@ -21,7 +21,7 @@ define(HelloWorld dv(.VirtualInstrument (
         it need to be escaped. How.
 */
 
-        StringToUpper(* str)
+        StringToUpper(str str)
         Printf("passing default value <%s>\n" str)
         StringToUpper("Hello, World" str)
         Printf("passing inline double quoted constant value <%s>\n" str)

--- a/test-it/ViaTests/WildCardArgumentsSubVICalls.via
+++ b/test-it/ViaTests/WildCardArgumentsSubVICalls.via
@@ -1,0 +1,85 @@
+define (g0 dv(.String 'aaaaa'))
+define (g1 dv(.String 'bbbbb'))
+define (c2 dv(.UInt32 0))
+define (c3 dv(.Int32 0))
+//---------------------------------------------------
+define (TopLevelVI dv(.VirtualInstrument (
+    Locals: c(   // Data Space1
+        e(dv(.String 'aaaaa') str1)
+        e(dv(.String 'bbbbb') str2)
+        e(dv(.Int32 11111) int1)
+        e(dv(.Int32 22222) int2)
+    )
+        clump(1
+           Printf("------- SubVI_Input -------------\n")
+           SubVI_Input(* *)
+           Printf("str1 = %s, int1 = %d\n" str1 int1)
+           SubVI_Input(str1 int1)
+           Printf("str1 = %s, int1 = %d\n" str1 int1)
+           SubVI_Input(* *)
+           Printf("------- SubVI_Output -------------\n")
+           SubVI_Output(* *)
+           Printf("str1 = %s, int1 = %d\n" str1 int1)
+           SubVI_Output(str1 int1)
+           Printf("str1 = %s, int1 = %d\n" str1 int1)
+           SubVI_Output(* *)
+           Printf("------- SubVI_InputOutput -------------\n")
+           Copy('aaaaa' str1)
+           Copy(11111 int1)
+           SubVI_InputOutput(* *)
+           Printf("str1 = %s, int1 = %d\n" str1 int1)
+           SubVI_InputOutput(str1 int1)
+           Printf("str1 = %s, int1 = %d\n" str1 int1)
+           SubVI_InputOutput(* *)
+/* Clump Ended. */    )
+)))
+
+define (SubVI_Input dv(.VirtualInstrument (
+    Params: c(  //param block
+        i(dv(.String 'xxxxx')inputString)
+        i(dv(.Int32 88888)inputInt)
+    )
+    Locals: c(   // Data Space1
+        e(.String local18)
+        e(.ErrorCluster local28)
+    )
+        clump(1
+        Printf("inputString = %s inputInt=%d\n" inputString inputInt)
+        Copy('yyyyy' inputString)
+        Copy(99999 inputInt)
+/* Clump Ended. */    )
+)))
+
+define (SubVI_Output dv(.VirtualInstrument (
+    Params: c(  //param block
+        o(dv(.String 'xxxxx')outputString)
+        o(dv(.Int32 88888)outputInt)
+    )
+    Locals: c(   // Data Space1
+        e(.String local18)
+        e(.ErrorCluster local28)
+    )
+        clump(1
+        Printf("outputString = %s outputInt=%d\n" outputString outputInt)
+        Copy('yyyyy' outputString)
+        Copy(99999 outputInt)
+/* Clump Ended. */    )
+)))
+
+define (SubVI_InputOutput dv(.VirtualInstrument (
+    Params: c(  //param block
+        io(dv(.String 'xxxxx')ioString)
+        io(dv(.Int32 88888)ioInt)
+    )
+    Locals: c(   // Data Space1
+        e(.String local18)
+        e(.ErrorCluster local28)
+    )
+        clump(1
+        Printf("ioString = %s ioInt=%d\n" ioString ioInt)
+        Copy('yyyyy' ioString)
+        Copy(99999 ioInt)
+/* Clump Ended. */    )
+)))
+enqueue (TopLevelVI)
+//Finished!! :D

--- a/test-it/ViaTests/WildcardArguments.via
+++ b/test-it/ViaTests/WildcardArguments.via
@@ -2,6 +2,7 @@ define (g0 dv(.String ''))
 define (g1 dv(.String '1'))
 define (c2 dv(.UInt32 0))
 define (c3 dv(.Int32 0))
+define (g26 dv(.String '%.3c'))
 //---------------------------------------------------
 define (TopLevelVI dv(.VirtualInstrument (
     Locals: c(   // Data Space1
@@ -13,8 +14,15 @@ define (TopLevelVI dv(.VirtualInstrument (
         e(.UInt32 local21)
         e(.Int32 local24)
         e(.Int32 local25)
+        e(dv(.String '')dateTimeStr1)
+        e(dv(.String '')dateTimeStr2)
+        e(dv(.Boolean true)isEqual)
     )
         clump(1
+           // Test non-flat datatype
+           // Error input is made an optional argument. First call to StringScan causes an error.
+           // Second call to StringScan must see the input unwired optional error argument as no error.
+           // The test ensures that a data value is not allocated for error argument and reused by Vireo.
            Copy(c3 local24)
            StringScan(g0 local20 local19 c2 local21 * local24)
            Printf("String=[%s] Scanned Value=[%d]\n" g0 local24)
@@ -25,6 +33,16 @@ define (TopLevelVI dv(.VirtualInstrument (
            SubVI1(g1 local_2)
            Printf("String=[%s] Scanned Value=[%d]\n" g0 local_1)
            Printf("String=[%s] Scanned Value=[%d]\n" g1 local_2)
+
+           // Test flat datatype
+           // If timestamp (flat) argument is made optional argument, FormatDateTimeString uses current timestamp.
+           // Make sure timestamps are different when called second time after a wait to ensure a data value is not allocated
+           // and reused by Vireo.
+           FormatDateTimeString(dateTimeStr1 g26 * true )
+           WaitMilliseconds(1005)
+           FormatDateTimeString(dateTimeStr2 g26 * true )
+           IsEQ(dateTimeStr1 dateTimeStr2 isEqual)
+           Printf("Timestamps equal = %z\n" isEqual)
 
 /* Clump Ended. */    )
 )))

--- a/test-it/ViaTests/WildcardArguments.via
+++ b/test-it/ViaTests/WildcardArguments.via
@@ -1,0 +1,54 @@
+define (g0 dv(.String ''))
+define (g1 dv(.String '1'))
+define (c2 dv(.UInt32 0))
+define (c3 dv(.Int32 0))
+//---------------------------------------------------
+define (TopLevelVI dv(.VirtualInstrument (
+    Locals: c(   // Data Space1
+        e(.Int32 local_1)
+        e(.Int32 local_2)
+        e(.String local18)
+        e(.String local19)
+        e(.String local20)
+        e(.UInt32 local21)
+        e(.Int32 local24)
+        e(.Int32 local25)
+    )
+        clump(1
+           Copy(c3 local24)
+           StringScan(g0 local20 local19 c2 local21 * local24)
+           Printf("String=[%s] Scanned Value=[%d]\n" g0 local24)
+           Copy(c3 local24)
+           StringScan(g1 local20 local19 c2 local21 * local24)
+           Printf("String=[%s] Scanned Value=[%d]\n" g1 local24)
+           SubVI1(g0 local_1)
+           SubVI1(g1 local_2)
+           Printf("String=[%s] Scanned Value=[%d]\n" g0 local_1)
+           Printf("String=[%s] Scanned Value=[%d]\n" g1 local_2)
+
+/* Clump Ended. */    )
+)))
+
+//---------------------------------------------------
+define (SubVI1 dv(.VirtualInstrument (
+    Params: c(  //param block
+        i(dv(.String '')dataItem_InputString)
+        o(dv(.Int32 0)dataItem_Value)
+    )
+    Locals: c(   // Data Space1
+        e(.String local18)
+        e(.String local19)
+        e(.String local20)
+        e(.UInt32 local21)
+        e(.Int32 local24)
+        e(.Int32 local25)
+    )
+        clump(1
+        Copy(dataItem_InputString local18)
+        Copy(c3 local24)
+        StringScan(local18 local20 local19 c2 local21 * local24 )
+        Copy(local24 dataItem_Value)
+/* Clump Ended. */    )
+)))
+enqueue (TopLevelVI)
+//Finished!! :D

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -366,6 +366,7 @@
                 "Waveform.via",
                 "WaveformAnalogBuildMissingArgs.via",
                 "WildcardArguments.via",
+                "WildCardArgumentsSubVICalls.via",
                 "ZDACrash1.via"
             ]
         }

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -365,6 +365,7 @@
                 "WaitUntilMultiple.via",
                 "Waveform.via",
                 "WaveformAnalogBuildMissingArgs.via",
+                "WildcardArguments.via",
                 "ZDACrash1.via"
             ]
         }


### PR DESCRIPTION
The existing code in ClumpParseState::ResolveActualArgument created a null
pointer for optional arguments for flat types but created a new value for
non-flat types. This was incorrect because the value for this optional
argument (though not explicit in the VIA code) is reused for subsequent
calls. (Almost) All the primitives explicitly handle correctly whether an
optional parameter is null by checking the pointer and using the correct
default value if null regardless of whether the type of the argument is
flat or not. Thus this method is fixed to treat flat and non-flat types
same and not allocate data value for optional arguments.

Add a test (WildcardArguments.via)

Some primitives such as StringFormat, FormatDateTimeString are the
exceptions that did not handle the optional arguments and they are fixed
to do so.

A memory overrun in StringScan is fixed by using AliasAssignCStrLen.

Fix InlineConstants.via to not use first argument as optional argument any
more as it is not anymore.