### PR TITLE
Spit STDERR also to console from test runner.

### DIFF
--- a/Vireo_VS/VireoCommandLine.vcxproj
+++ b/Vireo_VS/VireoCommandLine.vcxproj
@@ -127,7 +127,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>VIREO_STDIO;VIREO_FILESYSTEM;VIREO_FILESYSTEM_DIRLIST;WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>VIREO_USING_ASSERTS;VIREO_STDIO;VIREO_FILESYSTEM;VIREO_FILESYSTEM_DIRLIST;WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)/../source/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/test-it/test.js
+++ b/test-it/test.js
@@ -266,7 +266,7 @@
         } catch (e) {
             // If Vireo detects an error it will return non zero
             // and exec will throw an exception, so catch the results.
-            newResults = e.stdout.toString();
+            newResults = e.stdout.toString() + e.stderr.toString();
         }
         testFinishedCB(newResults);
     };


### PR DESCRIPTION
Spit STDERR to console from test runner to force test failures due to
exceptions and asserts.
Turn on ASSEERTS in Visual Studio Debug builds