### PR TITLE
Fix JSLI function context for function invocations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,4 @@ emscripten-sdk/*
 emsdk/*
 coverage/*
 objs/*
+gh-pages/*

--- a/source/io/module_javaScriptInvoke.js
+++ b/source/io/module_javaScriptInvoke.js
@@ -382,19 +382,19 @@
             return completionCallback;
         };
 
-        var generateContext = function (occurrencePointer, functionName, returnTypeName, returnValuePointer, errorStatusPointer, errorCodePointer, errorSourcePointer, completionCallbackStatus) {
-            var context = {};
-            context.getCompletionCallback = function () {
+        var generateAPI = function (occurrencePointer, functionName, returnTypeName, returnValuePointer, errorStatusPointer, errorCodePointer, errorSourcePointer, completionCallbackStatus) {
+            var api = {};
+            api.getCompletionCallback = function () {
                 if (completionCallbackStatus.retrievalState === completionCallbackRetrievalEnum.RETRIEVED) {
                     throw new Error('The completion callback was retrieved more than once for ' + functionName + '.');
                 }
                 if (completionCallbackStatus.retrievalState === completionCallbackRetrievalEnum.UNRETRIEVABLE) {
-                    throw new Error('The context being accessed for ' + functionName + ' is not valid anymore.');
+                    throw new Error('The API being accessed for ' + functionName + ' is not valid anymore.');
                 }
                 completionCallbackStatus.retrievalState = completionCallbackRetrievalEnum.RETRIEVED;
                 return generateCompletionCallback(occurrencePointer, functionName, returnTypeName, returnValuePointer, errorStatusPointer, errorCodePointer, errorSourcePointer, completionCallbackStatus);
             };
-            return context;
+            return api;
         };
 
         Module.javaScriptInvoke.jsJavaScriptInvoke = function (
@@ -452,10 +452,10 @@
             };
 
             var returnValue = undefined;
-            var jsAPI;
+            var api;
             if (functionToCall.length === parameters.length + 1) {
-                jsAPI = generateContext(occurrencePointer, functionName, returnTypeName, returnValuePointer, errorStatusPointer, errorCodePointer, errorSourcePointer, completionCallbackStatus);
-                parameters.push(jsAPI);
+                api = generateAPI(occurrencePointer, functionName, returnTypeName, returnValuePointer, errorStatusPointer, errorCodePointer, errorSourcePointer, completionCallbackStatus);
+                parameters.push(api);
             }
 
             try {

--- a/test-it/karma/javascriptinvoke/Async.Test.js
+++ b/test-it/karma/javascriptinvoke/Async.Test.js
@@ -44,7 +44,7 @@ describe('A JavaScript function invoke', function () {
         NI_RetrieveCompletionCallbackMoreThanOnceAfterCallback: function (inputInteger, jsAPI) {
             var completionCallback = jsAPI.getCompletionCallback();
             completionCallback(inputInteger * inputInteger);
-            expect(jsAPI.getCompletionCallback).toThrowError(/The context being accessed for NI_RetrieveCompletionCallbackMoreThanOnceAfterCallback is not valid anymore./);
+            expect(jsAPI.getCompletionCallback).toThrowError(/The API being accessed for NI_RetrieveCompletionCallbackMoreThanOnceAfterCallback is not valid anymore./);
         },
         NI_CallCompletionCallbackMoreThanOnce: function (inputInteger, jsAPI) {
             var completionCallback = jsAPI.getCompletionCallback();
@@ -61,7 +61,7 @@ describe('A JavaScript function invoke', function () {
             };
             expect(testCompletion).not.toThrowError();
             expect(testCompletion).toThrowError(/invoked more than once for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval/);
-            expect(jsAPI.getCompletionCallback).toThrowError(/The context being accessed for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval is not valid anymore./);
+            expect(jsAPI.getCompletionCallback).toThrowError(/The API being accessed for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval is not valid anymore./);
             expect(testCompletion).toThrowError(/invoked more than once for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval/);
         },
         NI_CompletionCallbackReturnsUndefined: function (inputInteger, jsAPI) {
@@ -198,7 +198,7 @@ describe('A JavaScript function invoke', function () {
         vireo.eggShell.loadVia('enqueue(RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution)');
         runSlicesAsync(function () {
             expect(CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution.getCompletionCallback)
-                .toThrowError(/The context being accessed for NI_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution is not valid anymore/);
+                .toThrowError(/The API being accessed for NI_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution is not valid anymore/);
             expect(viPathParser('return')).toBe(36);
             done();
         });
@@ -209,7 +209,7 @@ describe('A JavaScript function invoke', function () {
         vireo.eggShell.loadVia('enqueue(RetrieveCompletionCallbackAfterContextIsStaleFromError)');
         runSlicesAsync(function () {
             expect(CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromError.getCompletionCallback)
-                .toThrowError(/The context being accessed for NI_RetrieveCompletionCallbackAfterContextIsStaleFromError is not valid anymore/);
+                .toThrowError(/The API being accessed for NI_RetrieveCompletionCallbackAfterContextIsStaleFromError is not valid anymore/);
             done();
         });
     });

--- a/test-it/karma/javascriptinvoke/Async.Test.js
+++ b/test-it/karma/javascriptinvoke/Async.Test.js
@@ -14,17 +14,17 @@ describe('A JavaScript function invoke', function () {
     var NI_CallCompletionCallbackAfterFunctionErrors_Callback;
 
     var javaScriptInvokeFixtures = Object.freeze({
-        NI_AsyncSquareFunction: function (inputInteger) {
-            var completionCallback = this.getCompletionCallback();
+        NI_AsyncSquareFunction: function (inputInteger, jsAPI) {
+            var completionCallback = jsAPI.getCompletionCallback();
             setTimeout(function () {
                 completionCallback(inputInteger * inputInteger);
             }, 0);
         },
-        NI_CallCompletionCallbackSynchronously: function (inputInteger) {
-            var completionCallback = this.getCompletionCallback();
+        NI_CallCompletionCallbackSynchronously: function (inputInteger, jsAPI) {
+            var completionCallback = jsAPI.getCompletionCallback();
             completionCallback(inputInteger * inputInteger);
         },
-        NI_PromiseBasedAsyncSquareFunction: function (inputInteger) {
+        NI_PromiseBasedAsyncSquareFunction: function (inputInteger, jsAPI) {
             var createTimerPromise = function (input) {
                 var myPromise = new Promise(function (resolve) {
                     setTimeout(function () {
@@ -33,46 +33,46 @@ describe('A JavaScript function invoke', function () {
                 });
                 return myPromise;
             };
-            var completionCallback = this.getCompletionCallback();
+            var completionCallback = jsAPI.getCompletionCallback();
             createTimerPromise(inputInteger).then(completionCallback);
         },
-        NI_RetrieveCompletionCallbackMoreThanOnceBeforeCallback: function (inputInteger) {
-            var completionCallback = this.getCompletionCallback();
-            expect(this.getCompletionCallback).toThrowError(/retrieved more than once/);
+        NI_RetrieveCompletionCallbackMoreThanOnceBeforeCallback: function (inputInteger, jsAPI) {
+            var completionCallback = jsAPI.getCompletionCallback();
+            expect(jsAPI.getCompletionCallback).toThrowError(/retrieved more than once/);
             completionCallback(inputInteger + inputInteger);
         },
-        NI_RetrieveCompletionCallbackMoreThanOnceAfterCallback: function (inputInteger) {
-            var completionCallback = this.getCompletionCallback();
+        NI_RetrieveCompletionCallbackMoreThanOnceAfterCallback: function (inputInteger, jsAPI) {
+            var completionCallback = jsAPI.getCompletionCallback();
             completionCallback(inputInteger * inputInteger);
-            expect(this.getCompletionCallback).toThrowError(/The context being accessed for NI_RetrieveCompletionCallbackMoreThanOnceAfterCallback is not valid anymore./);
+            expect(jsAPI.getCompletionCallback).toThrowError(/The context being accessed for NI_RetrieveCompletionCallbackMoreThanOnceAfterCallback is not valid anymore./);
         },
-        NI_CallCompletionCallbackMoreThanOnce: function (inputInteger) {
-            var completionCallback = this.getCompletionCallback();
+        NI_CallCompletionCallbackMoreThanOnce: function (inputInteger, jsAPI) {
+            var completionCallback = jsAPI.getCompletionCallback();
             var testCompletion = function () {
                 completionCallback(inputInteger * inputInteger);
             };
             expect(testCompletion).not.toThrowError();
             expect(testCompletion).toThrowError(/invoked more than once for NI_CallCompletionCallbackMoreThanOnce/);
         },
-        NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval: function (inputInteger) {
-            var completionCallback = this.getCompletionCallback();
+        NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval: function (inputInteger, jsAPI) {
+            var completionCallback = jsAPI.getCompletionCallback();
             var testCompletion = function () {
                 completionCallback(inputInteger * inputInteger);
             };
             expect(testCompletion).not.toThrowError();
             expect(testCompletion).toThrowError(/invoked more than once for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval/);
-            expect(this.getCompletionCallback).toThrowError(/The context being accessed for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval is not valid anymore./);
+            expect(jsAPI.getCompletionCallback).toThrowError(/The context being accessed for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval is not valid anymore./);
             expect(testCompletion).toThrowError(/invoked more than once for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval/);
         },
-        NI_CompletionCallbackReturnsUndefined: function () {
-            var completionCallback = this.getCompletionCallback();
+        NI_CompletionCallbackReturnsUndefined: function (inputInteger, jsAPI) {
+            var completionCallback = jsAPI.getCompletionCallback();
             var testCompletion = function () {
                 completionCallback(undefined);
             };
             expect(testCompletion).not.toThrowError();
         },
-        NI_CallCompletionCallbackAcrossClumps_DoubleFunction: function (inputInteger) {
-            var completionCallback = this.getCompletionCallback();
+        NI_CallCompletionCallbackAcrossClumps_DoubleFunction: function (inputInteger, jsAPI) {
+            var completionCallback = jsAPI.getCompletionCallback();
             running = 1;
             var firstClumpCompletionCallback = function () {
                 if (running === 2) {
@@ -84,8 +84,8 @@ describe('A JavaScript function invoke', function () {
             };
             firstClumpCompletionCallback();
         },
-        NI_CallCompletionCallbackAcrossClumps_SquareFunction: function (inputInteger) {
-            var completionCallback = this.getCompletionCallback();
+        NI_CallCompletionCallbackAcrossClumps_SquareFunction: function (inputInteger, jsAPI) {
+            var completionCallback = jsAPI.getCompletionCallback();
             var secondClumpCompletionCallback = function () {
                 if (running === 1) {
                     completionCallback(inputInteger * inputInteger);
@@ -96,18 +96,16 @@ describe('A JavaScript function invoke', function () {
             };
             secondClumpCompletionCallback();
         },
-        NI_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution: function (inputInteger) {
-            // eslint-disable-next-line consistent-this
-            CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution = this;
+        NI_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution: function (inputInteger, jsAPI) {
+            CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution = jsAPI;
             return inputInteger * inputInteger;
         },
-        NI_RetrieveCompletionCallbackAfterContextIsStaleFromError: function () {
-            // eslint-disable-next-line consistent-this
-            CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromError = this;
+        NI_RetrieveCompletionCallbackAfterContextIsStaleFromError: function (inputInteger, jsAPI) {
+            CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromError = jsAPI;
             throw new Error('This function is a failure!');
         },
-        NI_CallCompletionCallbackAfterFunctionErrors: function () {
-            NI_CallCompletionCallbackAfterFunctionErrors_Callback = this.getCompletionCallback();
+        NI_CallCompletionCallbackAfterFunctionErrors: function (inputInteger, jsAPI) {
+            NI_CallCompletionCallbackAfterFunctionErrors_Callback = jsAPI.getCompletionCallback();
             throw new Error('Your function call just failed!');
         }
     });

--- a/test-it/karma/javascriptinvoke/Simple.Test.js
+++ b/test-it/karma/javascriptinvoke/Simple.Test.js
@@ -59,8 +59,9 @@ describe('A JavaScript function invoke', function () {
     afterEach(function () {
         // Cleanup functions
         window.NI_SimpleFunction = undefined;
-        window.NI_FunctionThatThrows = undefined;
+        window.NI_Scoped = undefined;
         window.NI_FunctionWithInvalidParameterType = undefined;
+        window.NI_FunctionThatThrows = undefined;
     });
 
     it('with no parameters succesfully works', function (done) {
@@ -178,6 +179,39 @@ describe('A JavaScript function invoke', function () {
             expect([kNIUnsupportedParameterTypeInJavaScriptInvoke]).toContain(viPathParser('error.code'));
             expect(viPathParser('error.source')).toMatch(/JavaScriptInvoke in MyVI/);
             done();
+        });
+    });
+
+    describe('with a specific context', function () {
+        var simpleScopedFunctionContext = undefined;
+
+        beforeEach(function () {
+            window.NI_Scoped = {};
+            window.NI_Scoped.NI_SimpleFunction = function () {
+                // eslint-disable-next-line consistent-this
+                simpleScopedFunctionContext = this;
+                return undefined;
+            };
+        });
+
+        afterEach(function () {
+            window.NI_Scoped = undefined;
+            simpleScopedFunctionContext = undefined;
+        });
+
+        it('with no parameters and within a scope succesfully works', function (done) {
+            var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsSimpleScopedFunctionViaUrl);
+            var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
+
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(simpleScopedFunctionContext).toBe(window.NI_Scoped);
+                expect(rawPrint).toBeEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+                expect(viPathParser('error.status')).toBeFalse();
+                expect(viPathParser('error.code')).toBe(0);
+                expect(viPathParser('error.source')).toBeEmptyString();
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
The current implementation has the following problems:

1. Functions in global scope do not preserve the context. This means `console.log` and `performance.now` cannot be invoked without a wrapper function.
2. We are using the context to pass the Vireo API reference which has the getCompletionCallback call on it. 

   This limits us in future use cases where we would want to enable the user to do method invocation on an opaque JavaScript reference. This limits us because we need access to be able to reconfigure the context, we should not have taken the context for just the Vireo API.

This pull request makes two changes:

1. We use the context of the function as found in the global scope to allow for invocation with the correct context. As such a user does not need to write wrapper code for `console.log` and `performance.now`

2. We pass the Vireo API reference to the JavaScript function only if requested by a user. The user requests the Vireo API reference by adding an additional parameter to the JavaScript function list. For example:

   In the JSLI a user configures a function with Symbol name `myFunction` and one parameter `test` of type string.

   In JavaScript is the user writes the function signature as:
   ```
   window.myFunction = function (test) {
      console.log('test');
   }
   ```
   The function `myFunction` will be invoked with `window` as the context and with a value called test from the block diagram. They will not have access to the vireo api functionality because it was not requested.

    If instead for the same JSLI configuration (Symbol: `myFunction`, 1 string parameter: `test`) the user created the following JavaScript function:
   ```
   window.myFunction = function (test, jsAPI) {
      var cb = jsAPI.getCompletionCallback();
      setTimeout(function () {
         console.log('test delayed 1s');
         cb();
      }, 0);
   }
   ```
   Now in this case the user has explicitly requested the jsAPI object. This was done by requesting an additional parameter than what was configured by the JSLI document. Internally we know the JSLI document was configured for only one parameter. By providing a function that has two parameters the user is requesting a reference to the jsAPI object that we will provide.

   The benefits of this approach are:
1. The context is free to act with the default behavior (using the context from the path in global scope) or to be customized in the editor (using an opaque JS reference as the context for method invocation)

   In other words if we use this behavior we can prevent having an api breaking change when we implement opaque js reference method invocation in the future.

2. We can avoid the overhead of creating the JS API object reference if it is not explicitly requested by the user.

Also, this openly recognizes that relying on the number of parameters is unusual behavior. There is precedence as the jasmine api does something very similar when a user adds the done parameter to a function. They are able to detect that the done parameter is added and cause the test system to wait for the execution of the done function before continuing: https://jasmine.github.io/2.9/introduction#section-Asynchronous_Support

Despite this flaw I believe this is a net benefit:
1. We are allowing the simple use cases to function correctly without wrapper code `console.log`, etc
2. We can avoid breaking changes when opaque refnums are added
3. We improve performance by only creating the jsAPI object when requested
4. We CAN improve the editor experience by adding a checkbox to have the user specify explicitly that the last parameter is the jsAPI reference.

We can get a net improvement today by adopting the change. And we can choose to improve the user experience for the advanced use case (asynchronous resolution with the JS api) by improving the editor experience or we could choose to delay that work while still enabling advanced use cases.