### PR TITLE
Add support for clusters of event reg. refs to WaitForEvents and fix race condition in Observables 

### DIFF
--- a/source/CommandLine/main.cpp
+++ b/source/CommandLine/main.cpp
@@ -115,6 +115,8 @@ int VIREO_MAIN(int argc, const char * argv[])
 void Vireo::RunExec() {
     TypeManagerRef tm = gShells._pUserShell;
     TypeManagerScope scope(tm);
+    // These numbers may need further tuning (numSlices and millisecondsToRun).
+    // They should match the values for VJS in io/module_eggShell.js
     Int32 state = tm->TheExecutionContext()->ExecuteSlices(10000, 4);
     Int32 delay = state > 0 ? state : 0;
     gShells._keepRunning = (state != kExecSlices_ClumpsFinished);

--- a/source/CommandLine/main.cpp
+++ b/source/CommandLine/main.cpp
@@ -115,7 +115,7 @@ int VIREO_MAIN(int argc, const char * argv[])
 void Vireo::RunExec() {
     TypeManagerRef tm = gShells._pUserShell;
     TypeManagerScope scope(tm);
-    Int32 state = tm->TheExecutionContext()->ExecuteSlices(400, 10000000);
+    Int32 state = tm->TheExecutionContext()->ExecuteSlices(10000, 4);
     Int32 delay = state > 0 ? state : 0;
     gShells._keepRunning = (state != kExecSlices_ClumpsFinished);
     if (delay)

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -431,7 +431,10 @@ Int32 EventOracle::GetPendingEventInfo(EventQueueID *pActiveQID, Int32 nQueues, 
         DynamicEventRegInfo *regInfo = NULL;
         if (dynRegRefs
             && EventRegistrationRefNumManager::RefNumStorage().GetRefNumData(dynRegRefs[regIndex].GetRefNum(), &regInfo) == kNIError_Success) {
-            if (_qObject[regInfo->_qID].GetPendingEventSequenceNumber(&eventSeq) && (!eventQID || EventTimeSeqCompare(eventSeq, earliestSeq) < 0)) {
+            // For each valid dynamic reference, find the event with the earliest event sequence number in its queue.
+            if (_qObject[regInfo->_qID].GetPendingEventSequenceNumber(&eventSeq)
+                && (!eventQID  // first time through loop, take starting seq number
+                    || EventTimeSeqCompare(eventSeq, earliestSeq) < 0)) {
                 eventQID = regInfo->_qID;
                 earliestSeq = eventSeq;
                 earliestIndex = regIndex+1;

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -409,7 +409,7 @@ class EventRegistrationRefNumManager : public RefNumManager {
 
 EventRegistrationRefNumManager EventRegistrationRefNumManager::_s_singleton;
 
-// GetPendingEventInfo -- given a static queue and a set of dynamic event queuse (passed via refnum), return the queue with the earliest event
+// GetPendingEventInfo -- given a static queue and a set of dynamic event queues (passed via refnum), return the queue with the earliest event
 // based on sequence number.  Returns 0 if the earliest event is in the static queue (if non-null), or a 1-based index into the dynamic queue
 // list if the earliest event is in one of the dynamic queues.
 // Also returns the base dynamic index of the returned queueID (e.g. event reg. refnum; if this event reg. refnum has multiple registered items

--- a/source/core/Queue.cpp
+++ b/source/core/Queue.cpp
@@ -35,6 +35,7 @@ void VIClumpQueue::Enqueue(VIClump* elt)
     } else {
         // Its not empty, add to tail
         VIREO_ASSERT((null == (this->_tail)->_next))
+        VIREO_ASSERT((elt != this->_tail && elt != this->_head))
         this->_tail->_next = elt;
         // not needed elt->_next = null;
         this->_tail = elt;

--- a/source/core/Synchronization.cpp
+++ b/source/core/Synchronization.cpp
@@ -83,6 +83,10 @@ void ObservableCore::ObserveStateChange(IntMax info, Boolean wakeAll)
             *ppPrevious = pNext;
             pObserver->_next = null;
             pObserver->_clump->EnqueueRunQueue();
+            // Every Observable that can trigger state changes has an associated timer owned by the clump.
+            // Cancel it so it doesn't race with this and possibly Enqueue the clump a second time.
+            VIREO_ASSERT((pObserver->_clump->_observationCount == 2 && pObserver == &pObserver->_clump->_observationStates[1]))
+            pObserver->_clump->TheExecutionContext()->_timer.RemoveObserver(&pObserver->_clump->_observationStates[0]);
             if (!wakeAll)
                 break;  // only enqueue first one found
         } else {

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -626,6 +626,9 @@
         // A good starting point for most vireo uses but can be copied and modified as needed
         // If a callback (stdout, stderr) is provided, it will be run asynchronously to completion
         Module.eggShell.executeSlicesUntilClumpsFinished = publicAPI.eggShell.executeSlicesUntilClumpsFinished = function (callback) {
+            // These numbers may still need tuning.  They should also match the numbers in native
+            // in CommandLine/main.cpp.  SLICE_SETS was lowered from 100000 because that was starving
+            // other clumps and running too long before checking the timer.
             var SLICE_SETS_PER_TIME_CHECK = 10000;
             var MAXIMUM_VIREO_EXECUTION_TIME_MS = 4;
             var timerToken;

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -626,7 +626,7 @@
         // A good starting point for most vireo uses but can be copied and modified as needed
         // If a callback (stdout, stderr) is provided, it will be run asynchronously to completion
         Module.eggShell.executeSlicesUntilClumpsFinished = publicAPI.eggShell.executeSlicesUntilClumpsFinished = function (callback) {
-            var SLICE_SETS_PER_TIME_CHECK = 100000;
+            var SLICE_SETS_PER_TIME_CHECK = 10000;
             var MAXIMUM_VIREO_EXECUTION_TIME_MS = 4;
             var timerToken;
             var origExecuteSlicesWakeUpCallback = Module.eggShell.executeSlicesWakeUpCallback;

--- a/test-it/ExpectedResults/UserEventsRegClust.vtr
+++ b/test-it/ExpectedResults/UserEventsRegClust.vtr
@@ -1,0 +1,19 @@
+Generating User Events [A,B,C,B] (before event wait)
+Waiting on events
+Event case 1, User Event A Fired, EventType:1000 Index:0 data:<('Hello' 1)>
+Waiting on events
+Event case 3, User Event B Fired, EventType:1000 Index:0 data:<('Bonjour' 'Aloha' 123)>
+Waiting on events
+Event case 4, User Event C Fired, EventType:1000 Index:0 data:<(456)>
+Waiting on events
+Event case 3, User Event B Fired, EventType:1000 Index:0 data:<('Bonjour' 'Aloha' 123)>
+Waiting on events
+(Generating User Events [B,A,C] in background)
+Event case 3, User Event B Fired, EventType:1000 Index:0 data:<('Bonjour' 'Aloha' 123)>
+Waiting on events
+Event case 1, User Event A Fired, EventType:1000 Index:0 data:<('Goodbye' 2)>
+Waiting on events
+Event case 4, User Event C Fired, EventType:1000 Index:0 data:<(456)>
+Waiting on events
+Event case 2, Timeout case (50ms), EventType:1 Index:0
+Done

--- a/test-it/ViaTests/UserEventsRegClust.via
+++ b/test-it/ViaTests/UserEventsRegClust.via
@@ -1,0 +1,141 @@
+
+define (MyEventDataA c(e(String str) e(Double val) ))
+define (MyEventDataB c(e(String str) e(String str2) e(Int32 val) ))
+define (MyEventDataC c(e(Double val) ))
+
+// Event enum:  1=Timeout, 2=Value Change, 1000=User Event Fired
+define(UserEventTestProgram dv(.VirtualInstrument (
+    Events:c( // Each entry in the top level cluster here represents Event config for a unique Event structure;
+      e(c( // Event Struct 1
+       e(dv(c(  // Event spec 0
+            e(UInt32 eventSource)e(UInt32 eventType)e(UInt32 controlUID)e(UInt32 dynIndex)) (25 1000 0 1)
+       ))
+       e(dv(c(  // Event spec 1 (more compact equivalent representation)
+            e(UInt32 eventSource)e(UInt32 eventType)e(UInt32 controlUID)e(UInt32 dynIndex)) (0 1 0 0)
+       ))
+       e(dv(c(  // Event spec 2
+            e(UInt32 eventSource)e(UInt32 eventType)e(UInt32 controlUID)e(UInt32 dynIndex)) (25 1000 0 2)
+       ))
+       e(dv(c(  // Event spec 3
+            e(UInt32 eventSource)e(UInt32 eventType)e(UInt32 controlUID)e(UInt32 dynIndex)) (25 1000 0 3)
+       ))
+     )) // End Event Struct 1
+    )
+    Locals:c(
+        e(UserEventRefNum<MyEventDataA> userEventRefA)
+        e(UserEventRefNum<MyEventDataB> userEventRefB)
+        e(UserEventRefNum<MyEventDataC> userEventRefC)
+        e(EventRegRefNum<c(
+	        e(c(e(Int32 eventType)e(UserEventRefNum<MyEventDataA>)))
+	    )> eventRegRef1)
+        e(EventRegRefNum<c(
+	        e(c(e(Int32 eventType)e(UserEventRefNum<MyEventDataB>)))
+	        e(c(e(Int32 eventType)e(UserEventRefNum<MyEventDataC>)))
+	    )> eventRegRef2)
+
+        e(c(e(EventRegRefNum<c(
+	        e(c(e(Int32 eventType)e(UserEventRefNum<MyEventDataA>)))
+	    )> reg1)
+          e(EventRegRefNum<c(
+	        e(c(e(Int32 eventType)e(UserEventRefNum<MyEventDataB>)))
+	        e(c(e(Int32 eventType)e(UserEventRefNum<MyEventDataC>)))
+	    )> reg2)
+        ) regRefClust)
+
+	e(dv(MyEventDataA ("Hello" 1.0)) myDataA1)
+	e(dv(MyEventDataA ("Goodbye" 2.0)) myDataA2)
+	e(dv(MyEventDataB ("Bonjour" "Aloha" 123)) myDataB)
+	e(dv(MyEventDataC (456.0)) myDataC)
+        e(.ErrorCluster errorIO)
+        e(dv(Int32 50) timeOut)
+
+	e(c(  // Storage for event data node on left border of event case 1 (user event A)
+	    e(UInt32 eventSource) e(UInt32 eventType) e(UInt32 eventTime) e(UInt32 eventIndex)
+	    e(UserEventRefNum<MyEventDataA> eventRef)
+	    e(MyEventDataA data)
+        ) localEventDataA)
+	e(c(  // Storage for event data node on left border of event case 2 (timeout event)
+	    e(UInt32 eventSource) e(UInt32 eventType) e(UInt32 eventTime) e(UInt32 eventIndex)
+        ) localEventDataTO)
+	e(c(  // Storage for event data node on left border of event case 3 (user event B)
+	    e(UInt32 eventSource) e(UInt32 eventType) e(UInt32 eventTime) e(UInt32 eventIndex)
+	    e(UserEventRefNum<MyEventDataB> eventRef)
+	    e(MyEventDataB data)
+        ) localEventDataB)
+	e(c(  // Storage for event data node on left border of event case 4 (user event C)
+	    e(UInt32 eventSource) e(UInt32 eventType) e(UInt32 eventTime) e(UInt32 eventIndex)
+	    e(UserEventRefNum<MyEventDataC> eventRef)
+	    e(MyEventDataC data)
+        ) localEventDataC)
+	e(Boolean bool)
+    )
+
+    clump (1 // top level
+	CreateUserEvent(userEventRefA errorIO)
+	CreateUserEvent(userEventRefB errorIO)
+	CreateUserEvent(userEventRefC errorIO)
+
+	// Generate 1 of each before registration (should be discarded and not leak)
+	GenerateUserEvent(userEventRefA myDataA1 false errorIO)
+	GenerateUserEvent(userEventRefB myDataB false errorIO)
+
+	RegisterForEvents(eventRegRef1 errorIO 1000 userEventRefA)
+	RegisterForEvents(eventRegRef2 errorIO 1000 userEventRefB 1000 userEventRefC)
+        Copy(eventRegRef1 regRefClust.reg1)
+        Copy(eventRegRef2 regRefClust.reg2)
+
+	Printf("Generating User Events [A,B,C,B] (before event wait)\n")
+	GenerateUserEvent(userEventRefA myDataA1 false errorIO)
+	GenerateUserEvent(userEventRefB myDataB false errorIO)
+	GenerateUserEvent(userEventRefC myDataC false errorIO)
+	GenerateUserEvent(userEventRefB myDataB false errorIO)
+
+	Trigger(1)  // start bg clump
+
+	Perch(5)
+	Printf("Waiting on events\n")
+	WaitForEventsAndDispatch(timeOut regRefClust 0
+				0 localEventDataA 10 // e.g. event spec 0 fills into localEventDataA and branches to perch 10
+				1 localEventDataTO 20
+				2 localEventDataB 30
+				3 localEventDataC 40
+				)
+	Printf("Event skipped\n")
+	Branch(5)
+
+	Perch(10)  // Event case 1
+	Printf ("Event case 1, User Event A Fired, EventType:%u Index:%u data:<%z>\n" localEventDataA.eventType localEventDataA.eventIndex localEventDataA.data)
+
+	Branch(5)  // User Event A waits again
+
+	Perch(20) // Event case 2
+	Printf ("Event case 2, Timeout case (%dms), EventType:%u Index:%u\n" timeOut localEventDataTO.eventType localEventDataTO.eventIndex)
+	Branch(100) // Timeout event finishes
+
+	Perch(30) // Event case 3
+	Printf ("Event case 3, User Event B Fired, EventType:%u Index:%u data:<%z>\n" localEventDataB.eventType localEventDataB.eventIndex localEventDataB.data)
+	Branch(5)  // User Event B waits again
+
+	Perch(40) // Event case 4
+	Printf ("Event case 4, User Event C Fired, EventType:%u Index:%u data:<%z>\n" localEventDataC.eventType localEventDataC.eventIndex localEventDataC.data)
+	Branch(5)  // User Event C waits again
+
+	Perch(100) // End of Event structure
+
+	UnregisterForEvents(eventRegRef1 errorIO)
+	UnregisterForEvents(eventRegRef2 errorIO)
+	DestroyUserEvent(userEventRefA errorIO)
+
+	Printf ("Done\n")
+    )
+    clump (1 // background clump
+	Printf("(Generating User Events [B,A,C] in background)\n")
+	GenerateUserEvent(userEventRefB myDataB false errorIO)
+	GenerateUserEvent(userEventRefA myDataA2 false errorIO)
+	GenerateUserEvent(userEventRefC myDataC false errorIO)
+    )
+
+) ) )
+
+
+enqueue(UserEventTestProgram)

--- a/test-it/ViaTests/UserEventsThroughput.via
+++ b/test-it/ViaTests/UserEventsThroughput.via
@@ -1,8 +1,13 @@
 
 // Measure UserEvent throughput.
-// On my dev machine, I get about 2100K events/sec on my machine native, and ~52K events/sec w/node.JS
-// Note: If you remove the clump triggers in the event cases, the JS performance is much
-// faster (320K e/s), but that doesn't match what DFIR would generate for an empty event case.
+// On my dev machine, I get about 2500K events/sec on my machine native, and ~180K events/sec w/node.JS
+
+// Note: with the timeout change to 50 ms, and the tweak of ExecSlices params to (10000,4),
+// this test is also a regression test for the race condition in ObserveStateChange/CheckTimers fixed
+// in the previous commit.
+
+// Without the patch to ObserveStateChange, this test would trigger the new assert in VIClumpQueue::Enqueue,
+// which detects the corruption causes by the race condition.
 
 define (MyEventDataA c(e(Int32 val) ))
 
@@ -37,7 +42,7 @@ define(UserEventTestProgram dv(.VirtualInstrument (
         e(dv(UInt32 0) timeElapsed)
         e(dv(Double 0) temp)
         e(dv(Double 0) throughput)
-        e(dv(Int32 100) timeOut)
+        e(dv(Int32 50) timeOut)
 
 	e(c(  // Storage for event data node on left border of event case 1 (user event A)
 	    e(UInt32 eventSource) e(UInt32 eventType) e(UInt32 eventTime) e(UInt32 eventIndex)

--- a/test-it/ViaTests/UserEventsThroughput.via
+++ b/test-it/ViaTests/UserEventsThroughput.via
@@ -55,7 +55,7 @@ define(UserEventTestProgram dv(.VirtualInstrument (
 
 	RegisterForEvents(eventRegRef errorIO 1000 userEventRefA)
 
-	Trigger(2)  // start background Producer loop clump
+	Trigger(1)  // start background Producer loop clump
 	WaitMilliseconds(10)
 
 	GetMillisecondTickCount(timeBegin)
@@ -72,20 +72,17 @@ define(UserEventTestProgram dv(.VirtualInstrument (
 
 	Perch(10)  // Event case 1
 
-	Trigger(3)  // Trigger an empty diagram clump since NG DFIR will always do this
-	Wait(3)	    // Unfortunately, this slows down how fast events can be processed by 10x in VireoJS
-	// (The penalty on native is much less.  TODO(spathiwa) Investigate descrepancy.)
 	Add(1 receivedCount receivedCount)
 	Branch(5)  // User Event A waits again
 
 	Perch(20) // Event case 2
-	Trigger(1)
-	Wait(1)
+	Printf ("Event case 2, Timeout case (%dms), EventType:%u Index:%u\n" timeOut localEventDataTO.eventType localEventDataTO.eventIndex)
+	//Printf ("// time:%u\n" localEventDataTO.eventTime)
 	Branch(100) // Timeout event finishes
 
 	Perch(100) // End of Event structure
 
-	Wait(2)
+	Wait(1)
 	GetMillisecondTickCount(timeEnd)
 	Sub(timeEnd timeBegin timeElapsed)
 	Convert(receivedCount throughput)
@@ -102,10 +99,6 @@ define(UserEventTestProgram dv(.VirtualInstrument (
 
 	Printf ("Done\n")
     )
-    clump (1 // event timeout case
-	Printf ("Event case 2, Timeout case (%dms), EventType:%u Index:%u\n" timeOut localEventDataTO.eventType localEventDataTO.eventIndex)
-	//Printf ("// time:%u\n" localEventDataTO.eventTime)
-    )
     clump (1 // background clump Producer Loop
 	Perch(200)
 	BranchIfGE(250 sentCount max)
@@ -113,14 +106,8 @@ define(UserEventTestProgram dv(.VirtualInstrument (
 	GenerateUserEvent(userEventRefA myDataA1 false errorIO)
 	Add(1 sentCount sentCount)
 
-        Trigger(4)  // Trigger an empty clump in producer loop as well, so it doesn't greatly outperform
-        Wait(4)     // consumer loop and run out of memory by growing the event queue too large
 	Branch(200)
 	Perch(250)
-    )
-    clump (1 // empty clump, Event case 1
-    )
-    clump (1 // empty clump
     )
 
 ) ) )

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -59,6 +59,16 @@
                 "QueueInvalidRefnum.via"
             ]
         },
+        "events": {
+            "tests": [
+                "UserEventsBasic.via",
+                "UserEventsMultiple.via",
+                "UserEventsMultUEMultES.via",
+                "UserEventsRegClust.via",
+                "UserEventsReregister.via",
+                "UserEventsThroughput.via"
+            ]
+        },
         "manual": {
             "tests": [
                 "StringFormatTime.via",
@@ -66,7 +76,7 @@
             ]
         },
         "common": {
-            "include": ["queue"],
+            "include": ["queue", "events"],
             "tests": [
                 "2HelloWorlds.via",
                 "AllocatedDataValues.via",
@@ -361,11 +371,6 @@
                 "UnflattenStrictValidation.via",
                 "UnOpFunctions.via",
                 "UsageType.via",
-                "UserEventsBasic.via",
-                "UserEventsMultiple.via",
-                "UserEventsMultUEMultES.via",
-                "UserEventsReregister.via",
-                "UserEventsThroughput.via",
                 "UserTypes.via",
                 "UTF-8CodePoints.via",
                 "UTF-8HelloWorld.via",


### PR DESCRIPTION
(The race condition appears to be the source of the long-standing intermittent CI failure in Queue tests.)