### PR TITLE
Fix for propertyNode path format

### DIFF
--- a/Vireo_VS/VireoCommandLine.vcxproj
+++ b/Vireo_VS/VireoCommandLine.vcxproj
@@ -67,6 +67,7 @@
     <ClInclude Include="..\source\include\BuildConfig.h" />
     <ClInclude Include="..\source\include\CEntryPoints.h" />
     <ClInclude Include="..\source\include\ControlRef.h" />
+    <ClInclude Include="..\source\include\DataReflectionVisitor.h" />
     <ClInclude Include="..\source\include\DataTypes.h" />
     <ClInclude Include="..\source\include\Date.h" />
     <ClInclude Include="..\source\include\EventLog.h" />

--- a/Vireo_VS/VireoCommandLine.vcxproj
+++ b/Vireo_VS/VireoCommandLine.vcxproj
@@ -37,6 +37,7 @@
     <ClCompile Include="..\source\core\TimeFunctions.cpp" />
     <ClCompile Include="..\source\core\Timestamp.cpp" />
     <ClCompile Include="..\source\core\TypeAndDataManager.cpp" />
+    <ClCompile Include="..\source\core\TypeAndDataPathFinder.cpp" />
     <ClCompile Include="..\source\core\TypeAndDataReflection.cpp" />
     <ClCompile Include="..\source\core\TypeDefiner.cpp" />
     <ClCompile Include="..\source\core\TypeTemplates.cpp" />

--- a/Vireo_VS/VireoCommandLine.vcxproj.filters
+++ b/Vireo_VS/VireoCommandLine.vcxproj.filters
@@ -235,5 +235,8 @@
     <ClInclude Include="..\source\include\Array.h">
       <Filter>VireoSource\Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\source\include\DataReflectionVisitor.h">
+      <Filter>VireoSource\Include</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Vireo_VS/VireoCommandLine.vcxproj.filters
+++ b/Vireo_VS/VireoCommandLine.vcxproj.filters
@@ -133,6 +133,9 @@
     <ClCompile Include="..\source\io\PropertyNode.cpp">
       <Filter>VireoSource\IO</Filter>
     </ClCompile>
+    <ClCompile Include="..\source\core\TypeAndDataPathFinder.cpp">
+      <Filter>VireoSource\Core</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\source\include\ConversionTable.def">

--- a/Vireo_Xcode/VireoEggShell.xcodeproj/project.pbxproj
+++ b/Vireo_Xcode/VireoEggShell.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		441441ED2089A08900C97FC0 /* TypeAndDataPathFinder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 441441EC2089A08900C97FC0 /* TypeAndDataPathFinder.cpp */; };
 		444C46841E1C5A540037FA98 /* Date.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 444C46821E1C5A540037FA98 /* Date.cpp */; };
 		444C46851E1C5A540037FA98 /* TimeFunctions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 444C46831E1C5A540037FA98 /* TimeFunctions.cpp */; };
 		444C468C1E26D73C0037FA98 /* RefNum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 444C468B1E26D73C0037FA98 /* RefNum.cpp */; };
@@ -121,6 +122,8 @@
 
 /* Begin PBXFileReference section */
 		44026BAA1EFAEFC600DB51B4 /* Array.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Array.h; path = include/Array.h; sourceTree = "<group>"; };
+		441441EB2089A07600C97FC0 /* DataReflectionVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DataReflectionVisitor.h; path = include/DataReflectionVisitor.h; sourceTree = "<group>"; };
+		441441EC2089A08900C97FC0 /* TypeAndDataPathFinder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypeAndDataPathFinder.cpp; path = core/TypeAndDataPathFinder.cpp; sourceTree = "<group>"; };
 		443536321CFF4979002BA5DB /* 2HelloWorlds.via */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = 2HelloWorlds.via; path = "../test-it/2HelloWorlds.via"; sourceTree = "<group>"; };
 		443536331CFF4979002BA5DB /* AllocatedDataValues.via */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = AllocatedDataValues.via; path = "../test-it/AllocatedDataValues.via"; sourceTree = "<group>"; };
 		443536341CFF4979002BA5DB /* ArrayComparison.via */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = ArrayComparison.via; path = "../test-it/ArrayComparison.via"; sourceTree = "<group>"; };
@@ -871,6 +874,7 @@
 				47D84DE417C2A271009053DB /* Timestamp.cpp */,
 				47D84DE517C2A271009053DB /* TypeAndDataManager.cpp */,
 				47EEBCC11A5EFF0E00B033DC /* TypeAndDataReflection.cpp */,
+				441441EC2089A08900C97FC0 /* TypeAndDataPathFinder.cpp */,
 				4744A9DC1818594D00E1F7D9 /* TypeDefiner.cpp */,
 				470E20771A36A5DB006FEACC /* TypeTemplates.cpp */,
 				47D84DE617C2A271009053DB /* VirtualInstrument.cpp */,
@@ -895,6 +899,7 @@
 				4797A38E1862265B00E643D7 /* CEntryPoints.h */,
 				446506DA206ACB3400B0CD8E /* ControlRef.h */,
 				47D84DC417C2A258009053DB /* BuildConfig.h */,
+				441441EB2089A07600C97FC0 /* DataReflectionVisitor.h */,
 				47D84DC917C2A258009053DB /* DataTypes.h */,
 				470F626A1886F522003146BF /* EventLog.h */,
 				47D84DCB17C2A258009053DB /* ExecutionContext.h */,
@@ -1153,6 +1158,7 @@
 				470E20781A36A5DC006FEACC /* TypeTemplates.cpp in Sources */,
 				44C2350E20428CD50064583B /* Events.cpp in Sources */,
 				444C46851E1C5A540037FA98 /* TimeFunctions.cpp in Sources */,
+				441441ED2089A08900C97FC0 /* TypeAndDataPathFinder.cpp in Sources */,
 				472B7BE517D0E1E800201196 /* TDCodecVia.cpp in Sources */,
 				472B7BE817D0E1FC00201196 /* FileIO.cpp in Sources */,
 				444C46841E1C5A540037FA98 /* Date.cpp in Sources */,

--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -180,6 +180,7 @@ EM_BC_FILES=$(OBJS)/Array.bc\
 	$(OBJS)/Timestamp.bc\
 	$(OBJS)/TimeFunctions.bc\
 	$(OBJS)/TypeAndDataManager.bc\
+	$(OBJS)/TypeAndDataPathFinder.bc\
 	$(OBJS)/TypeAndDataReflection.bc\
 	$(OBJS)/TypeDefiner.bc\
 	$(OBJS)/TypeTemplates.bc\

--- a/make-it/Makefile
+++ b/make-it/Makefile
@@ -12,7 +12,7 @@ OUTPUT_EXE=$(OUTPUT_DIR)/esh
 OUTPUT_TEST_EXE=$(OUTPUT_DIR)/esh-test
 
 COMMANDLINE = main.cpp
-CORE = Array.cpp Assert.cpp CEntryPoints.cpp ControlRef.cpp Date.cpp EventLog.cpp Events.cpp ExecutionContext.cpp GenericFunctions.cpp MatchPat.cpp Math.cpp NumericString.cpp Platform.cpp Queue.cpp RefNum.cpp String.cpp StringUtilities.cpp Synchronization.cpp TDCodecLVFlat.cpp TDCodecVia.cpp Thread.cpp TimeFunctions.cpp Timestamp.cpp TypeAndDataManager.cpp TypeAndDataReflection.cpp TypeDefiner.cpp TypeTemplates.cpp UnitTest.cpp VirtualInstrument.cpp Waveform.cpp
+CORE = Array.cpp Assert.cpp CEntryPoints.cpp ControlRef.cpp Date.cpp EventLog.cpp Events.cpp ExecutionContext.cpp GenericFunctions.cpp MatchPat.cpp Math.cpp NumericString.cpp Platform.cpp Queue.cpp RefNum.cpp String.cpp StringUtilities.cpp Synchronization.cpp TDCodecLVFlat.cpp TDCodecVia.cpp Thread.cpp TimeFunctions.cpp Timestamp.cpp TypeAndDataManager.cpp TypeAndDataReflection.cpp TypeAndDataPathFinder.cpp TypeDefiner.cpp TypeTemplates.cpp UnitTest.cpp VirtualInstrument.cpp Waveform.cpp
 UNITTEST = RefNumTest.cpp
 IO = FileIO.cpp Canvas2d.cpp DebugGPIO.cpp HttpClient.cpp WebSocketClient.cpp JavaScriptInvoke.cpp PropertyNode.cpp
 

--- a/source/core/TypeAndDataPathFinder.cpp
+++ b/source/core/TypeAndDataPathFinder.cpp
@@ -11,79 +11,48 @@ SDG
  */
 
 #include "TypeAndDataManager.h"
+#include "DataReflectionVisitor.h"
 
 namespace Vireo
 {
 
 //------------------------------------------------------------
-/* Create a visitor with a needle being looked for and a TypeRef
-* that describes what the needle is a pointer to. The visitor will visit
-* all types in the type manger and thus ultimate all values owned by that type manager
-* and if necessary parent type managers as well.
-* initially the hay stack is null, but when a type is visited that owns a value ( constant or var)
-* it will establish a haystack then as the type is visited the stack is narrowed.
+/* Inherits searching behavior from DataReflectionVisitor to build
+* a path for the specified needle and haystack. Path format does
+* not include the VI name nor "Locals" section.
 */
 
-class PathFinderVisitor : public TypeVisitor
+class PathFinderVisitor : public DataReflectionVisitor
 {
  public:
     PathFinderVisitor(TypeRef tNeedle, DataPointer pHaystack, StringRef path);
-    void Accept(TypeRef tHaystack, DataPointer pHaystack);
     void Accept(TypeManagerRef tm);
-    Boolean Found() {return _found;}
 
  private:
-    // What is being searched through
-    void*           _pHayStack;
-
-    // What is being looked for
-    TypeRef         _tNeedle;
-    void*           _pNeedle;
-
     // Used as frames are unwound
     Boolean         _pathEmpty;
-    Boolean         _found;
-    StringRef       _path;
 
  private:
-    virtual void VisitBad(TypeRef type);
-    virtual void VisitBitBlock(BitBlockType* type);
-    virtual void VisitBitCluster(BitClusterType* type);
     virtual void VisitCluster(ClusterType* type);
-    virtual void VisitParamBlock(ParamBlockType* type);
-    virtual void VisitEquivalence(EquivalenceType* type);
-    virtual void VisitArray(ArrayType* type);
-    virtual void VisitElement(ElementType* type);
-    virtual void VisitNamed(NamedType* type);
-    virtual void VisitPointer(PointerType* type);
-    virtual void VisitEnum(EnumType* type);
-    virtual void VisitRefNumVal(RefNumValType* type);
-    virtual void VisitDefaultValue(DefaultValueType* type);
-    virtual void VisitDefaultPointer(DefaultPointerType* type);
-    virtual void VisitCustomDataProc(CustomDataProcType* type);
 };
 //------------------------------------------------------------
 void TypeManager::GetPathFromPointer(TypeRef tNeedle, DataPointer pNeedle, StringRef path)
 {
     path->Resize1D(0);
-    PathFinderVisitor drv(tNeedle, pNeedle, path);
-    for (TypeManager *tm = this; tm && !drv.Found(); tm = tm->BaseTypeManager()) {
-        drv.Accept(tm);
+    PathFinderVisitor pfv(tNeedle, pNeedle, path);
+    for (TypeManager *tm = this; tm && !pfv.Found(); tm = tm->BaseTypeManager()) {
+        pfv.Accept(tm);
     }
 
-    if (!drv.Found()) {
+    if (!pfv.Found()) {
         path->AppendCStr("*pointer-not-found*");
     }
 }
 //------------------------------------------------------------
-PathFinderVisitor::PathFinderVisitor(TypeRef tHaystack, DataPointer pNeedle, StringRef path)
+PathFinderVisitor::PathFinderVisitor(TypeRef tHaystack, DataPointer pNeedle, StringRef path) :
+    DataReflectionVisitor(tHaystack, pNeedle, path)
 {
-    _tNeedle = tHaystack;
-    _pNeedle = pNeedle;
-    _pHayStack = null;
     _pathEmpty = true;
-    _found = false;
-    _path = path;
 }
 //------------------------------------------------------------
 //! Visitor dispatch helper method that traverses all the types in a TypeManager
@@ -91,7 +60,7 @@ void PathFinderVisitor::Accept(TypeManagerRef tm)
 {
     TypeRef type = tm->TypeList();
     while (type) {
-        Accept(type, type->Begin(kPASoftRead));
+        DataReflectionVisitor::Accept(type, type->Begin(kPASoftRead));
         if (_found)
             break;
         type = type->Next();
@@ -116,41 +85,6 @@ void PathFinderVisitor::Accept(TypeManagerRef tm)
     }
 }
 //------------------------------------------------------------
-//! Visitor dispatch helper method that defines a new/smaller haystack
-void PathFinderVisitor::Accept(TypeRef tHayStack, DataPointer pHayStack)
-{
-    if (_pNeedle == tHayStack) {
-        // The value may be a TypeRef. If so check and catch it here,
-        // no need for each visitor to do a check.
-        // _isTypeRef = true;
-        _found = true;
-    } else if ((_pNeedle == pHayStack) && (_tNeedle->IsA(tHayStack, true) )) {
-        // Once the needle is found then there is no need to keep
-        // digging if the types match. However, if the needle is the
-        // first field in a cluster more digging may be necessary
-        // to get the correct full symbol path.
-        _found = true;
-    } else {
-        // Dig deeper into the data.
-        void* saveData = _pHayStack;
-        _pHayStack = pHayStack;
-        tHayStack->Accept(this);
-        _pHayStack = saveData;
-    }
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitBad(TypeRef type)
-{
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitBitBlock(BitBlockType* type)
-{
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitBitCluster(BitClusterType* type)
-{
-}
-//------------------------------------------------------------
 void PathFinderVisitor::VisitCluster(ClusterType* type)
 {
     if (_pHayStack == null)
@@ -161,7 +95,7 @@ void PathFinderVisitor::VisitCluster(ClusterType* type)
         TypeRef elementType = type->GetSubElement(j);
         IntIndex offset = elementType->ElementOffset();
         AQBlock1* pElementData = (AQBlock1*)_pHayStack + offset;
-        Accept(elementType, pElementData);
+        DataReflectionVisitor::Accept(elementType, pElementData);
         if (_found) {
             if (!elementType->ElementName().CompareCStr("Locals")) {
                 if (!_pathEmpty) {
@@ -175,66 +109,6 @@ void PathFinderVisitor::VisitCluster(ClusterType* type)
             break;
         }
     }
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitParamBlock(ParamBlockType* type)
-{
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitEquivalence(EquivalenceType* type)
-{
-    Accept(type->GetSubElement(0), _pHayStack);
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitArray(ArrayType* type)
-{
-    if (_pHayStack == null)
-        return;
-
-    TypedArrayCoreRef pArray = *(TypedArrayCoreRef*)_pHayStack;
-    TypeRef elementType = pArray->ElementType();
-
-    if (type->IsZDA()) {
-        // ZDA's have one element.
-        Accept(elementType, pArray->RawBegin());
-    }
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitElement(ElementType* type)
-{
-    Accept(type->BaseType(), _pHayStack);
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitNamed(NamedType* type)
-{
-    Accept(type->BaseType(), _pHayStack);
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitPointer(PointerType* type)
-{
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitEnum(EnumType* type)
-{
-    Accept(type->BaseType(), _pHayStack);
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitRefNumVal(RefNumValType *type)
-{
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitDefaultValue(DefaultValueType* type)
-{
-    Accept(type->BaseType(), _pHayStack);
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitDefaultPointer(DefaultPointerType* type)
-{
-}
-//------------------------------------------------------------
-void PathFinderVisitor::VisitCustomDataProc(CustomDataProcType* type)
-{
-    Accept(type->BaseType(), _pHayStack);
 }
 
 }  // namespace Vireo

--- a/source/core/TypeAndDataPathFinder.cpp
+++ b/source/core/TypeAndDataPathFinder.cpp
@@ -1,6 +1,6 @@
 /**
 
-Copyright (c) 2015 National Instruments Corp.
+Copyright (c) 2018 National Instruments Corp.
 
 This software is subject to the terms described in the LICENSE.TXT file
 
@@ -20,7 +20,7 @@ namespace Vireo
 * that describes what the needle is a pointer to. The visitor will visit
 * all types in the type manger and thus ultimate all values owned by that type manager
 * and if necessary parent type managers as well.
-* initiall the hay stack is null, but when a type is visited that owns a value ( constant or var)
+* initially the hay stack is null, but when a type is visited that owns a value ( constant or var)
 * it will establish a haystack then as the type is visited the stack is narrowed.
 */
 
@@ -111,8 +111,6 @@ void PathFinderVisitor::Accept(TypeManagerRef tm)
             _path->InsertCStr(0, ".");
         }
         if (!type->IsA("VirtualInstrument")) {
-            // EncodedSubString encodedStr(rootName, true, false);
-            // SubString encSubStr = encodedStr.GetSubString();
             _path->InsertSubString(0, &rootName);
         }
     }
@@ -165,10 +163,9 @@ void PathFinderVisitor::VisitCluster(ClusterType* type)
         AQBlock1* pElementData = (AQBlock1*)_pHayStack + offset;
         Accept(elementType, pElementData);
         if (_found) {
-            
             if (!elementType->ElementName().CompareCStr("Locals")) {
                 if (!_pathEmpty) {
-                    _path->InsertCStr(0, ".");   
+                    _path->InsertCStr(0, ".");
                 }
                 SubString ss = elementType->ElementName();
                 _path->InsertSubString(0, &ss);

--- a/source/core/TypeAndDataPathFinder.cpp
+++ b/source/core/TypeAndDataPathFinder.cpp
@@ -1,0 +1,244 @@
+/**
+
+Copyright (c) 2015 National Instruments Corp.
+
+This software is subject to the terms described in the LICENSE.TXT file
+
+SDG
+*/
+
+/*! \file
+ */
+
+#include "TypeAndDataManager.h"
+
+namespace Vireo
+{
+
+//------------------------------------------------------------
+/* Create a visitor with a needle being looked for and a TypeRef
+* that describes what the needle is a pointer to. The visitor will visit
+* all types in the type manger and thus ultimate all values owned by that type manager
+* and if necessary parent type managers as well.
+* initiall the hay stack is null, but when a type is visited that owns a value ( constant or var)
+* it will establish a haystack then as the type is visited the stack is narrowed.
+*/
+
+class PathFinderVisitor : public TypeVisitor
+{
+ public:
+    PathFinderVisitor(TypeRef tNeedle, DataPointer pHaystack, StringRef path);
+    void Accept(TypeRef tHaystack, DataPointer pHaystack);
+    void Accept(TypeManagerRef tm);
+    Boolean Found() {return _found;}
+
+ private:
+    // What is being searched through
+    void*           _pHayStack;
+
+    // What is being looked for
+    TypeRef         _tNeedle;
+    void*           _pNeedle;
+
+    // Used as frames are unwound
+    Boolean         _pathEmpty;
+    Boolean         _found;
+    StringRef       _path;
+
+ private:
+    virtual void VisitBad(TypeRef type);
+    virtual void VisitBitBlock(BitBlockType* type);
+    virtual void VisitBitCluster(BitClusterType* type);
+    virtual void VisitCluster(ClusterType* type);
+    virtual void VisitParamBlock(ParamBlockType* type);
+    virtual void VisitEquivalence(EquivalenceType* type);
+    virtual void VisitArray(ArrayType* type);
+    virtual void VisitElement(ElementType* type);
+    virtual void VisitNamed(NamedType* type);
+    virtual void VisitPointer(PointerType* type);
+    virtual void VisitEnum(EnumType* type);
+    virtual void VisitRefNumVal(RefNumValType* type);
+    virtual void VisitDefaultValue(DefaultValueType* type);
+    virtual void VisitDefaultPointer(DefaultPointerType* type);
+    virtual void VisitCustomDataProc(CustomDataProcType* type);
+};
+//------------------------------------------------------------
+void TypeManager::GetPathFromPointer(TypeRef tNeedle, DataPointer pNeedle, StringRef path)
+{
+    path->Resize1D(0);
+    PathFinderVisitor drv(tNeedle, pNeedle, path);
+    for (TypeManager *tm = this; tm && !drv.Found(); tm = tm->BaseTypeManager()) {
+        drv.Accept(tm);
+    }
+
+    if (!drv.Found()) {
+        path->AppendCStr("*pointer-not-found*");
+    }
+}
+//------------------------------------------------------------
+PathFinderVisitor::PathFinderVisitor(TypeRef tHaystack, DataPointer pNeedle, StringRef path)
+{
+    _tNeedle = tHaystack;
+    _pNeedle = pNeedle;
+    _pHayStack = null;
+    _pathEmpty = true;
+    _found = false;
+    _path = path;
+}
+//------------------------------------------------------------
+//! Visitor dispatch helper method that traverses all the types in a TypeManager
+void PathFinderVisitor::Accept(TypeManagerRef tm)
+{
+    TypeRef type = tm->TypeList();
+    while (type) {
+        Accept(type, type->Begin(kPASoftRead));
+        if (_found)
+            break;
+        type = type->Next();
+    }
+
+    SubString rootName;
+    Boolean isTypeRefConstant = false;
+    if (_found) {
+        rootName = type->Name();
+    } else {
+        _found = tm->PointerToTypeConstRefName((TypeRef*)_pNeedle, &rootName);
+        isTypeRefConstant = _found;
+    }
+
+    if (_found) {
+        if (isTypeRefConstant) {
+            _path->InsertCStr(0, ".");
+        }
+        if (!type->IsA("VirtualInstrument")) {
+            // EncodedSubString encodedStr(rootName, true, false);
+            // SubString encSubStr = encodedStr.GetSubString();
+            _path->InsertSubString(0, &rootName);
+        }
+    }
+}
+//------------------------------------------------------------
+//! Visitor dispatch helper method that defines a new/smaller haystack
+void PathFinderVisitor::Accept(TypeRef tHayStack, DataPointer pHayStack)
+{
+    if (_pNeedle == tHayStack) {
+        // The value may be a TypeRef. If so check and catch it here,
+        // no need for each visitor to do a check.
+        // _isTypeRef = true;
+        _found = true;
+    } else if ((_pNeedle == pHayStack) && (_tNeedle->IsA(tHayStack, true) )) {
+        // Once the needle is found then there is no need to keep
+        // digging if the types match. However, if the needle is the
+        // first field in a cluster more digging may be necessary
+        // to get the correct full symbol path.
+        _found = true;
+    } else {
+        // Dig deeper into the data.
+        void* saveData = _pHayStack;
+        _pHayStack = pHayStack;
+        tHayStack->Accept(this);
+        _pHayStack = saveData;
+    }
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitBad(TypeRef type)
+{
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitBitBlock(BitBlockType* type)
+{
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitBitCluster(BitClusterType* type)
+{
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitCluster(ClusterType* type)
+{
+    if (_pHayStack == null)
+        return;
+
+    IntIndex count = type->SubElementCount();
+    for (IntIndex j = 0; j < count; j++) {
+        TypeRef elementType = type->GetSubElement(j);
+        IntIndex offset = elementType->ElementOffset();
+        AQBlock1* pElementData = (AQBlock1*)_pHayStack + offset;
+        Accept(elementType, pElementData);
+        if (_found) {
+            
+            if (!elementType->ElementName().CompareCStr("Locals")) {
+                if (!_pathEmpty) {
+                    _path->InsertCStr(0, ".");   
+                }
+                SubString ss = elementType->ElementName();
+                _path->InsertSubString(0, &ss);
+                _pathEmpty = false;
+            }
+
+            break;
+        }
+    }
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitParamBlock(ParamBlockType* type)
+{
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitEquivalence(EquivalenceType* type)
+{
+    Accept(type->GetSubElement(0), _pHayStack);
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitArray(ArrayType* type)
+{
+    if (_pHayStack == null)
+        return;
+
+    TypedArrayCoreRef pArray = *(TypedArrayCoreRef*)_pHayStack;
+    TypeRef elementType = pArray->ElementType();
+
+    if (type->IsZDA()) {
+        // ZDA's have one element.
+        Accept(elementType, pArray->RawBegin());
+    }
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitElement(ElementType* type)
+{
+    Accept(type->BaseType(), _pHayStack);
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitNamed(NamedType* type)
+{
+    Accept(type->BaseType(), _pHayStack);
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitPointer(PointerType* type)
+{
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitEnum(EnumType* type)
+{
+    Accept(type->BaseType(), _pHayStack);
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitRefNumVal(RefNumValType *type)
+{
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitDefaultValue(DefaultValueType* type)
+{
+    Accept(type->BaseType(), _pHayStack);
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitDefaultPointer(DefaultPointerType* type)
+{
+}
+//------------------------------------------------------------
+void PathFinderVisitor::VisitCustomDataProc(CustomDataProcType* type)
+{
+    Accept(type->BaseType(), _pHayStack);
+}
+
+}  // namespace Vireo
+

--- a/source/core/TypeAndDataReflection.cpp
+++ b/source/core/TypeAndDataReflection.cpp
@@ -115,18 +115,6 @@ void DataReflectionVisitor::Accept(TypeRef tHayStack, DataPointer pHayStack)
     }
 }
 //------------------------------------------------------------
-void DataReflectionVisitor::VisitBad(TypeRef type)
-{
-}
-//------------------------------------------------------------
-void DataReflectionVisitor::VisitBitBlock(BitBlockType* type)
-{
-}
-//------------------------------------------------------------
-void DataReflectionVisitor::VisitBitCluster(BitClusterType* type)
-{
-}
-//------------------------------------------------------------
 void DataReflectionVisitor::VisitCluster(ClusterType* type)
 {
     if (_pHayStack == null)
@@ -145,15 +133,6 @@ void DataReflectionVisitor::VisitCluster(ClusterType* type)
             break;
         }
     }
-}
-//------------------------------------------------------------
-void DataReflectionVisitor::VisitParamBlock(ParamBlockType* type)
-{
-}
-//------------------------------------------------------------
-void DataReflectionVisitor::VisitEquivalence(EquivalenceType* type)
-{
-    Accept(type->GetSubElement(0), _pHayStack);
 }
 //------------------------------------------------------------
 void DataReflectionVisitor::VisitArray(ArrayType* type)
@@ -190,43 +169,6 @@ void DataReflectionVisitor::VisitArray(ArrayType* type)
         }
     }
 #endif
-}
-//------------------------------------------------------------
-void DataReflectionVisitor::VisitElement(ElementType* type)
-{
-    Accept(type->BaseType(), _pHayStack);
-}
-//------------------------------------------------------------
-void DataReflectionVisitor::VisitNamed(NamedType* type)
-{
-    Accept(type->BaseType(), _pHayStack);
-}
-//------------------------------------------------------------
-void DataReflectionVisitor::VisitPointer(PointerType* type)
-{
-}
-//------------------------------------------------------------
-void DataReflectionVisitor::VisitEnum(EnumType* type)
-{
-    Accept(type->BaseType(), _pHayStack);
-}
-//------------------------------------------------------------
-void DataReflectionVisitor::VisitRefNumVal(RefNumValType *type)
-{
-}
-//------------------------------------------------------------
-void DataReflectionVisitor::VisitDefaultValue(DefaultValueType* type)
-{
-    Accept(type->BaseType(), _pHayStack);
-}
-//------------------------------------------------------------
-void DataReflectionVisitor::VisitDefaultPointer(DefaultPointerType* type)
-{
-}
-//------------------------------------------------------------
-void DataReflectionVisitor::VisitCustomDataProc(CustomDataProcType* type)
-{
-    Accept(type->BaseType(), _pHayStack);
 }
 #endif
 }  // namespace Vireo

--- a/source/core/TypeAndDataReflection.cpp
+++ b/source/core/TypeAndDataReflection.cpp
@@ -11,57 +11,11 @@ SDG
  */
 
 #include "TypeAndDataManager.h"
+#include "DataReflectionVisitor.h"
 
 namespace Vireo
 {
 #if defined (VIREO_INSTRUCTION_REFLECTION)
-
-//------------------------------------------------------------
-/* Create a visitor with a needle being looked for and a TypeRef
-* that describes what the needle is a pointer to. The visitor will visit
-* all types in the type manger and thus ultimate all values owned by that type manager
-* and if necessary parent type managers as well.
-* initiall the hay stack is null, but when a type is visited that owns a value ( constant or var)
-* it will establish a haystack then as the type is visited the stack is narrowed.
-*/
-
-class DataReflectionVisitor : public TypeVisitor
-{
- public:
-    DataReflectionVisitor(TypeRef tNeedle, DataPointer pHaystack, StringRef path);
-    void Accept(TypeRef tHaystack, DataPointer pHaystack);
-    void Accept(TypeManagerRef tm);
-    Boolean Found() {return _found;}
-
- private:
-    // What is being searched through
-    void*           _pHayStack;
-
-    // What is being looked for
-    TypeRef         _tNeedle;
-    void*           _pNeedle;
-
-    // Used as frames are unwound
-    Boolean         _found;
-    StringRef       _path;
-
- private:
-    virtual void VisitBad(TypeRef type);
-    virtual void VisitBitBlock(BitBlockType* type);
-    virtual void VisitBitCluster(BitClusterType* type);
-    virtual void VisitCluster(ClusterType* type);
-    virtual void VisitParamBlock(ParamBlockType* type);
-    virtual void VisitEquivalence(EquivalenceType* type);
-    virtual void VisitArray(ArrayType* type);
-    virtual void VisitElement(ElementType* type);
-    virtual void VisitNamed(NamedType* type);
-    virtual void VisitPointer(PointerType* type);
-    virtual void VisitEnum(EnumType* type);
-    virtual void VisitRefNumVal(RefNumValType* type);
-    virtual void VisitDefaultValue(DefaultValueType* type);
-    virtual void VisitDefaultPointer(DefaultPointerType* type);
-    virtual void VisitCustomDataProc(CustomDataProcType* type);
-};
 //------------------------------------------------------------
 TypeRef TypeManager::PointerToSymbolPath(TypeRef tNeedle, DataPointer pNeedle, StringRef path)
 {

--- a/source/include/DataReflectionVisitor.h
+++ b/source/include/DataReflectionVisitor.h
@@ -49,21 +49,21 @@ class DataReflectionVisitor : public TypeVisitor
     StringRef       _path;
 
  private:
-    virtual void VisitBad(TypeRef type);
-    virtual void VisitBitBlock(BitBlockType* type);
-    virtual void VisitBitCluster(BitClusterType* type);
+    virtual void VisitBad(TypeRef type)                         { }
+    virtual void VisitBitBlock(BitBlockType* type)              { }
+    virtual void VisitBitCluster(BitClusterType* type)          { }
     virtual void VisitCluster(ClusterType* type);
-    virtual void VisitParamBlock(ParamBlockType* type);
-    virtual void VisitEquivalence(EquivalenceType* type);
+    virtual void VisitParamBlock(ParamBlockType* type)          { }
+    virtual void VisitEquivalence(EquivalenceType* type)        { Accept(type->GetSubElement(0), _pHayStack); }
     virtual void VisitArray(ArrayType* type);
-    virtual void VisitElement(ElementType* type);
-    virtual void VisitNamed(NamedType* type);
-    virtual void VisitPointer(PointerType* type);
-    virtual void VisitEnum(EnumType* type);
-    virtual void VisitRefNumVal(RefNumValType* type);
-    virtual void VisitDefaultValue(DefaultValueType* type);
-    virtual void VisitDefaultPointer(DefaultPointerType* type);
-    virtual void VisitCustomDataProc(CustomDataProcType* type);
+    virtual void VisitElement(ElementType* type)                { Accept(type->BaseType(), _pHayStack); }
+    virtual void VisitNamed(NamedType* type)                    { Accept(type->BaseType(), _pHayStack); }
+    virtual void VisitPointer(PointerType* type)                { }
+    virtual void VisitEnum(EnumType* type)                      { Accept(type->BaseType(), _pHayStack); }
+    virtual void VisitRefNumVal(RefNumValType* type)            { }
+    virtual void VisitDefaultValue(DefaultValueType* type)      { Accept(type->BaseType(), _pHayStack); }
+    virtual void VisitDefaultPointer(DefaultPointerType* type)  { }
+    virtual void VisitCustomDataProc(CustomDataProcType* type)  { Accept(type->BaseType(), _pHayStack); }
 };
 #endif
 }  // namespace Vireo

--- a/source/include/DataReflectionVisitor.h
+++ b/source/include/DataReflectionVisitor.h
@@ -1,0 +1,71 @@
+
+/**
+
+Copyright (c) 2015 National Instruments Corp.
+
+This software is subject to the terms described in the LICENSE.TXT file
+
+SDG
+*/
+
+/*! \file
+*/
+
+#ifndef DataReflectionVisitor_H
+#define DataReflectionVisitor_H
+
+#include "TypeAndDataManager.h"
+
+namespace Vireo
+{
+#if defined (VIREO_INSTRUCTION_REFLECTION)
+//------------------------------------------------------------
+/* Create a visitor with a needle being looked for and a TypeRef
+* that describes what the needle is a pointer to. The visitor will visit
+* all types in the type manager and thus ultimate all values owned by that type manager
+* and if necessary parent type managers as well.
+* initially the hay stack is null, but when a type is visited that owns a value ( constant or var)
+* it will establish a haystack then as the type is visited the stack is narrowed.
+*/
+
+class DataReflectionVisitor : public TypeVisitor
+{
+ public:
+    DataReflectionVisitor(TypeRef tNeedle, DataPointer pHaystack, StringRef path);
+    void Accept(TypeRef tHaystack, DataPointer pHaystack);
+    void Accept(TypeManagerRef tm);
+    Boolean Found() { return _found; }
+
+ protected:
+    // What is being searched through
+    void*           _pHayStack;
+
+    // What is being looked for
+    TypeRef         _tNeedle;
+    void*           _pNeedle;
+
+    // Used as frames are unwound
+    Boolean         _found;
+    StringRef       _path;
+
+ private:
+    virtual void VisitBad(TypeRef type);
+    virtual void VisitBitBlock(BitBlockType* type);
+    virtual void VisitBitCluster(BitClusterType* type);
+    virtual void VisitCluster(ClusterType* type);
+    virtual void VisitParamBlock(ParamBlockType* type);
+    virtual void VisitEquivalence(EquivalenceType* type);
+    virtual void VisitArray(ArrayType* type);
+    virtual void VisitElement(ElementType* type);
+    virtual void VisitNamed(NamedType* type);
+    virtual void VisitPointer(PointerType* type);
+    virtual void VisitEnum(EnumType* type);
+    virtual void VisitRefNumVal(RefNumValType* type);
+    virtual void VisitDefaultValue(DefaultValueType* type);
+    virtual void VisitDefaultPointer(DefaultPointerType* type);
+    virtual void VisitCustomDataProc(CustomDataProcType* type);
+};
+#endif
+}  // namespace Vireo
+
+#endif  // /* DataReflectionVisitor_H */

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -289,6 +289,7 @@ class TypeManager
     //! Parse through a path, digging through Aggregate element names, references and array indexes.
     TypeRef GetObjectElementAddressFromPath(SubString* objectName, SubString* path, void** ppData,
                                             Boolean allowDynamic);
+    void GetPathFromPointer(TypeRef t, DataPointer p, StringRef path);
 #if defined (VIREO_INSTRUCTION_REFLECTION)
     TypeRef DefineCustomPointerTypeWithValue(ConstCStr name, void* pointer, TypeRef type,
                                              PointerTypeEnum pointerType, ConstCStr cName);

--- a/source/io/PropertyNode.cpp
+++ b/source/io/PropertyNode.cpp
@@ -82,12 +82,12 @@ VIREO_FUNCTION_SIGNATUREV(PropertyNodeWrite, PropertyNodeWriteParamBlock)
     STACK_VAR(String, dataItemIdVar);
     StringRef dataItemId = dataItemIdVar.Value;
     if (!LookupControlRefForPropertyNode(refNumPtr, errorClusterPtr, viName, dataItemId, propNodeWriteName))
-        return _NextInstruction();  // control refnum lookup failed and set errorCluter
+        return _NextInstruction();  // control refnum lookup failed and set errorCluster
 
     TypeManagerRef typeManager = value->_paramType->TheTypeManager();
 
     STACK_VAR(String, pathRef);
-    typeManager->PointerToSymbolPath(value->_paramType, value->_pData, pathRef.Value);
+    typeManager->GetPathFromPointer(value->_paramType, value->_pData, pathRef.Value);
 
     STACK_VAR(String, typeRef);
     SubString typeName = value->_paramType->Name();
@@ -137,12 +137,12 @@ VIREO_FUNCTION_SIGNATUREV(PropertyNodeRead, PropertyNodeReadParamBlock)
     STACK_VAR(String, dataItemIdVar);
     StringRef dataItemId = dataItemIdVar.Value;
     if (!LookupControlRefForPropertyNode(refNumPtr, errorClusterPtr, viName, dataItemId, propNodeReadName))
-        return _NextInstruction();  // control refnum lookup failed and set errorCluter
+        return _NextInstruction();  // control refnum lookup failed and set errorCluster
 
     TypeManagerRef typeManager = value->_paramType->TheTypeManager();
 
     STACK_VAR(String, pathRef);
-    typeManager->PointerToSymbolPath(value->_paramType, value->_pData, pathRef.Value);
+    typeManager->GetPathFromPointer(value->_paramType, value->_pData, pathRef.Value);
 
     STACK_VAR(String, typeRef);
     SubString typeName = value->_paramType->Name();

--- a/test-it/karma/fixtures/propertynode/PropertyNodeRead.via
+++ b/test-it/karma/fixtures/propertynode/PropertyNodeRead.via
@@ -1,4 +1,4 @@
-define (MyVI dv(.VirtualInstrument (
+define (%3AWeb%20Server%3AInteractive%3AWebApp%3AMain%2Egviweb dv(.VirtualInstrument (
     Locals: c(
         e(.Boolean booleanLocal)
         e(.String stringLocal)
@@ -7,7 +7,13 @@ define (MyVI dv(.VirtualInstrument (
         e(.UInt32 uint32Local)
         e(.ComplexDouble complexDoubleLocal)
         e(.Timestamp timestampLocal)
-
+        e(.Double numberLocal)
+        e(dv(c(
+            e(.Double %3Anumeric%3A)
+            e(c(
+                e(.Boolean Boolean%20Space%20Part)
+            ) nestedClusterLocal )
+        ) (0 (false ) )) clusterLocal)
         e(c(
             e(.Boolean status)
             e(.Int32 code)
@@ -20,6 +26,7 @@ define (MyVI dv(.VirtualInstrument (
         e(dv(ControlRefNum ControlReference("dataItem_UInt32")) uInt32Ref)
         e(dv(ControlRefNum ControlReference("dataItem_ComplexDouble")) complexDoubleRef)
         e(dv(ControlRefNum ControlReference("dataItem_Timestamp")) timestampRef)
+        e(dv(ControlRefNum ControlReference("dataItem_MíNúmero")) numberRef)
     )
         clump(1
 
@@ -30,6 +37,9 @@ define (MyVI dv(.VirtualInstrument (
             PropertyNodeRead(uInt32Ref "value" uint32Local error)
             PropertyNodeRead(complexDoubleRef "value" complexDoubleLocal error)
             PropertyNodeRead(timestampRef "value" timestampLocal error)
+            PropertyNodeRead(numberRef "Value" numberLocal error)
+            PropertyNodeRead(numberRef "Value" clusterLocal.%3Anumeric%3A error)
+            PropertyNodeRead(booleanRef "Value" clusterLocal.nestedClusterLocal.Boolean%20Space%20Part error)
         )
 )))
-enqueue(MyVI)
+enqueue(%3AWeb%20Server%3AInteractive%3AWebApp%3AMain%2Egviweb)

--- a/test-it/karma/propertynode/PropertyNode.Test.js
+++ b/test-it/karma/propertynode/PropertyNode.Test.js
@@ -1,4 +1,4 @@
-describe('The Vireo PropertyNode', function () {
+fdescribe('The Vireo PropertyNode', function () {
     'use strict';
 
     var Vireo = window.NationalInstruments.Vireo.Vireo;
@@ -9,6 +9,8 @@ describe('The Vireo PropertyNode', function () {
 
     var publicApiPropertyNodeWrite = fixtures.convertToAbsoluteFromFixturesDir('propertynode/PropertyNodeWrite.via');
     var publicApiPropertyNodeRead = fixtures.convertToAbsoluteFromFixturesDir('propertynode/PropertyNodeRead.via');
+    var propertyReadVIName = '%3AWeb%20Server%3AInteractive%3AWebApp%3AMain%2Egviweb';
+    var propertyWriteVIName = 'MyVI';
 
     beforeAll(function (done) {
         fixtures.preloadAbsoluteUrls([
@@ -32,43 +34,85 @@ describe('The Vireo PropertyNode', function () {
         });
     });
 
-    it('calls propertyRead', function (done) {
-        var spy = jasmine.createSpy();
-        vireo.propertyNode.setPropertyReadFunction(spy);
+    describe('propertyRead', function () {
+        var runSlicesAsync, viPathParser, viPathWriter,
+            decodedReadVIName = decodeURIComponent(propertyReadVIName);
 
-        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiPropertyNodeRead);
-
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeEmptyString();
-            expect(rawPrintError).toBeEmptyString();
-            expect(spy.calls.argsFor(0)).toEqual(['MyVI', 'dataItem_Boolean', 'value', 'Boolean', 'MyVI.Locals.booleanLocal']);
-            expect(spy.calls.argsFor(1)).toEqual(['MyVI', 'dataItem_String', 'value', 'String', 'MyVI.Locals.stringLocal']);
-            expect(spy.calls.argsFor(2)).toEqual(['MyVI', 'dataItem_Double', 'value', 'Double', 'MyVI.Locals.doubleLocal']);
-            expect(spy.calls.argsFor(3)).toEqual(['MyVI', 'dataItem_Int32', 'value', 'Int32', 'MyVI.Locals.int32Local']);
-            expect(spy.calls.argsFor(4)).toEqual(['MyVI', 'dataItem_UInt32', 'value', 'UInt32', 'MyVI.Locals.uint32Local']);
-            expect(spy.calls.argsFor(5)).toEqual(['MyVI', 'dataItem_ComplexDouble', 'value', 'ComplexDouble', 'MyVI.Locals.complexDoubleLocal']);
-            expect(spy.calls.argsFor(6)).toEqual(['MyVI', 'dataItem_Timestamp', 'value', 'Timestamp', 'MyVI.Locals.timestampLocal']);
-            done();
+        beforeEach(function () {
+            runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiPropertyNodeRead);
+            viPathParser = vireoRunner.createVIPathParser(vireo, propertyReadVIName);
+            viPathWriter = vireoRunner.createVIPathWriter(vireo, propertyReadVIName);
         });
-    });
 
-    it('propertyRead writes an error when external function throws', function (done) {
-        var readFunction = function () {
-            throw new Error('This is not good');
-        };
+        it('callback is invoked with expected parameters', function (done) {
+            var spy = jasmine.createSpy();
+            vireo.propertyNode.setPropertyReadFunction(spy);
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+                expect(spy.calls.argsFor(0)).toEqual([decodedReadVIName, 'dataItem_Boolean', 'value', 'Boolean', 'booleanLocal']);
+                expect(spy.calls.argsFor(1)).toEqual([decodedReadVIName, 'dataItem_String', 'value', 'String', 'stringLocal']);
+                expect(spy.calls.argsFor(2)).toEqual([decodedReadVIName, 'dataItem_Double', 'value', 'Double', 'doubleLocal']);
+                expect(spy.calls.argsFor(3)).toEqual([decodedReadVIName, 'dataItem_Int32', 'value', 'Int32', 'int32Local']);
+                expect(spy.calls.argsFor(4)).toEqual([decodedReadVIName, 'dataItem_UInt32', 'value', 'UInt32', 'uint32Local']);
+                expect(spy.calls.argsFor(5)).toEqual([decodedReadVIName, 'dataItem_ComplexDouble', 'value', 'ComplexDouble', 'complexDoubleLocal']);
+                expect(spy.calls.argsFor(6)).toEqual([decodedReadVIName, 'dataItem_Timestamp', 'value', 'Timestamp', 'timestampLocal']);
+                expect(spy.calls.argsFor(7)).toEqual([decodedReadVIName, 'dataItem_MíNúmero', 'Value', 'Double', 'numberLocal']);
+                expect(spy.calls.argsFor(8)).toEqual([decodedReadVIName, 'dataItem_MíNúmero', 'Value', 'Double', 'clusterLocal.%3Anumeric%3A']);
+                expect(spy.calls.argsFor(9)).toEqual([decodedReadVIName, 'dataItem_Boolean', 'Value', 'Boolean', 'clusterLocal.nestedClusterLocal.Boolean%20Space%20Part']);
+                done();
+            });
+        });
 
-        vireo.propertyNode.setPropertyReadFunction(readFunction);
+        it('writes an error when callback function throws', function (done) {
+            var readFunction = function () {
+                throw new Error('This is not good');
+            };
+            vireo.propertyNode.setPropertyReadFunction(readFunction);
 
-        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiPropertyNodeRead);
-        var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+                expect(viPathParser('error.status')).toBeTrue();
+                expect(viPathParser('error.code')).toBe(1055);
+                expect(viPathParser('error.source')).toMatch(/PropertyNodeRead/);
+                done();
+            });
+        });
 
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeEmptyString();
-            expect(rawPrintError).toBeEmptyString();
-            expect(viPathParser('error.status')).toBeTrue();
-            expect(viPathParser('error.code')).toBe(1055);
-            expect(viPathParser('error.source')).toMatch(/PropertyNodeRead in MyVI/);
-            done();
+        it('callback can use parameters to write back to vireo', function (done) {
+            var complexToWrite = {
+                real: 10,
+                imaginary: -10
+            };
+            var expectedTimestamp = {
+                seconds: 0,
+                fraction: 0
+            };
+            var valuesToRead = [true, 'Lorem ipsum', 3.14, -24, 123456, complexToWrite, '0:0', 6.28];
+            var indexToRead = 0;
+            var readFunction = function (viName, fpId, propertyName, propertyTypeName, propertyPath) {
+                var valueRead = valuesToRead[indexToRead];
+                indexToRead += 1;
+                viPathWriter(propertyPath, valueRead);
+            };
+
+            vireo.propertyNode.setPropertyReadFunction(readFunction);
+
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+                expect(viPathParser('booleanLocal')).toEqual(valuesToRead[0]);
+                expect(viPathParser('stringLocal')).toEqual(valuesToRead[1]);
+                expect(viPathParser('doubleLocal')).toEqual(valuesToRead[2]);
+                expect(viPathParser('int32Local')).toEqual(valuesToRead[3]);
+                expect(viPathParser('uint32Local')).toEqual(valuesToRead[4]);
+                expect(viPathParser('complexDoubleLocal')).toEqual(valuesToRead[5]);
+                expect(viPathParser('timestampLocal')).toEqual(expectedTimestamp);
+                expect(viPathParser('numberLocal')).toEqual(valuesToRead[7]);
+
+                done();
+            });
         });
     });
 
@@ -83,44 +127,74 @@ describe('The Vireo PropertyNode', function () {
         });
     });
 
-    it('calls propertyWrite', function (done) {
-        var spy = jasmine.createSpy();
+    describe('propertyWrite', function () {
+        var runSlicesAsync, viPathParser;
 
-        vireo.propertyNode.setPropertyWriteFunction(spy);
-
-        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiPropertyNodeWrite);
-
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeEmptyString();
-            expect(rawPrintError).toBeEmptyString();
-            expect(spy.calls.argsFor(0)).toEqual(['MyVI', 'dataItem_Boolean', 'value', 'Boolean', 'MyVI.Locals.myBoolValue']);
-            expect(spy.calls.argsFor(1)).toEqual(['MyVI', 'dataItem_String', 'value', 'String', 'MyVI.Locals.stringLocal']);
-            expect(spy.calls.argsFor(2)).toEqual(['MyVI', 'dataItem_Double', 'value', 'Double', 'MyVI.Locals.doubleLocal']);
-            expect(spy.calls.argsFor(3)).toEqual(['MyVI', 'dataItem_Int32', 'value', 'Int32', 'MyVI.Locals.int32Local']);
-            expect(spy.calls.argsFor(4)).toEqual(['MyVI', 'dataItem_UInt32', 'value', 'UInt32', 'MyVI.Locals.uint32Local']);
-            expect(spy.calls.argsFor(5)).toEqual(['MyVI', 'dataItem_ComplexDouble', 'value', 'ComplexDouble', 'MyVI.Locals.complexDoubleLocal']);
-            expect(spy.calls.argsFor(6)).toEqual(['MyVI', 'dataItem_Timestamp', 'value', 'Timestamp', 'MyVI.Locals.timestampLocal']);
-            done();
+        beforeEach(function () {
+            runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiPropertyNodeWrite);
+            viPathParser = vireoRunner.createVIPathParser(vireo, propertyWriteVIName);
         });
-    });
 
-    it('propertyWrite writes an error when external function throws', function (done) {
-        var writeFunction = function () {
-            throw new Error('This is not good');
-        };
+        it('callback is invoked with expected parameters', function (done) {
+            var spy = jasmine.createSpy();
+            vireo.propertyNode.setPropertyWriteFunction(spy);
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+                expect(spy.calls.argsFor(0)).toEqual([propertyWriteVIName, 'dataItem_Boolean', 'value', 'Boolean', 'myBoolValue']);
+                expect(spy.calls.argsFor(1)).toEqual([propertyWriteVIName, 'dataItem_String', 'value', 'String', 'stringLocal']);
+                expect(spy.calls.argsFor(2)).toEqual([propertyWriteVIName, 'dataItem_Double', 'value', 'Double', 'doubleLocal']);
+                expect(spy.calls.argsFor(3)).toEqual([propertyWriteVIName, 'dataItem_Int32', 'value', 'Int32', 'int32Local']);
+                expect(spy.calls.argsFor(4)).toEqual([propertyWriteVIName, 'dataItem_UInt32', 'value', 'UInt32', 'uint32Local']);
+                expect(spy.calls.argsFor(5)).toEqual([propertyWriteVIName, 'dataItem_ComplexDouble', 'value', 'ComplexDouble', 'complexDoubleLocal']);
+                expect(spy.calls.argsFor(6)).toEqual([propertyWriteVIName, 'dataItem_Timestamp', 'value', 'Timestamp', 'timestampLocal']);
+                done();
+            });
+        });
 
-        vireo.propertyNode.setPropertyWriteFunction(writeFunction);
+        it('writes an error when callback function throws', function (done) {
+            var writeFunction = function () {
+                throw new Error('This is not good');
+            };
+            vireo.propertyNode.setPropertyWriteFunction(writeFunction);
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+                expect(viPathParser('error.status')).toBeTrue();
+                expect(viPathParser('error.code')).toBe(1055);
+                expect(viPathParser('error.source')).toMatch(/PropertyNodeWrite/);
+                done();
+            });
+        });
 
-        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiPropertyNodeWrite);
-        var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
+        it('callback function can read from vireo using parameters', function (done) {
+            var expectedValues = {
+                myBoolValue: false,
+                stringLocal: 'Dolor amet sit amet',
+                doubleLocal: 1234.5678,
+                int32Local: -1000,
+                uint32Local: 9876543,
+                complexDoubleLocal: {
+                    real: 5.045,
+                    imaginary: -5.67
+                },
+                timestampLocal: {
+                    seconds: 3564057536,
+                    fraction: 7811758927381449000
+                }
+            };
+            var writeFunction = function (viName, fpId, propertyName, propertyTypeName, propertyPath) {
+                var readValue = viPathParser(propertyPath);
+                var expectedVal = expectedValues[propertyPath];
+                expect(readValue).toEqual(expectedVal);
+            };
+            vireo.propertyNode.setPropertyWriteFunction(writeFunction);
 
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeEmptyString();
-            expect(rawPrintError).toBeEmptyString();
-            expect(viPathParser('error.status')).toBeTrue();
-            expect(viPathParser('error.code')).toBe(1055);
-            expect(viPathParser('error.source')).toMatch(/PropertyNodeWrite in MyVI/);
-            done();
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+                done();
+            });
         });
     });
 });

--- a/test-it/karma/propertynode/PropertyNode.Test.js
+++ b/test-it/karma/propertynode/PropertyNode.Test.js
@@ -1,4 +1,4 @@
-fdescribe('The Vireo PropertyNode', function () {
+describe('The Vireo PropertyNode', function () {
     'use strict';
 
     var Vireo = window.NationalInstruments.Vireo.Vireo;


### PR DESCRIPTION
The main purpose of this change is to change the format of the path that propertyRead/Write JS callbacks receive.
Previously we were using `TypeManager::PointerToSymbolPath` however this method adds the decoded VI name and the `Locals` section to the resulting path.

I started just tweaking and modifying TypeAndDataReflection, but since it already has some tests and I didn't want to break it, I added TypeAndDataPathFinder visitor which is based on the former.

I also added a few more cases to `PropertyNode.Test.js` to validate that the path passed to the js callbacks can be used to read/write from Vireo.

A few more comments before starting.
1. I ended up not using the EncodedSubString I implemented because while building the path we are already using encoded names.
2. Ended up not saving the encoded VI name since JS uses the decoded VI name to search for the control model. The model (on JS side) has the encoded VI name which can be used to read/write to/from vireo.