### PR TITLE
add appveyor-retry command

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,8 +11,8 @@ init:
 - ps: $PSVersionTable
 install:
   - ps: Install-Product node 8
-  - chocolatey install make
-  - chocolatey install gnuwin32-coreutils.portable
+  - appveyor-retry chocolatey install make
+  - appveyor-retry chocolatey install gnuwin32-coreutils.portable
   - appveyor-retry npm install
   - pip install tox
   - ps: Start-Process npm "run httpbin" -PassThru

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ install:
   - ps: Install-Product node 8
   - chocolatey install make
   - chocolatey install gnuwin32-coreutils.portable
-  - npm install
+  - appveyor-retry npm install
   - pip install tox
   - ps: Start-Process npm "run httpbin" -PassThru
   - git clone https://github.com/juj/emsdk.git


### PR DESCRIPTION
See appveyor/ci#418 for how script works. The idea to use it came from https://help.appveyor.com/discussions/problems/3147-error-eperm-operation-not-permitted-rename-on-npm-install (See the last comment).