### PR TITLE
Support dynamic re-registration of events in RegisterForEvents

### DIFF
--- a/test-it/ExpectedResults/UserEventsReregister.vtr
+++ b/test-it/ExpectedResults/UserEventsReregister.vtr
@@ -1,0 +1,17 @@
+Generating User Events [A,B,B] (before event wait)
+Short delay (50ms)
+Waiting on events
+Event case 1, User Event A Fired, EventType:1000 Index:0 data:<('Hello' 1)>
+Waiting on events
+Event case 3, User Event B Fired, EventType:1000 Index:0 data:<('Bonjour' 'Aloha' 123)>
+Unregistering for UserEvent B
+Waiting on events
+Event skipped
+Waiting on events
+(Generating User Events [B,A] in background)
+Event skipped
+Waiting on events
+Event case 1, User Event A Fired, EventType:1000 Index:0 data:<('Goodbye' 2)>
+Waiting on events
+Event case 2, Timeout case (300ms), EventType:1 Index:0
+Done

--- a/test-it/ViaTests/UserEventsReregister.via
+++ b/test-it/ViaTests/UserEventsReregister.via
@@ -1,0 +1,118 @@
+
+define (MyEventDataA c(e(String str) e(Double val) ))
+define (MyEventDataB c(e(String str) e(String str2) e(Int32 val) ))
+
+// Event enum:  1=Timeout, 2=Value Change, 1000=User Event Fired
+define(UserEventTestProgram dv(.VirtualInstrument (
+    Events:c( // Each entry in the top level cluster here represents Event config for a unique Event structure;
+      e(c( // Event Struct 1
+       e(dv(c(  // Event spec 0
+            e(UInt32 eventSource)e(UInt32 eventType)e(UInt32 controlUID)e(UInt32 dynIndex)) (25 1000 0 1)
+       ))
+       e(dv(c(  // Event spec 1 (more compact equivalent representation)
+            e(UInt32 eventSource)e(UInt32 eventType)e(UInt32 controlUID)e(UInt32 dynIndex)) (0 1 0 0)
+       ))
+       e(dv(c(  // Event spec 2
+            e(UInt32 eventSource)e(UInt32 eventType)e(UInt32 controlUID)e(UInt32 dynIndex)) (25 1000 0 2)
+       ))
+     )) // End Event Struct 1
+     //e(c( // Event Struct 2
+     //  e(c(  // Event spec 1 ...
+     //    e(...)
+     //  ))
+     //)) // End Event Struct 2
+    )
+    Locals:c(
+        e(UserEventRefNum<MyEventDataA> userEventRefA)
+        e(UserEventRefNum<MyEventDataB> userEventRefB)
+        e(EventRegRefNum<c(
+	        e(c(e(Int32 eventType)e(UserEventRefNum<MyEventDataA>)))
+	        e(c(e(Int32 eventType)e(UserEventRefNum<MyEventDataB>)))
+	    )> eventRegRef)
+
+	e(dv(MyEventDataA ("Hello" 1.0)) myDataA1)
+	e(dv(MyEventDataA ("Goodbye" 2.0)) myDataA2)
+	e(dv(MyEventDataB ("Bonjour" "Aloha" 123)) myDataB)
+        e(.ErrorCluster errorIO)
+        e(dv(Int32 300) timeOut)
+
+	e(c(  // Storage for event data node on left border of event case 1 (user event A)
+	    e(UInt32 eventSource) e(UInt32 eventType) e(UInt32 eventTime) e(UInt32 eventIndex)
+	    e(UserEventRefNum<MyEventDataA> eventRef)
+	    e(MyEventDataA data)
+        ) localEventDataA)
+	e(c(  // Storage for event data node on left border of event case 2 (timeout event)
+	    e(UInt32 eventSource) e(UInt32 eventType) e(UInt32 eventTime) e(UInt32 eventIndex)
+        ) localEventDataTO)
+	e(c(  // Storage for event data node on left border of event case 3 (user event B)
+	    e(UInt32 eventSource) e(UInt32 eventType) e(UInt32 eventTime) e(UInt32 eventIndex)
+	    e(UserEventRefNum<MyEventDataB> eventRef)
+	    e(MyEventDataB data)
+        ) localEventDataB)
+	e(Boolean bool)
+    )
+
+    clump (1 // top level
+	CreateUserEvent(userEventRefA errorIO)
+	CreateUserEvent(userEventRefB errorIO)
+
+	// Generate 1 of each before registration (should be discarded and not leak)
+	GenerateUserEvent(userEventRefA myDataA1 false errorIO)
+	GenerateUserEvent(userEventRefB myDataB false errorIO)
+
+	RegisterForEvents(eventRegRef errorIO 1000 userEventRefA 1000 userEventRefB)
+
+	Trigger(1)  // start bg clump
+
+
+	Printf("Generating User Events [A,B,B] (before event wait)\n")
+	GenerateUserEvent(userEventRefA myDataA1 false errorIO)
+
+	GenerateUserEvent(userEventRefB myDataB false errorIO)
+	Printf("Short delay (50ms)\n")
+	WaitMilliseconds(50)
+	GenerateUserEvent(userEventRefB myDataB false errorIO)
+
+	Perch(5)
+	Printf("Waiting on events\n")
+	WaitForEventsAndDispatch(timeOut eventRegRef 0
+				0 localEventDataA 10 // e.g. event spec 0 fills into localEventDataA and branches to perch 10
+				1 localEventDataTO 20
+				2 localEventDataB 30
+				)
+	Printf("Event skipped\n")
+	Branch(5)
+
+	Perch(10)  // Event case 1
+	Printf ("Event case 1, User Event A Fired, EventType:%u Index:%u data:<%z>\n" localEventDataA.eventType localEventDataA.eventIndex localEventDataA.data)
+
+	Branch(5)  // User Event A waits again
+
+	Perch(20) // Event case 2
+	Printf ("Event case 2, Timeout case (%dms), EventType:%u Index:%u\n" timeOut localEventDataTO.eventType localEventDataTO.eventIndex)
+	Branch(100) // Timeout event finishes
+
+	Perch(30) // Event case 3
+	Printf ("Event case 3, User Event B Fired, EventType:%u Index:%u data:<%z>\n" localEventDataB.eventType localEventDataB.eventIndex localEventDataB.data)
+	Printf ("Unregistering for UserEvent B\n")
+	RegisterForEvents(eventRegRef errorIO * * 1000 0)
+	Branch(5)  // User Event B waits again
+
+	Perch(100) // End of Event structure
+
+	UnregisterForEvents(eventRegRef errorIO)
+	DestroyUserEvent(userEventRefA errorIO)
+
+	Printf ("Done\n")
+    )
+    clump (1 // background clump
+	WaitMilliseconds(100)
+	Printf("(Generating User Events [B,A] in background)\n")
+	GenerateUserEvent(userEventRefB myDataB false errorIO)
+	GenerateUserEvent(userEventRefA myDataA2 false errorIO)
+    )
+
+) ) )
+
+
+enqueue(UserEventTestProgram)

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -363,6 +363,7 @@
                 "UserEventsBasic.via",
                 "UserEventsMultiple.via",
                 "UserEventsMultUEMultES.via",
+                "UserEventsReregister.via",
                 "UserEventsThroughput.via",
                 "UserTypes.via",
                 "UTF-8CodePoints.via",


### PR DESCRIPTION
    Pass * * for an input eventtype/ref pair to leave a registration entry unchanged.
    '0' can be used for not-a-refnum (rather than requiring a strictly-typed
    dv refnum to be declared, although that of course works too.)
