### PR TITLE
Implement Control References

### DIFF
--- a/Vireo_VS/VireoCommandLine.vcxproj
+++ b/Vireo_VS/VireoCommandLine.vcxproj
@@ -15,6 +15,7 @@
     <ClCompile Include="..\source\core\Array.cpp" />
     <ClCompile Include="..\source\core\Assert.cpp" />
     <ClCompile Include="..\source\core\CEntryPoints.cpp" />
+    <ClCompile Include="..\source\core\ControlRef.cpp" />
     <ClCompile Include="..\source\core\DataQueue.cpp" />
     <ClCompile Include="..\source\core\Date.cpp" />
     <ClCompile Include="..\source\core\EventLog.cpp" />
@@ -64,6 +65,7 @@
     <ClInclude Include="..\source\include\Array.h" />
     <ClInclude Include="..\source\include\BuildConfig.h" />
     <ClInclude Include="..\source\include\CEntryPoints.h" />
+    <ClInclude Include="..\source\include\ControlRef.h" />
     <ClInclude Include="..\source\include\DataTypes.h" />
     <ClInclude Include="..\source\include\Date.h" />
     <ClInclude Include="..\source\include\EventLog.h" />

--- a/Vireo_VS/VireoCommandLine.vcxproj.filters
+++ b/Vireo_VS/VireoCommandLine.vcxproj.filters
@@ -34,6 +34,9 @@
     <ClCompile Include="..\source\core\CEntryPoints.cpp">
       <Filter>VireoSource\Core</Filter>
     </ClCompile>
+    <ClCompile Include="..\source\core\ControlRef.cpp">
+      <Filter>VireoSource\Core</Filter>
+    </ClCompile>
     <ClCompile Include="..\source\core\DataQueue.cpp">
       <Filter>VireoSource\Core</Filter>
     </ClCompile>
@@ -162,6 +165,9 @@
       <Filter>VireoSource\Include</Filter>
     </ClInclude>
     <ClInclude Include="..\source\include\CEntryPoints.h">
+      <Filter>VireoSource\Include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\include\ControlRef.h">
       <Filter>VireoSource\Include</Filter>
     </ClInclude>
     <ClInclude Include="..\source\include\DataTypes.h">

--- a/Vireo_Xcode/VireoEggShell.xcodeproj/project.pbxproj
+++ b/Vireo_Xcode/VireoEggShell.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		444C468C1E26D73C0037FA98 /* RefNum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 444C468B1E26D73C0037FA98 /* RefNum.cpp */; };
 		444C46901E299A390037FA98 /* RefNumTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 444C468F1E299A390037FA98 /* RefNumTest.cpp */; };
 		444C46931E2D70AB0037FA98 /* UnitTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 444C46921E2D70AB0037FA98 /* UnitTest.cpp */; };
+		446506D8206AC83700B0CD8E /* JavaScriptInvoke.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 446506D3206AC83600B0CD8E /* JavaScriptInvoke.cpp */; };
+		446506D9206AC83700B0CD8E /* PropertyNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 446506D7206AC83700B0CD8E /* PropertyNode.cpp */; };
+		446506DC206ACCCA00B0CD8E /* ControlRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 446506DB206ACCCA00B0CD8E /* ControlRef.cpp */; };
 		4466C7991E4F08EE004B5E31 /* MatchPat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4466C7971E4F08EE004B5E31 /* MatchPat.cpp */; };
 		4466C79A1E4F08EE004B5E31 /* Waveform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4466C7981E4F08EE004B5E31 /* Waveform.cpp */; };
 		44B71BD31EC65368008683F6 /* WebSocketClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 44B71BD21EC65368008683F6 /* WebSocketClient.cpp */; };
@@ -252,6 +255,14 @@
 		444C468F1E299A390037FA98 /* RefNumTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RefNumTest.cpp; path = ../source/unittest/RefNumTest.cpp; sourceTree = "<group>"; };
 		444C46911E2D69ED0037FA98 /* UnitTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UnitTest.h; path = include/UnitTest.h; sourceTree = "<group>"; };
 		444C46921E2D70AB0037FA98 /* UnitTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UnitTest.cpp; path = core/UnitTest.cpp; sourceTree = "<group>"; };
+		446506D2206AC83600B0CD8E /* library_javaScriptInvoke.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = library_javaScriptInvoke.js; path = ../source/io/library_javaScriptInvoke.js; sourceTree = "<group>"; };
+		446506D3206AC83600B0CD8E /* JavaScriptInvoke.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = JavaScriptInvoke.cpp; path = ../source/io/JavaScriptInvoke.cpp; sourceTree = "<group>"; };
+		446506D4206AC83600B0CD8E /* module_propertyNode.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = module_propertyNode.js; path = ../source/io/module_propertyNode.js; sourceTree = "<group>"; };
+		446506D5206AC83600B0CD8E /* module_javaScriptInvoke.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = module_javaScriptInvoke.js; path = ../source/io/module_javaScriptInvoke.js; sourceTree = "<group>"; };
+		446506D6206AC83600B0CD8E /* library_propertyNode.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = library_propertyNode.js; path = ../source/io/library_propertyNode.js; sourceTree = "<group>"; };
+		446506D7206AC83700B0CD8E /* PropertyNode.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PropertyNode.cpp; path = ../source/io/PropertyNode.cpp; sourceTree = "<group>"; };
+		446506DA206ACB3400B0CD8E /* ControlRef.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ControlRef.h; path = include/ControlRef.h; sourceTree = "<group>"; };
+		446506DB206ACCCA00B0CD8E /* ControlRef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ControlRef.cpp; path = core/ControlRef.cpp; sourceTree = "<group>"; };
 		4466C7971E4F08EE004B5E31 /* MatchPat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MatchPat.cpp; path = core/MatchPat.cpp; sourceTree = "<group>"; };
 		4466C7981E4F08EE004B5E31 /* Waveform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Waveform.cpp; path = core/Waveform.cpp; sourceTree = "<group>"; };
 		4466C79B1E4FEDFB004B5E31 /* Waveform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Waveform.h; path = include/Waveform.h; sourceTree = "<group>"; };
@@ -762,6 +773,8 @@
 		475F6F0117C3E70900285242 /* IO */ = {
 			isa = PBXGroup;
 			children = (
+				446506D3206AC83600B0CD8E /* JavaScriptInvoke.cpp */,
+				446506D7206AC83700B0CD8E /* PropertyNode.cpp */,
 				4786297D1927064300141666 /* Canvas2d.cpp */,
 				472A078F1AA67EF8008109FA /* DebugGPIO.cpp */,
 				472B7BE717D0E1FC00201196 /* FileIO.cpp */,
@@ -774,6 +787,10 @@
 				44C295D61F8C037A001877B4 /* module_httpClient.js */,
 				44C295D71F8C037A001877B4 /* module_other.js */,
 				44C295D81F8C037A001877B4 /* module_webSocketClient.js */,
+				446506D2206AC83600B0CD8E /* library_javaScriptInvoke.js */,
+				446506D6206AC83600B0CD8E /* library_propertyNode.js */,
+				446506D5206AC83600B0CD8E /* module_javaScriptInvoke.js */,
+				446506D4206AC83600B0CD8E /* module_propertyNode.js */,
 			);
 			name = IO;
 			sourceTree = "<group>";
@@ -832,6 +849,7 @@
 				47D84DD317C2A271009053DB /* Array.cpp */,
 				47E220B01950C1F700988185 /* Assert.cpp */,
 				47D84DD417C2A271009053DB /* CEntryPoints.cpp */,
+				446506DB206ACCCA00B0CD8E /* ControlRef.cpp */,
 				444C46821E1C5A540037FA98 /* Date.cpp */,
 				472B24CF180F0FEB00C08186 /* GenericFunctions.cpp */,
 				470F626B1886F53F003146BF /* EventLog.cpp */,
@@ -875,6 +893,7 @@
 				47B76CD71B28DACA0083AEEB /* Platform.h */,
 				475DCFA918654336003810C0 /* ConversionTable.def */,
 				4797A38E1862265B00E643D7 /* CEntryPoints.h */,
+				446506DA206ACB3400B0CD8E /* ControlRef.h */,
 				47D84DC417C2A258009053DB /* BuildConfig.h */,
 				47D84DC917C2A258009053DB /* DataTypes.h */,
 				470F626A1886F522003146BF /* EventLog.h */,
@@ -1122,6 +1141,7 @@
 				47D84DF417C2A271009053DB /* Thread.cpp in Sources */,
 				47D84DF517C2A271009053DB /* Queue.cpp in Sources */,
 				47D84DF617C2A271009053DB /* String.cpp in Sources */,
+				446506D9206AC83700B0CD8E /* PropertyNode.cpp in Sources */,
 				444C46901E299A390037FA98 /* RefNumTest.cpp in Sources */,
 				47D84DF717C2A271009053DB /* StringUtilities.cpp in Sources */,
 				444C468C1E26D73C0037FA98 /* RefNum.cpp in Sources */,
@@ -1141,9 +1161,11 @@
 				4466C79A1E4F08EE004B5E31 /* Waveform.cpp in Sources */,
 				47B76CD91B28DB090083AEEB /* Platform.cpp in Sources */,
 				472A07901AA67EF8008109FA /* DebugGPIO.cpp in Sources */,
+				446506D8206AC83700B0CD8E /* JavaScriptInvoke.cpp in Sources */,
 				47E220B11950C1F700988185 /* Assert.cpp in Sources */,
 				470F626C1886F53F003146BF /* EventLog.cpp in Sources */,
 				4786297E19270C9900141666 /* Canvas2d.cpp in Sources */,
+				446506DC206ACCCA00B0CD8E /* ControlRef.cpp in Sources */,
 				4744A9DD1818594D00E1F7D9 /* TypeDefiner.cpp in Sources */,
 				47C554E418452E4A001DDC46 /* TDCodecLVFlat.cpp in Sources */,
 			);

--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -141,6 +141,7 @@ EM_EXPORTS = -s EXPORTED_FUNCTIONS="[\
 EM_BC_FILES=$(OBJS)/Array.bc\
 	$(OBJS)/Assert.bc\
 	$(OBJS)/CEntryPoints.bc\
+	$(OBJS)/ControlRef.bc\
 	$(OBJS)/EventLog.bc\
 	$(OBJS)/Events.bc\
 	$(OBJS)/ExecutionContext.bc\

--- a/make-it/Makefile
+++ b/make-it/Makefile
@@ -12,7 +12,7 @@ OUTPUT_EXE=$(OUTPUT_DIR)/esh
 OUTPUT_TEST_EXE=$(OUTPUT_DIR)/esh-test
 
 COMMANDLINE = main.cpp
-CORE = Array.cpp Assert.cpp CEntryPoints.cpp Date.cpp EventLog.cpp Events.cpp ExecutionContext.cpp GenericFunctions.cpp MatchPat.cpp Math.cpp NumericString.cpp Platform.cpp Queue.cpp RefNum.cpp String.cpp StringUtilities.cpp Synchronization.cpp TDCodecLVFlat.cpp TDCodecVia.cpp Thread.cpp TimeFunctions.cpp Timestamp.cpp TypeAndDataManager.cpp TypeAndDataReflection.cpp TypeDefiner.cpp TypeTemplates.cpp UnitTest.cpp VirtualInstrument.cpp Waveform.cpp
+CORE = Array.cpp Assert.cpp CEntryPoints.cpp ControlRef.cpp Date.cpp EventLog.cpp Events.cpp ExecutionContext.cpp GenericFunctions.cpp MatchPat.cpp Math.cpp NumericString.cpp Platform.cpp Queue.cpp RefNum.cpp String.cpp StringUtilities.cpp Synchronization.cpp TDCodecLVFlat.cpp TDCodecVia.cpp Thread.cpp TimeFunctions.cpp Timestamp.cpp TypeAndDataManager.cpp TypeAndDataReflection.cpp TypeDefiner.cpp TypeTemplates.cpp UnitTest.cpp VirtualInstrument.cpp Waveform.cpp
 UNITTEST = RefNumTest.cpp
 IO = FileIO.cpp Canvas2d.cpp DebugGPIO.cpp HttpClient.cpp WebSocketClient.cpp JavaScriptInvoke.cpp PropertyNode.cpp
 

--- a/source/core/ControlRef.cpp
+++ b/source/core/ControlRef.cpp
@@ -1,0 +1,34 @@
+
+/**
+
+ Copyright (c) 2018 National Instruments Corp.
+
+ This software is subject to the terms described in the LICENSE.TXT file
+
+ SDG
+ */
+
+/*! \file
+ \brief Control reference management
+ */
+
+#include "TypeDefiner.h"
+#include "ExecutionContext.h"
+#include "VirtualInstrument.h"
+#include "RefNum.h"
+#include "ControlRef.h"
+
+namespace Vireo {
+
+ControlRefNumManager ControlRefNumManager::_s_singleton;
+
+//------------------------------------------------------------
+DEFINE_VIREO_BEGIN(ControlRefs)
+    DEFINE_VIREO_REQUIRE(VirtualInstrument)
+
+    DEFINE_VIREO_TYPE(ControlRefNumInfo, "c(e(VirtualInstrument vi) e(String controlTag))")
+    DEFINE_VIREO_TYPE(ControlRefNum, "refnum(ControlRefNumInfo)")
+
+DEFINE_VIREO_END()
+}  // namespace Vireo
+

--- a/source/core/ControlRef.cpp
+++ b/source/core/ControlRef.cpp
@@ -47,33 +47,33 @@ ControlRefNumManager ControlRefNumManager::_s_singleton;
 
 // ControlReferenceDestroy -- deallocate control ref
 // (The VI and string tag are weak references into the owning VI, so do not have to be deallocated.)
-NIError ControlReferenceDestroy(RefNum refnum) {
+NIError ControlReferenceDestroy(ControlRefNum refnum) {
     return ControlRefNumManager::RefNumStorage().DisposeRefNum(refnum, NULL);
 }
 
 // Clean-up Proc, run when top level VI finishes, disposing control reference.
 static void CleanUpControlReference(intptr_t arg) {
-    RefNum refnum = RefNum(arg);
+    ControlRefNum refnum = ControlRefNum(arg);
     ControlReferenceDestroy(refnum);
 }
 
 // ControlReferenceCreate -- create a control ref linked to control associated with controlTag on given VI.
-RefNum ControlReferenceCreate(VirtualInstrument *vi, const SubString &controlTag) {
+ControlRefNum ControlReferenceCreate(VirtualInstrument *vi, const SubString &controlTag) {
     ControlRefInfo controlRefInfo(vi, controlTag);
-    RefNum refnum = ControlRefNumManager::RefNumStorage().NewRefNum(&controlRefInfo);
+    ControlRefNum refnum = ControlRefNumManager::RefNumStorage().NewRefNum(&controlRefInfo);
 
     ControlRefNumManager::AddCleanupProc(null, CleanUpControlReference, refnum);
     return refnum;
 }
 
 // ControlReferenceCreate -- RefNumVal version
-RefNum ControlReferenceCreate(RefNumVal *pRefNumVal, VirtualInstrument *vi, const SubString &controlTag) {
-    RefNum refnum = ControlReferenceCreate(vi, controlTag);
+ControlRefNum ControlReferenceCreate(RefNumVal *pRefNumVal, VirtualInstrument *vi, const SubString &controlTag) {
+    ControlRefNum refnum = ControlReferenceCreate(vi, controlTag);
     pRefNumVal->SetRefNum(refnum);
     return refnum;
 }
 
-NIError ControlReferenceLookup(RefNum refnum, VirtualInstrument **pVI, SubString *pControlTag) {
+NIError ControlReferenceLookup(ControlRefNum refnum, VirtualInstrument **pVI, SubString *pControlTag) {
     ControlRefInfo controlRefInfo;
     NIError err = ControlRefNumManager::RefNumStorage().GetRefNumData(refnum, &controlRefInfo);
     if (err == kNIError_Success) {
@@ -87,7 +87,7 @@ NIError ControlReferenceLookup(RefNum refnum, VirtualInstrument **pVI, SubString
 }
 
 // ControlReferenceAppendDescription -- output the VI and control a refnum is linked to (for test validation)
-NIError ControlReferenceAppendDescription(StringRef str, RefNum refnum) {
+NIError ControlReferenceAppendDescription(StringRef str, ControlRefNum refnum) {
     ControlRefInfo controlRefInfo;
     NIError err = ControlRefNumManager::RefNumStorage().GetRefNumData(refnum, &controlRefInfo);
     if (err == kNIError_Success) {

--- a/source/core/ControlRef.cpp
+++ b/source/core/ControlRef.cpp
@@ -73,6 +73,19 @@ RefNum ControlReferenceCreate(RefNumVal *pRefNumVal, VirtualInstrument *vi, cons
     return refnum;
 }
 
+NIError ControlReferenceLookup(RefNum refnum, VirtualInstrument **pVI, SubString *pControlTag) {
+    ControlRefInfo controlRefInfo;
+    NIError err = ControlRefNumManager::RefNumStorage().GetRefNumData(refnum, &controlRefInfo);
+    if (err == kNIError_Success) {
+        *pVI = controlRefInfo.vi;
+        *pControlTag = controlRefInfo.controlTag;
+    } else {
+        *pVI = NULL;
+        *pControlTag = SubString();
+    }
+    return err;
+}
+
 // ControlReferenceAppendDescription -- output the VI and control a refnum is linked to (for test validation)
 NIError ControlReferenceAppendDescription(StringRef str, RefNum refnum) {
     ControlRefInfo controlRefInfo;

--- a/source/core/ExecutionContext.cpp
+++ b/source/core/ExecutionContext.cpp
@@ -425,6 +425,9 @@ Int32 /*ExecSlicesResult*/ ExecutionContext::ExecuteSlices(Int32 numSlices, Int3
         reply = kExecSlices_ClumpsFinished;
     }
 #endif
+    if (reply == kExecSlices_ClumpsFinished)
+        RunCleanupProcs(null);  // Cleans up all control refs when top VI finishes (refs not associated with the completion of the VI they are linked to).
+
     return reply;
 }
 //------------------------------------------------------------

--- a/source/core/RefNum.cpp
+++ b/source/core/RefNum.cpp
@@ -316,7 +316,7 @@ void RefNumManager::RunCleanupProcs(VirtualInstrument *vi) {
 }
 
 void RunCleanupProcs(VirtualInstrument *vi) {
-    return RefNumManager::RunCleanupProcs(vi);
+    RefNumManager::RunCleanupProcs(vi);
 }
 
 }  // namespace Vireo

--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -649,7 +649,7 @@ TypeRef TDViaParser::ParseRefNumType()
     return refnum;
 }
 //------------------------------------------------------------
-TypeRef TDViaParser::ParseControlReference() {
+TypeRef TDViaParser::ParseControlReference(void *pData) {
     SubString controlTagToken;
     TypeRef ctrlRefType = null;
 
@@ -663,9 +663,13 @@ TypeRef TDViaParser::ParseControlReference() {
     }
     if (!ctrlRefType)
         return BadType();
+    if (pData) {
+        ControlReferenceCreate((RefNumVal*)pData, _virtualInstrumentScope, controlTagToken);
+        return ((RefNumVal*)pData)->Type();
+    }
 
     DefaultValueType *cdt = DefaultValueType::New(_typeManager, ctrlRefType, true);
-    void *pData = cdt->Begin(kPAInit);
+    pData = cdt->Begin(kPAInit);
 
     ControlReferenceCreate((RefNumVal*)pData, _virtualInstrumentScope, controlTagToken);
 
@@ -1335,6 +1339,12 @@ Int32 TDViaParser::ParseData(TypeRef type, void* pData)
                         }
                     }
                 }
+            }
+            break;
+        case kEncoding_RefNum: {
+            TokenTraits tt = _string.ReadToken(&token);
+            if (tt == TokenTraits_SymbolName && token.CompareCStr(tsControlReferenceToken))
+                ParseControlReference(pData);
             }
             break;
         default:

--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -1415,6 +1415,7 @@ void TDViaParser::ParseVirtualInstrument(TypeRef viType, void* pData)
     TypeRef paramsType = emptyVIParamList;
     TypeRef localsType = emptyVIParamList;
     TypeRef eventSpecsType = emptyVIParamList;
+    TypeRef controlRefsType = emptyVIParamList;
 
     SubString name;
     Boolean hasName = _string.ReadNameToken(&name);
@@ -1427,7 +1428,9 @@ void TDViaParser::ParseVirtualInstrument(TypeRef viType, void* pData)
             } else if (name.CompareCStr("Params")) {
                 paramsType = type;
             } else if (name.CompareCStr("Events")) {
-                    eventSpecsType = type;
+                eventSpecsType = type;
+            } else if (name.CompareCStr("ControlRefs")) {
+                controlRefsType = type;
             } else {
                 LOG_EVENTV(kSoftDataError, "Field does not exist '%.*s'", FMT_LEN_BEGIN(&name));
             }

--- a/source/core/TypeAndDataManager.cpp
+++ b/source/core/TypeAndDataManager.cpp
@@ -1931,7 +1931,7 @@ void* DefaultValueType::Begin(PointerAccessEnum mode)
 //------------------------------------------------------------
 NIError DefaultValueType::InitData(void* pData, TypeRef pattern)
 {
-    if (!IsFlat()) {
+    if (!IsFlat() || IsRefnum()) {  // RefNumVals carry their type, which must be initialized
         _wrapped->InitData(pData, pattern);
     }
     return CopyData(Begin(kPARead), pData);

--- a/source/include/ControlRef.h
+++ b/source/include/ControlRef.h
@@ -9,7 +9,29 @@
 
 /*! \file
  \brief Control refnum management
-  */
+
+ Control references are defined in the Locals: block of a VI (or inside an EventSpec),
+ and define a named, statically-bound reference to a control on a specific VI.
+ 
+ Example:
+ 
+ define(MyVI dv(.VirtualInstrument (
+ Locals: c(
+ e(ControlReference("dataItem_Foo") ctlref1)  // static control ref linked to dataItem_Foo
+ ) ...
+ 
+ The actual Type of ctlref1 is ControlRefNum and stores a refnum (cookie) which
+ opaquely holds onto the VI and control tag (data item).
+ The VI isn't passed directly, it's implicitly taken from the context,
+ whatever VI the ControlReference is defined in.
+ ControlRefNums defined with ControlReference() exist during the entire
+ lifetime of the VI and are only deallocated when the last clump of the last
+ top-level VI finishes.
+ 
+ Non-statically-bound ControlRefNums variables can also be declared in the Params:
+ or Locals: sections, e.g.  e(ControlRefNum ref).
+ These can be used in subVIs to refer to a reference passed in by a caller.
+*/
 
 #ifndef ControlRef_h
 #define ControlRef_h
@@ -19,24 +41,12 @@
 
 namespace Vireo
 {
-class ControlRefInfo {
- public:
-    VirtualInstrument *vi;
-    StringRef dataItemName;
-};
 
-class ControlRefNumManager : public RefNumManager {
- private:
-    typedef TypedRefNum<ControlRefInfo*, true> ControlRefNumType;
-    ControlRefNumType _refStorage;  // manages refnum storage
+RefNum ControlReferenceCreate(VirtualInstrument *vi, const SubString &controlTag);
+RefNum ControlReferenceCreate(RefNumVal *pRefNumVal, VirtualInstrument *vi, const SubString &controlTag);
 
-    static ControlRefNumManager _s_singleton;
- public:
-    static ControlRefNumManager &ControlRefManager() { return _s_singleton; }
-    static ControlRefNumType &RefNumStorage() { return _s_singleton.RefNumManager(); }
-
-    ControlRefNumType &RefNumManager() { return _refStorage; }
-};
+NIError ControlReferenceDestroy(RefNum refnum);
+NIError ControlReferenceAppendDescription(StringRef str, RefNum refnum);
 
 }  // namespace Vireo
 

--- a/source/include/ControlRef.h
+++ b/source/include/ControlRef.h
@@ -41,15 +41,16 @@
 
 namespace Vireo
 {
+typedef RefNum ControlRefNum;  // RefNum to be used with Control Ref Num API (or underlying RefNumManager class)
 
 // Control RefNum API: create, lookup, and destroy control refnums
-RefNum ControlReferenceCreate(VirtualInstrument *vi, const SubString &controlTag);
-RefNum ControlReferenceCreate(RefNumVal *pRefNumVal, VirtualInstrument *vi, const SubString &controlTag);
+ControlRefNum ControlReferenceCreate(VirtualInstrument *vi, const SubString &controlTag);
+ControlRefNum ControlReferenceCreate(RefNumVal *pRefNumVal, VirtualInstrument *vi, const SubString &controlTag);
 
-NIError ControlReferenceLookup(RefNum refnum, VirtualInstrument **pVI, SubString *pControlTag);
+NIError ControlReferenceLookup(ControlRefNum refnum, VirtualInstrument **pVI, SubString *pControlTag);
 
-NIError ControlReferenceDestroy(RefNum refnum);
-NIError ControlReferenceAppendDescription(StringRef str, RefNum refnum);
+NIError ControlReferenceDestroy(ControlRefNum refnum);
+NIError ControlReferenceAppendDescription(StringRef str, ControlRefNum refnum);
 
 }  // namespace Vireo
 

--- a/source/include/ControlRef.h
+++ b/source/include/ControlRef.h
@@ -18,6 +18,8 @@
  define(MyVI dv(.VirtualInstrument (
  Locals: c(
  e(ControlReference("dataItem_Foo") ctlref1)  // static control ref linked to dataItem_Foo
+ // -or-
+ e(dv(ControlRefNum ControlReference("dataItem_Bar")) ctlref2)  // more explicit syntax
  ) ...
  
  The actual Type of ctlref1 is ControlRefNum and stores a refnum (cookie) which

--- a/source/include/ControlRef.h
+++ b/source/include/ControlRef.h
@@ -42,8 +42,11 @@
 namespace Vireo
 {
 
+// Control RefNum API: create, lookup, and destroy control refnums
 RefNum ControlReferenceCreate(VirtualInstrument *vi, const SubString &controlTag);
 RefNum ControlReferenceCreate(RefNumVal *pRefNumVal, VirtualInstrument *vi, const SubString &controlTag);
+
+NIError ControlReferenceLookup(RefNum refnum, VirtualInstrument **pVI, SubString *pControlTag);
 
 NIError ControlReferenceDestroy(RefNum refnum);
 NIError ControlReferenceAppendDescription(StringRef str, RefNum refnum);

--- a/source/include/ControlRef.h
+++ b/source/include/ControlRef.h
@@ -1,0 +1,43 @@
+/**
+
+ Copyright (c) 2018 National Instruments Corp.
+
+ This software is subject to the terms described in the LICENSE.TXT file
+
+ SDG
+ */
+
+/*! \file
+ \brief Control refnum management
+  */
+
+#ifndef ControlRef_h
+#define ControlRef_h
+
+#include "TypeAndDataManager.h"
+#include "RefNum.h"
+
+namespace Vireo
+{
+class ControlRefInfo {
+ public:
+    VirtualInstrument *vi;
+    StringRef dataItemName;
+};
+
+class ControlRefNumManager : public RefNumManager {
+ private:
+    typedef TypedRefNum<ControlRefInfo*, true> ControlRefNumType;
+    ControlRefNumType _refStorage;  // manages refnum storage
+
+    static ControlRefNumManager _s_singleton;
+ public:
+    static ControlRefNumManager &ControlRefManager() { return _s_singleton; }
+    static ControlRefNumType &RefNumStorage() { return _s_singleton.RefNumManager(); }
+
+    ControlRefNumType &RefNumManager() { return _refStorage; }
+};
+
+}  // namespace Vireo
+
+#endif  // ControlRef_h

--- a/source/include/TDCodecVia.h
+++ b/source/include/TDCodecVia.h
@@ -94,6 +94,7 @@ class TDViaParser
     TypeManagerRef  _typeManager;
     SubString       _string;      // "Begin()" moves through string as it is parsed.
     const Utf8Char* _originalStart;
+    VirtualInstrument *_virtualInstrumentScope;  // holds the current (innermost) VI during parsing
     Int32           _lineNumberBase;
 
  public:
@@ -126,6 +127,7 @@ class TDViaParser
     void    ParseClump(VIClump* clump, InstructionAllocator* cia);
     void    PreParseClump(VIClump* viClump);
     SubString* TheString() {return &_string;}
+    VirtualInstrument *CurrentVIScope() { return _virtualInstrumentScope; }
 
  public:
     static NIError StaticRepl(TypeManagerRef typeManager, SubString *replStream);
@@ -148,6 +150,7 @@ class TDViaParser
     TypeRef ParseParamBlock();
     TypeRef ParsePointerType(Boolean shortNotation);
     TypeRef ParseRefNumType();
+    TypeRef ParseControlReference();
     TypeRef ParseEnumType(SubString *token);
     EncodingEnum ParseEncoding(SubString* str);
 };
@@ -242,6 +245,9 @@ void Format(SubString *format, Int32 count, StaticTypeAndData arguments[], Strin
 #define tsParamBlockTypeToken   "p"   // Used for defining param blocks used by native functions.
 #define tsPointerTypeToken      "ptr"
 #define tsRefNumTypeToken       "refnum"
+
+#define tsControlReferenceToken "ControlReference"
+#define tsControlRefNumToken    "ControlRefNum"
 
 #define tsEnumTypeToken         "Enum"
 #define tsEnumTypeTokenLen      4     // strlen of above

--- a/source/include/TDCodecVia.h
+++ b/source/include/TDCodecVia.h
@@ -150,7 +150,7 @@ class TDViaParser
     TypeRef ParseParamBlock();
     TypeRef ParsePointerType(Boolean shortNotation);
     TypeRef ParseRefNumType();
-    TypeRef ParseControlReference();
+    TypeRef ParseControlReference(void *pData = null);
     TypeRef ParseEnumType(SubString *token);
     EncodingEnum ParseEncoding(SubString* str);
 };

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -510,9 +510,11 @@ class TypeCommon
     //! True if the type is an indexable container that contains another type.
     Boolean IsZDA()                 { return (IsArray() && Rank() ==0); }
     //! True if the type is an aggregate of other types.
-    Boolean IsCluster()              { return BitEncoding() == kEncoding_Cluster; }
+    Boolean IsCluster()             { return BitEncoding() == kEncoding_Cluster; }
     //! True if type is an enum
-    Boolean IsEnum()               { return BitEncoding() == kEncoding_Enum; }
+    Boolean IsEnum()                { return BitEncoding() == kEncoding_Enum; }
+    //! True if type is an enum
+    Boolean IsRefnum()              { return BitEncoding() == kEncoding_RefNum; }
     //! True if data can be copied by a simple block copy.
     Boolean IsFlat()                { return _isFlat != 0; }
     //! True if all types the type is composed of have been resolved to valid types.

--- a/test-it/ExpectedResults/ControlRefBasic.vtr
+++ b/test-it/ExpectedResults/ControlRefBasic.vtr
@@ -1,6 +1,7 @@
 Ref: ControlRefNum<ControlRefTestProgram,dataItem1>
 Ref: ControlRefNum<ControlRefTestProgram,dataItem2>
 Ref: ControlRefNum<ControlRefTestProgram,dataItem1>
+Ref: ControlRefNum<ControlRefTestProgram,dataItem3>
 In SubVI:
 SubSubVI Ref: ControlRefNum<subSubVI,nestedRef>
 Ref: ControlRefNum<ControlRefTestProgram,dataItem1>

--- a/test-it/ExpectedResults/ControlRefBasic.vtr
+++ b/test-it/ExpectedResults/ControlRefBasic.vtr
@@ -1,0 +1,11 @@
+Ref: ControlRefNum<ControlRefTestProgram,dataItem1>
+Ref: ControlRefNum<ControlRefTestProgram,dataItem2>
+Ref: ControlRefNum<ControlRefTestProgram,dataItem1>
+In SubVI:
+SubSubVI Ref: ControlRefNum<subSubVI,nestedRef>
+Ref: ControlRefNum<ControlRefTestProgram,dataItem1>
+Ref: ControlRefNum<subVI,myItem>
+In SubVI:
+SubSubVI Ref: ControlRefNum<subSubVI,nestedRef>
+Ref: ControlRefNum<ControlRefTestProgram,dataItem2>
+Ref: ControlRefNum<subVI,myItem>

--- a/test-it/ViaTests/ControlRefBasic.via
+++ b/test-it/ViaTests/ControlRefBasic.via
@@ -1,0 +1,74 @@
+
+define(PrintControlRef dv(.VirtualInstrument (
+    Params:c(
+        i(ControlRefNum ref)
+    )
+    Locals:c(
+        e(String out)
+        e(String refString)
+        e(String refvalString)
+    )
+    clump (1 // top level
+        // Strip the refnum cookie value (which varies per run) from ref output and put it on
+        // its own line after a // comment, so test runners will ignore it
+        StringFormat(refString "%z" * ref)
+	MatchPattern(refString "(0x.*" * out refvalString * *)
+        Printf("Ref: %s\n// %s\n" out refvalString)
+    )
+)))
+
+define(subVI dv(.VirtualInstrument (
+    Params:c(
+        i(ControlRefNum refarg)  // parameter control ref, passed from caller
+    )
+    Locals: c(
+        e(ControlReference("myItem") subref) // control ref in subVI (we won't support this in WebVIs initially, but Vireo already supports it)
+
+        // Define a nested local VI with a control ref, to make sure binding works
+	e(define(subSubVI dv(.VirtualInstrument (
+             Locals:c(e(ControlReference("nestedRef") subsubref))
+             clump(1 Printf("SubSubVI ") PrintControlRef(subsubref))) ) ) foo)
+    )
+    clump (1 // top level
+        Println("In SubVI:")
+	subSubVI()
+        PrintControlRef(refarg)
+        PrintControlRef(subref)
+    )
+)))
+
+define(ControlRefTestProgram dv(.VirtualInstrument (
+    // Unreferenced Event spec with static control reference.  This test doesn't test event
+    // usage of control refs, it just makes sure it parses.
+    Events:c( // Each entry in the top level cluster here represents Event config for a unique Event structure;
+      e(c( // Event Struct 1
+       e(c(  // Event spec 0
+           e(dv(UInt32 0) eventSource)  // event source enum, 0==User int
+           e(dv(UInt32 2) eventType)    // (2=ValueChange)
+           e(ControlReference("eventControl") controlRef)  // static control ref
+           e(dv(UInt32 0) dynIndex)
+       ))
+       /*e(dv(c(  // Event spec 1 (more compact equivalent representation)
+            e(UInt32 eventSource)e(UInt32 eventType)e(ControlRefNum controlUID)e(UInt32 dynIndex)) (0 1 ControlRef("blah") 0)  // TODO
+       )) */
+     )) // End Event Struct 1
+    )
+    Locals:c(
+        e(ControlReference("dataItem1") ref1)  // static control ref linked to dataItem1
+        e(dv(ControlReference("dataItem2")) ref2)  // static control ref linked to dataItem2
+	e(ControlRefNum ref3)  // variable control refnum wire
+        // e(dv(ControlRefNum ControlReference("dataItem3")) ref4)  // make this syntax work too?
+    )
+
+    clump (1 // top level
+        PrintControlRef(ref1)
+        PrintControlRef(ref2)
+        Copy(ref1 ref3)
+        PrintControlRef(ref3)
+        subVI(ref3)
+        subVI(ref2)
+    )
+
+) ) )
+
+enqueue(ControlRefTestProgram)

--- a/test-it/ViaTests/ControlRefBasic.via
+++ b/test-it/ViaTests/ControlRefBasic.via
@@ -56,16 +56,17 @@ define(ControlRefTestProgram dv(.VirtualInstrument (
     Locals:c(
         e(ControlReference("dataItem1") ref1)  // static control ref linked to dataItem1
         e(dv(ControlReference("dataItem2")) ref2)  // static control ref linked to dataItem2
-	e(ControlRefNum ref3)  // variable control refnum wire
-        // e(dv(ControlRefNum ControlReference("dataItem3")) ref4)  // make this syntax work too?
+        e(dv(ControlRefNum ControlReference("dataItem3")) ref3)  // more verbose with explicit type and dv definition
+	e(ControlRefNum ref4)  // variable control refnum wire
     )
 
     clump (1 // top level
         PrintControlRef(ref1)
         PrintControlRef(ref2)
-        Copy(ref1 ref3)
+        Copy(ref1 ref4)
+        PrintControlRef(ref4)
         PrintControlRef(ref3)
-        subVI(ref3)
+        subVI(ref4)
         subVI(ref2)
     )
 

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -129,6 +129,7 @@
                 "ComplexConversions.via",
                 "ComplexMathFunctions.via",
                 "Conjugate.via",
+                "ControlRefBasic.via",
                 "ConvertStringNumber.via",
                 "CopyAlignmentError.via",
                 "CopyAndReset.via",


### PR DESCRIPTION
Implement control references.  …
Note: Control references are defined in the Locals: block of a VI (or inside an EventSpec),
rather than in a "ControlRefs:" block as we had discussed. (The reason is
that each ControlReference definition defines a local name which must be
visible as a local from within the clumps of the VI.)

Example:

define(MyVI dv(.VirtualInstrument (
    Locals: c(
        e(ControlReference("dataItem_Foo") ctlref1)  // static control ref linked to dataItem_Foo
        // -or-
        e(dv(ControlRefNum ControlReference("dataItem_Bar")) ctlref2)  // more explicit syntax
    ) ...

The actual Type of ctlref1 is ControlRefNum (as you can see by the more explicit syntax
using dv for ctlref2)  and stores a refnum (cookie) which opaquely holds onto the VI and 
control tag (data item).
The VI isn't passed directly, it's implicitly taken from the context,
whatever VI the ControlReference is defined in.  (Note, this is a refinement of
the original model we worked out which passed the VI's name as a string.)
ControlRefNums defined with ControlReference() exist during the entire
lifetime of the VI and are only deallocated when the last clump of the last
top-level VI finishes.

Non-statically-bound ControlRefNums variables can also be declared in the Params:
or Locals: sections, e.g.  'i(ControlRefNum ref)' or  'e(ControlRefNum ref)'.
These can be used in subVIs to refer to a reference passed in by a caller.

See test-it/ViaTests/ControlRefBasic.via for examples.