### PR TITLE
Appveyor chrome fix

### DIFF
--- a/karma.shared.js
+++ b/karma.shared.js
@@ -80,10 +80,12 @@
 
         // Aliases for launchers that provide custom settings
         // No Sandbox mode needed to run in Travis container https://docs.travis-ci.com/user/chrome#Sandboxing
+        // Launching chrome has been timing out, some forums suggest disabling proxy settings:
+        // https://github.com/karma-runner/karma-chrome-launcher/issues/175#issuecomment-378247457
         customLaunchers: {
             ChromeHeadlessNoSandbox: {
                 base: 'ChromeHeadless',
-                flags: ['--no-sandbox']
+                flags: ['--no-sandbox', '--no-proxy-server']
             }
         },
 

--- a/test-it/karma/javascriptinvoke/Async.Test.js
+++ b/test-it/karma/javascriptinvoke/Async.Test.js
@@ -122,7 +122,9 @@ describe('A JavaScript function invoke', function () {
     });
 
     afterAll(function () {
-        Object.keys(javaScriptInvokeFixtures).forEach((functionName) => (window[functionName] = undefined));
+        Object.keys(javaScriptInvokeFixtures).forEach(function (functionName) {
+            window[functionName] = undefined;
+        });
         CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution = undefined;
         CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromError = undefined;
         NI_CallCompletionCallbackAfterFunctionErrors_Callback = undefined;

--- a/test-it/karma/javascriptinvoke/ReturnDataTypes.Test.js
+++ b/test-it/karma/javascriptinvoke/ReturnDataTypes.Test.js
@@ -220,8 +220,13 @@ describe('A JavaScript function invoke', function () {
         };
 
         window.NI_ExceptionInUpdateReturnValue = function () {
-            var notReallyAnArray = {};
-            Object.setPrototypeOf(notReallyAnArray, Int16Array.prototype);
+            var notReallyAnArrayPrototype = Object.create(Int16Array.prototype);
+            Object.defineProperty(notReallyAnArrayPrototype, 'length', {
+                get: function () {
+                    throw new Error('Not really a typed array length');
+                }
+            });
+            var notReallyAnArray = Object.create(notReallyAnArrayPrototype);
             expect(notReallyAnArray instanceof Int16Array).toBeTrue();
             return notReallyAnArray;
         };


### PR DESCRIPTION
Many AppVeyor builds have been failing with errors like the following:
```
npm run test
> vireo@9.5.0 test C:\projects\vireosdk
> karma start --browsers ChromeHeadlessNoSandbox,FirefoxHeadless
01 06 2018 10:27:36.215:INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
01 06 2018 10:27:36.217:INFO [launcher]: Launching browsers ChromeHeadlessNoSandbox, FirefoxHeadless with concurrency 1
01 06 2018 10:27:36.222:INFO [launcher]: Starting browser ChromeHeadless
01 06 2018 10:28:36.225:WARN [launcher]: ChromeHeadless have not captured in 60000 ms, killing.
01 06 2018 10:28:38.225:WARN [launcher]: ChromeHeadless was not killed in 2000 ms, sending SIGKILL.
01 06 2018 10:28:40.226:WARN [launcher]: ChromeHeadless was not killed by SIGKILL in 2000 ms, continuing.
```

Some searching suggests that proxy settings being misconfigured may result in Chrome failing to run. This change disables the Headless Chrome proxy. In addition it modifies some tests so they can run in browsers currently running on the AppVeyor CI.