### PR TITLE
Fix truncating of errors larger than 255 characters

### DIFF
--- a/source/io/HttpClient.cpp
+++ b/source/io/HttpClient.cpp
@@ -57,8 +57,8 @@ void AddCallChainToSourceIfErrorPresent(ErrorCluster *errorCluster, ConstCStr me
 {
     if (errorCluster && errorCluster->status) {
         STACK_VAR(String, currentErrorString);
-		StringRef s = currentErrorString.Value;
-		s->Append(errorCluster->source);
+        StringRef s = currentErrorString.Value;
+        s->Append(errorCluster->source);
         errorCluster->source->Resize1D(0);
         errorCluster->source->AppendCStr(methodName);
         errorCluster->source->AppendCStr(" in ");

--- a/source/io/HttpClient.cpp
+++ b/source/io/HttpClient.cpp
@@ -56,12 +56,14 @@ extern "C" {
 void AddCallChainToSourceIfErrorPresent(ErrorCluster *errorCluster, ConstCStr methodName)
 {
     if (errorCluster && errorCluster->status) {
-        TempStackCStringFromString currentErrorString(errorCluster->source);
+        STACK_VAR(String, currentErrorString);
+		StringRef s = currentErrorString.Value;
+		s->Append(errorCluster->source);
         errorCluster->source->Resize1D(0);
         errorCluster->source->AppendCStr(methodName);
         errorCluster->source->AppendCStr(" in ");
         AppendCallChainString(errorCluster->source);
-        errorCluster->source->AppendCStr(currentErrorString.BeginCStr());
+        errorCluster->source->Append(s);
     }
 }
 

--- a/test-it/karma/http/HttpGet.Test.js
+++ b/test-it/karma/http/HttpGet.Test.js
@@ -139,6 +139,8 @@ describe('Performing a GET request #FailsIE', function () {
             expect(viPathParser('error.status')).toBeTrue();
             expect([WEBVI_TIMEOUT, WEBVI_NETWORK_ERROR, kNIHttpResultInternalUndefinedError]).toContain(viPathParser('error.code'));
             expect(viPathParser('error.source')).toMatch(/HttpClientGet in MyVI/);
+            expect(viPathParser('error.source').length).toBeGreaterThan(255);
+            expect(viPathParser('error.source')).toContain('Due to browser security restrictions');
             done();
         });
     });


### PR DESCRIPTION
The TempStackCStringFromString only holds 255 characters, which was causing the problem.