### PR TITLE
Only run Firefox on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,7 +37,7 @@ test_script:
   - make testjs
   - make testnative
   - make testhttpbin
-  - npm run test
+  - npm run test -- --browsers FirefoxHeadless
   - npm run test -- --browsers IE --skip-tags FailsIE
 
 # Using the same naming convention as rust https://forge.rust-lang.org/platform-support.html


### PR DESCRIPTION
Currently Headless Chrome fails to launch intermittently on AppVeyor with the error shown in PR https://github.com/ni/VireoSDK/pull/440

And disabling the proxy as shown in the PR does not seem to improve the behavior reliably. Because the failure to launch results in a hung build instead of failing quickly, opting to disable HeadlessChrome until we can investigate further.