### PR TITLE
Introducing JavaScriptReference to vireo

### DIFF
--- a/Vireo_VS/VireoCommandLine.vcxproj
+++ b/Vireo_VS/VireoCommandLine.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="..\source\core\Events.cpp" />
     <ClCompile Include="..\source\core\ExecutionContext.cpp" />
     <ClCompile Include="..\source\core\GenericFunctions.cpp" />
+    <ClCompile Include="..\source\core\JavaScriptRef.cpp" />
     <ClCompile Include="..\source\core\MatchPat.cpp" />
     <ClCompile Include="..\source\core\Math.cpp" />
     <ClCompile Include="..\source\core\NumericString.cpp" />
@@ -75,6 +76,7 @@
     <ClInclude Include="..\source\include\Events.h" />
     <ClInclude Include="..\source\include\ExecutionContext.h" />
     <ClInclude Include="..\source\include\Instruction.h" />
+    <ClInclude Include="..\source\include\JavaScriptRef.h" />
     <ClInclude Include="..\source\include\LVDateTimeRecord.h" />
     <ClInclude Include="..\source\include\Platform.h" />
     <ClInclude Include="..\source\include\RefNum.h" />

--- a/Vireo_VS/VireoCommandLine.vcxproj.filters
+++ b/Vireo_VS/VireoCommandLine.vcxproj.filters
@@ -130,6 +130,9 @@
     <ClCompile Include="..\source\io\PropertyNode.cpp">
       <Filter>VireoSource\IO</Filter>
     </ClCompile>
+    <ClCompile Include="..\source\core\JavaScriptRef.cpp">
+      <Filter>VireoSource\Core</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\source\include\ConversionTable.def">
@@ -239,6 +242,9 @@
       <Filter>VireoSource\Include</Filter>
     </ClInclude>
     <ClInclude Include="..\source\include\DataReflectionVisitor.h">
+      <Filter>VireoSource\Include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\source\include\JavaScriptRef.h">
       <Filter>VireoSource\Include</Filter>
     </ClInclude>
   </ItemGroup>

--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -164,6 +164,7 @@ EM_BC_FILES=$(OBJS)/Array.bc\
 	$(OBJS)/Events.bc\
 	$(OBJS)/ExecutionContext.bc\
 	$(OBJS)/GenericFunctions.bc\
+	$(OBJS)/JavaScriptRef.bc\
 	$(OBJS)/MatchPat.bc\
 	$(OBJS)/Math.bc\
 	$(OBJS)/NumericString.bc\

--- a/make-it/Makefile
+++ b/make-it/Makefile
@@ -12,7 +12,7 @@ OUTPUT_EXE=$(OUTPUT_DIR)/esh
 OUTPUT_TEST_EXE=$(OUTPUT_DIR)/esh-test
 
 COMMANDLINE = main.cpp
-CORE = Array.cpp Assert.cpp CEntryPoints.cpp ControlRef.cpp Date.cpp EventLog.cpp Events.cpp ExecutionContext.cpp GenericFunctions.cpp MatchPat.cpp Math.cpp NumericString.cpp Platform.cpp Queue.cpp RefNum.cpp String.cpp StringUtilities.cpp Synchronization.cpp TDCodecLVFlat.cpp TDCodecVia.cpp Thread.cpp TimeFunctions.cpp Timestamp.cpp TypeAndDataManager.cpp TypeAndDataReflection.cpp TypeDefiner.cpp TypeTemplates.cpp UnitTest.cpp VirtualInstrument.cpp Waveform.cpp
+CORE = Array.cpp Assert.cpp CEntryPoints.cpp ControlRef.cpp Date.cpp EventLog.cpp Events.cpp ExecutionContext.cpp GenericFunctions.cpp JavaScriptRef.cpp MatchPat.cpp Math.cpp NumericString.cpp Platform.cpp Queue.cpp RefNum.cpp String.cpp StringUtilities.cpp Synchronization.cpp TDCodecLVFlat.cpp TDCodecVia.cpp Thread.cpp TimeFunctions.cpp Timestamp.cpp TypeAndDataManager.cpp TypeAndDataReflection.cpp TypeDefiner.cpp TypeTemplates.cpp UnitTest.cpp VirtualInstrument.cpp Waveform.cpp
 UNITTEST = RefNumTest.cpp
 IO = FileIO.cpp Canvas2d.cpp DebugGPIO.cpp HttpClient.cpp JavaScriptInvoke.cpp PropertyNode.cpp
 

--- a/source/core/JavaScriptRef.cpp
+++ b/source/core/JavaScriptRef.cpp
@@ -22,7 +22,7 @@ namespace Vireo {
 VIREO_FUNCTION_SIGNATURE2(IsNotAJavaScriptRefnum, JavaScriptRefNum, Boolean)
 {
     JavaScriptRefNum* refnumPtr = _ParamPointer(0);
-    bool result = *refnumPtr == 0; // this will be changed to call into JS to validate reference.
+    bool result = *refnumPtr == 0;  // this will be changed to call into JS to validate reference.
     _Param(1) = result;
     return _NextInstruction();
 }

--- a/source/core/JavaScriptRef.cpp
+++ b/source/core/JavaScriptRef.cpp
@@ -1,0 +1,45 @@
+
+/**
+
+ Copyright (c) 2018 National Instruments Corp.
+
+ This software is subject to the terms described in the LICENSE.TXT file
+
+ SDG
+ */
+
+/*! \file
+ \brief JavaScript reference
+ */
+
+#include "TypeDefiner.h"
+#include "RefNum.h"
+#include "JavaScriptRef.h"
+
+namespace Vireo {
+
+
+VIREO_FUNCTION_SIGNATURE2(IsNotAJavaScriptRefnum, JavaScriptRefNum, Boolean)
+{
+    JavaScriptRefNum* refnumPtr = _ParamPointer(0);
+    bool result = *refnumPtr == 0; // this will be changed to call into JS to validate reference.
+    _Param(1) = result;
+    return _NextInstruction();
+}
+
+VIREO_FUNCTION_SIGNATURE3(IsEQRefnum, RefNumVal, RefNumVal, Boolean);
+VIREO_FUNCTION_SIGNATURE3(IsNERefnum, RefNumVal, RefNumVal, Boolean);
+
+//------------------------------------------------------------
+DEFINE_VIREO_BEGIN(JavaScriptRefs)
+    DEFINE_VIREO_REQUIRE(VirtualInstrument)
+
+    DEFINE_VIREO_TYPE(JavaScriptRefNum, "refnum(UInt32)")
+
+    DEFINE_VIREO_FUNCTION_CUSTOM(IsNotANumPathRefnum, IsNotAJavaScriptRefnum, "p(i(JavaScriptRefNum) o(Boolean))")
+    DEFINE_VIREO_FUNCTION_CUSTOM(IsEQ, IsEQRefnum, "p(i(JavaScriptRefNum) i(JavaScriptRefNum) o(Boolean))")
+    DEFINE_VIREO_FUNCTION_CUSTOM(IsNE, IsNERefnum, "p(i(JavaScriptRefNum) i(JavaScriptRefNum) o(Boolean))")
+
+DEFINE_VIREO_END()
+}  // namespace Vireo
+

--- a/source/include/JavaScriptRef.h
+++ b/source/include/JavaScriptRef.h
@@ -1,0 +1,42 @@
+/**
+
+ Copyright (c) 2018 National Instruments Corp.
+
+ This software is subject to the terms described in the LICENSE.TXT file
+
+ SDG
+ */
+
+/*! \file
+ \brief JavaScript refnum
+
+ JavaScript references are defined in the Params or Locals section of a VI,
+ and define a named, non-statically-bound reference to a JavaScript opaque object.
+ 
+ Example:
+ 
+ define(MyVI dv(.VirtualInstrument (
+ Locals: c(
+ e(JavaScriptRefNum  jsref)  // JavaScript ref that is not statically linked
+ ) ...
+ 
+ The actual Type of jsref is JavaScriptRefNum and stores a refnum (cookie) which
+ opaquely holds onto the javascript object.
+ 
+ These can be used in subVIs to refer to a reference passed in by a caller.
+*/
+
+#ifndef JavaScriptRef_h
+#define JavaScriptRef_h
+
+#include "TypeAndDataManager.h"
+#include "RefNum.h"
+
+namespace Vireo
+{
+
+typedef RefNum JavaScriptRefNum;  // RefNum to be used with JavaScript Ref Num API 
+
+}  // namespace Vireo
+
+#endif  // JavaScriptRef_h

--- a/source/include/JavaScriptRef.h
+++ b/source/include/JavaScriptRef.h
@@ -15,14 +15,15 @@
  
  Example:
  
- define(MyVI dv(.VirtualInstrument (
- Locals: c(
- e(JavaScriptRefNum  jsref)  // JavaScript ref that is not statically linked
- ) ...
+    define(MyVI dv(.VirtualInstrument (
+    Locals: c(
+        e(JavaScriptRefNum  jsref)  // JavaScript ref that is not statically linked
+    ) ...
  
  The actual Type of jsref is JavaScriptRefNum and stores a refnum (cookie) which
- opaquely holds onto the javascript object.
- 
+ opaquely holds onto the javascript object. The refnum is managed on the JS side 
+ and does not use the Vireo RefNumManager.
+  
  These can be used in subVIs to refer to a reference passed in by a caller.
 */
 
@@ -35,7 +36,7 @@
 namespace Vireo
 {
 
-typedef RefNum JavaScriptRefNum;  // RefNum to be used with JavaScript Ref Num API 
+typedef RefNum JavaScriptRefNum;  // RefNum to be used with JavaScript Ref Num API
 
 }  // namespace Vireo
 

--- a/test-it/ExpectedResults/JavaScriptRefBasic.vtr
+++ b/test-it/ExpectedResults/JavaScriptRefBasic.vtr
@@ -1,0 +1,9 @@
+Ref ref1: JavaScriptRefNum(0x0)
+Ref ref2: JavaScriptRefNum(0x0)
+IsEQ ref1 ref2: true
+IsNE ref1 ref2: false
+IsNotARefNum: true
+IsNotARefNum: true
+Ref ref2: JavaScriptRefNum(0x0)
+IsNotARefNum: true
+IsEQ ref1 ref2: true

--- a/test-it/ExpectedResults/JavaScriptRefBasic.vtr
+++ b/test-it/ExpectedResults/JavaScriptRefBasic.vtr
@@ -7,3 +7,8 @@ IsNotARefNum: true
 Ref ref2: JavaScriptRefNum(0x0)
 IsNotARefNum: true
 IsEQ ref1 ref2: true
+In SubVI:
+Ref refarg: JavaScriptRefNum(0x0)
+IsNotARefNum: true
+Ref subref: JavaScriptRefNum(0x0)
+IsNotARefNum: true

--- a/test-it/ExpectedResults/PredicateFunctions.vtr
+++ b/test-it/ExpectedResults/PredicateFunctions.vtr
@@ -13,6 +13,7 @@ true
 IsNotANumPathRefnum
 true
 false
+false
 true
 false
 (false true false)

--- a/test-it/ViaTests/JavaScriptRefBasic.via
+++ b/test-it/ViaTests/JavaScriptRefBasic.via
@@ -1,0 +1,44 @@
+define(PrintJavaScriptRef dv(.VirtualInstrument (
+    Params:c(
+        i(String refName)
+        i(JavaScriptRefNum ref)
+    )
+    Locals:c(
+        e(String out)
+        e(String refString)
+    )
+    clump (1 // top level
+        StringFormat(refString "%z" * ref)
+        Printf("Ref %s: %s\n" refName refString)
+    )
+)))
+
+define(JavaScriptRefTestProgram dv(.VirtualInstrument (
+    Locals:c(
+		e(JavaScriptRefNum ref1)      // static javascript ref 
+        e(dv(JavaScriptRefNum) ref2)  // static javascript ref 
+        e(Boolean bool)
+    )
+
+    clump (1 // top level
+        PrintJavaScriptRef("ref1" ref1)
+        PrintJavaScriptRef("ref2" ref2)
+        IsEQ(ref1 ref2 bool)
+        Printf("IsEQ ref1 ref2: %z\n" bool)
+        IsNE(ref1 ref2 bool)
+        Printf("IsNE ref1 ref2: %z\n" bool)
+        IsNotANumPathRefnum(ref1 bool)
+        Printf("IsNotARefNum: %z\n" bool)
+        IsNotANumPathRefnum(ref2 bool)
+        Printf("IsNotARefNum: %z\n" bool)
+        Copy(ref1 ref2)
+        PrintJavaScriptRef("ref2" ref2)
+        IsNotANumPathRefnum(ref2 bool)
+        Printf("IsNotARefNum: %z\n" bool)
+        IsEQ(ref1 ref2 bool)
+        Printf("IsEQ ref1 ref2: %z\n" bool)
+    )
+
+) ) )
+
+enqueue(JavaScriptRefTestProgram)

--- a/test-it/ViaTests/JavaScriptRefBasic.via
+++ b/test-it/ViaTests/JavaScriptRefBasic.via
@@ -13,6 +13,25 @@ define(PrintJavaScriptRef dv(.VirtualInstrument (
     )
 )))
 
+define(subVI dv(.VirtualInstrument (
+    Params:c(
+        i(JavaScriptRefNum refarg)  // parameter javascript ref, passed from caller
+    )
+    Locals: c(
+        e(JavaScriptRefNum subref) // javascript ref in subVI
+        e(Boolean bool)
+    )
+    clump (1 // top level
+        Println("In SubVI:")
+        PrintJavaScriptRef("refarg" refarg)
+        IsNotANumPathRefnum(refarg bool)
+        Printf("IsNotARefNum: %z\n" bool)
+        PrintJavaScriptRef("subref" subref)
+        IsNotANumPathRefnum(subref bool)
+        Printf("IsNotARefNum: %z\n" bool)
+    )
+)))
+
 define(JavaScriptRefTestProgram dv(.VirtualInstrument (
     Locals:c(
 		e(JavaScriptRefNum ref1)      // static javascript ref 
@@ -37,6 +56,7 @@ define(JavaScriptRefTestProgram dv(.VirtualInstrument (
         Printf("IsNotARefNum: %z\n" bool)
         IsEQ(ref1 ref2 bool)
         Printf("IsEQ ref1 ref2: %z\n" bool)
+        subVI(ref1)
     )
 
 ) ) )

--- a/test-it/ViaTests/PredicateFunctions.via
+++ b/test-it/ViaTests/PredicateFunctions.via
@@ -52,6 +52,8 @@ start( VI<(
 	Println("IsNotANumPathRefnum")
 	IsNotANumPathRefnum(nan result)
 	Println(result)
+	IsNotANumPathRefnum(0 result)
+	Println(result)
 	IsNotANumPathRefnum(0.0 result)
 	Println(result)
 	IsNotANumPathRefnum("" result)

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -215,6 +215,7 @@
                 "IsOctalDigitFail.via",
                 "IsPrintableFail.via",
                 "IsWhiteSpaceFail.via",
+                "JavaScriptRefBasic.via",
                 "JSONArray.via",
                 "JSONErrorCodes.via",
                 "KeyValuePairDefinitions.via",


### PR DESCRIPTION
Introducing javascript opaque object reference to vireo (#450)
Adding a small basic test.
Extending PredicateFunctions.via test to also test IsNotANumPathRefnum with integer, to make sure we don't override the behavior for integers.