### PR TITLE
Type reflection

### DIFF
--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -142,7 +142,7 @@ EM_EXPORTS = -s EXPORTED_FUNCTIONS="[\
 	'_TypeRef_TopAQSize',\
 	'_TypeRef_Name',\
 	'_TypeRef_SubElementCount',\
-	'_TypeRef_SubElementByIndex',\
+	'_TypeRef_GetSubElementByIndex',\
 	'_TypeRef_IsCluster',\
 	'_TypeRef_IsArray',\
 	'_TypeRef_IsBoolean',\

--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -143,6 +143,18 @@ EM_EXPORTS = -s EXPORTED_FUNCTIONS="[\
 	'_TypeRef_Name',\
 	'_TypeRef_SubElementCount',\
 	'_TypeRef_SubElementByIndex',\
+	'_TypeRef_IsCluster',\
+	'_TypeRef_IsArray',\
+	'_TypeRef_IsBoolean',\
+	'_TypeRef_IsInteger',\
+	'_TypeRef_IsSigned',\
+	'_TypeRef_IsEnum',\
+	'_TypeRef_IsFloat',\
+	'_TypeRef_IsString',\
+	'_TypeRef_IsPath',\
+	'_TypeRef_IsTimestamp',\
+	'_TypeRef_IsComplex',\
+	'_TypeRef_IsAnalogWaveform',\
     '_JavaScriptInvoke_GetParameterType',\
     '_JavaScriptInvoke_GetParameterPointer',\
     '_JavaScriptInvoke_GetArrayElementType'\

--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -139,6 +139,10 @@ EM_EXPORTS = -s EXPORTED_FUNCTIONS="[\
     '_Data_GetArrayMetadata',\
     '_Data_GetArrayDimLength',\
     '_Data_ResizeArray',\
+	'_TypeRef_TopAQSize',\
+	'_TypeRef_Name',\
+	'_TypeRef_SubElementCount',\
+	'_TypeRef_SubElementByIndex',\
     '_JavaScriptInvoke_GetParameterType',\
     '_JavaScriptInvoke_GetParameterPointer',\
     '_JavaScriptInvoke_GetArrayElementType'\

--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -139,22 +139,22 @@ EM_EXPORTS = -s EXPORTED_FUNCTIONS="[\
     '_Data_GetArrayMetadata',\
     '_Data_GetArrayDimLength',\
     '_Data_ResizeArray',\
-	'_TypeRef_TopAQSize',\
-	'_TypeRef_Name',\
-	'_TypeRef_SubElementCount',\
-	'_TypeRef_GetSubElementByIndex',\
-	'_TypeRef_IsCluster',\
-	'_TypeRef_IsArray',\
-	'_TypeRef_IsBoolean',\
-	'_TypeRef_IsInteger',\
-	'_TypeRef_IsSigned',\
-	'_TypeRef_IsEnum',\
-	'_TypeRef_IsFloat',\
-	'_TypeRef_IsString',\
-	'_TypeRef_IsPath',\
-	'_TypeRef_IsTimestamp',\
-	'_TypeRef_IsComplex',\
-	'_TypeRef_IsAnalogWaveform',\
+    '_TypeRef_TopAQSize',\
+    '_TypeRef_Name',\
+    '_TypeRef_SubElementCount',\
+    '_TypeRef_GetSubElementByIndex',\
+    '_TypeRef_IsCluster',\
+    '_TypeRef_IsArray',\
+    '_TypeRef_IsBoolean',\
+    '_TypeRef_IsInteger',\
+    '_TypeRef_IsSigned',\
+    '_TypeRef_IsEnum',\
+    '_TypeRef_IsFloat',\
+    '_TypeRef_IsString',\
+    '_TypeRef_IsPath',\
+    '_TypeRef_IsTimestamp',\
+    '_TypeRef_IsComplex',\
+    '_TypeRef_IsAnalogWaveform',\
     '_JavaScriptInvoke_GetParameterType',\
     '_JavaScriptInvoke_GetParameterPointer',\
     '_JavaScriptInvoke_GetArrayElementType'\

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -503,6 +503,7 @@ VIREO_EXPORT Int32 TypeRef_Alignment(TypeRef typeRef)
 //------------------------------------------------------------
 VIREO_EXPORT const char* TypeRef_Name(TypeRef typeRef)
 {
+    TypeManagerScope scope(typeRef->TheTypeManager());
     SubString name = typeRef->Name();
 
     static StringRef returnBuffer = nullptr;
@@ -521,7 +522,7 @@ VIREO_EXPORT const char* TypeRef_Name(TypeRef typeRef)
         returnBuffer->Append((Utf8Char)'\0');
         return (const char*) returnBuffer->Begin();
     }
-    
+
     return "";
 }
 //------------------------------------------------------------
@@ -590,7 +591,7 @@ VIREO_EXPORT Boolean TypeRef_IsEnum(TypeRef typeRef)
     return typeRef->IsEnum();
 }
 //------------------------------------------------------------
-VIREO_EXPORT Boolean TypeRef_IsFloat(TypeRef typeRef) 
+VIREO_EXPORT Boolean TypeRef_IsFloat(TypeRef typeRef)
 {
     return typeRef->IsFloat();
 }

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -560,6 +560,66 @@ VIREO_EXPORT TypeRef TypeRef_GetSubElementByIndex(TypeRef typeRef, Int32 index)
     return typeRef->GetSubElement(index);
 }
 //------------------------------------------------------------
+VIREO_EXPORT Boolean TypeRef_IsCluster(TypeRef typeRef)
+{
+    return typeRef->IsCluster();
+}
+//------------------------------------------------------------
+VIREO_EXPORT Boolean TypeRef_IsArray(TypeRef typeRef)
+{
+    return typeRef->IsArray();
+}
+//------------------------------------------------------------
+VIREO_EXPORT Boolean TypeRef_IsBoolean(TypeRef typeRef)
+{
+    return typeRef->IsBoolean();
+}
+//------------------------------------------------------------
+VIREO_EXPORT Boolean TypeRef_IsInteger(TypeRef typeRef)
+{
+    return typeRef->IsInteger();
+}
+//------------------------------------------------------------
+VIREO_EXPORT Boolean TypeRef_IsSigned(TypeRef typeRef)
+{
+    return typeRef->IsSignedInteger();
+}
+//------------------------------------------------------------
+VIREO_EXPORT Boolean TypeRef_IsEnum(TypeRef typeRef)
+{
+    return typeRef->IsEnum();
+}
+//------------------------------------------------------------
+VIREO_EXPORT Boolean TypeRef_IsFloat(TypeRef typeRef) 
+{
+    return typeRef->IsFloat();
+}
+//------------------------------------------------------------
+VIREO_EXPORT Boolean TypeRef_IsString(TypeRef typeRef)
+{
+    return typeRef->IsString();
+}
+//------------------------------------------------------------
+VIREO_EXPORT Boolean TypeRef_IsPath(TypeRef typeRef)
+{
+    return typeRef->IsPath();
+}
+//------------------------------------------------------------
+VIREO_EXPORT Boolean TypeRef_IsTimestamp(TypeRef typeRef)
+{
+    return typeRef->IsTimestamp();
+}
+//------------------------------------------------------------
+VIREO_EXPORT Boolean TypeRef_IsComplex(TypeRef typeRef)
+{
+    return typeRef->IsComplex();
+}
+//------------------------------------------------------------
+VIREO_EXPORT Boolean TypeRef_IsAnalogWaveform(TypeRef typeRef)
+{
+    return typeRef->IsAnalogWaveform();
+}
+//------------------------------------------------------------
 //------------------------------------------------------------
 VIREO_EXPORT Int32 Data_RawBlockSize(TypedBlock* object)
 {

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -501,10 +501,28 @@ VIREO_EXPORT Int32 TypeRef_Alignment(TypeRef typeRef)
     return typeRef->AQAlignment();
 }
 //------------------------------------------------------------
-VIREO_EXPORT void TypeRef_Name(TypeRef typeRef, Int32* bufferSize, char* buffer)
+VIREO_EXPORT const char* TypeRef_Name(TypeRef typeRef)
 {
     SubString name = typeRef->Name();
-    *bufferSize = name.CopyToBoundedBuffer(*bufferSize, reinterpret_cast<Utf8Char*>(buffer));
+
+    static StringRef returnBuffer = nullptr;
+    if (returnBuffer == nullptr) {
+        // Allocate a string the first time it is used.
+        // After that it will be resized as needed.
+        STACK_VAR(String, tempReturn);
+        returnBuffer = tempReturn.DetachValue();
+    } else {
+        returnBuffer->Resize1D(0);
+    }
+
+    if (returnBuffer) {
+        returnBuffer->AppendSubString(&name);
+        // Add an explicit nullptr terminator so it looks like a C string.
+        returnBuffer->Append((Utf8Char)'\0');
+        return (const char*) returnBuffer->Begin();
+    }
+    
+    return "";
 }
 //------------------------------------------------------------
 VIREO_EXPORT Int32 TypeRef_ElementOffset(TypeRef typeRef)

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -501,9 +501,9 @@ VIREO_EXPORT Int32 TypeRef_Alignment(TypeRef typeRef)
     return typeRef->AQAlignment();
 }
 //------------------------------------------------------------
-VIREO_EXPORT const char* TypeRef_Name(TypeRef typeRef)
+VIREO_EXPORT const char* TypeRef_Name(TypeManagerRef tm, TypeRef typeRef)
 {
-    TypeManagerScope scope(typeRef->TheTypeManager());
+    TypeManagerScope scope(tm);
     SubString name = typeRef->Name();
 
     static StringRef returnBuffer = nullptr;

--- a/source/core/TypeAndDataManager.cpp
+++ b/source/core/TypeAndDataManager.cpp
@@ -884,7 +884,7 @@ Boolean TypeCommon::IsNumeric()
     return false;
 }
 //------------------------------------------------------------
-Boolean TypeCommon::IsInteger() 
+Boolean TypeCommon::IsInteger()
 {
     TypeRef t = this;
     while (t) {

--- a/source/core/TypeAndDataManager.cpp
+++ b/source/core/TypeAndDataManager.cpp
@@ -612,6 +612,8 @@ const SubString TypeCommon::TypeString = SubString(tsStringType);
 const SubString TypeCommon::TypeTimestamp = SubString("Timestamp");
 const SubString TypeCommon::TypeComplexSingle = SubString("ComplexSingle");
 const SubString TypeCommon::TypeComplexDouble = SubString("ComplexDouble");
+const SubString TypeCommon::TypePath = SubString("NIPath");
+const SubString TypeCommon::TypeAnalogWaveform = SubString("AnalogWaveform");
 const SubString TypeCommon::TypeStaticTypeAndData = SubString("StaticTypeAndData");
 
 TypeCommon::TypeCommon(TypeManagerRef typeManager)
@@ -882,6 +884,34 @@ Boolean TypeCommon::IsNumeric()
     return false;
 }
 //------------------------------------------------------------
+Boolean TypeCommon::IsInteger() 
+{
+    TypeRef t = this;
+    while (t) {
+        if (t->Name().Compare(&TypeInt8) || t->Name().Compare(&TypeInt16) || t->Name().Compare(&TypeInt32)
+            || t->Name().Compare(&TypeInt64) || t->Name().Compare(&TypeUInt8)
+            || t->Name().Compare(&TypeUInt16) || t->Name().Compare(&TypeUInt32)
+            || t->Name().Compare(&TypeUInt64)) {
+            return true;
+        }
+        t = t->BaseType();
+    }
+    return false;
+}
+//------------------------------------------------------------
+Boolean TypeCommon::IsSignedInteger()
+{
+    TypeRef t = this;
+    while (t) {
+        if (t->Name().Compare(&TypeInt8) || t->Name().Compare(&TypeInt16) || t->Name().Compare(&TypeInt32)
+            || t->Name().Compare(&TypeInt64)) {
+            return true;
+        }
+        t = t->BaseType();
+    }
+    return false;
+}
+//------------------------------------------------------------
 Boolean TypeCommon::IsInteger64()
 {
     TypeRef t = this;
@@ -918,7 +948,6 @@ Boolean TypeCommon::IsBoolean()
     }
     return false;
 }
-
 //------------------------------------------------------------
 Boolean TypeCommon::IsString()
 {
@@ -931,7 +960,18 @@ Boolean TypeCommon::IsString()
     }
     return false;
 }
-
+//------------------------------------------------------------
+Boolean TypeCommon::IsPath()
+{
+    TypeRef t = this;
+    while (t) {
+        if (t->Name().Compare(&TypePath)) {
+            return true;
+        }
+        t = t->BaseType();
+    }
+    return false;
+}
 //------------------------------------------------------------
 Boolean TypeCommon::IsTimestamp()
 {
@@ -956,7 +996,20 @@ Boolean TypeCommon::IsComplex()
     }
     return false;
 }
-
+//------------------------------------------------------------
+Boolean TypeCommon::IsAnalogWaveform()
+{
+    TypeRef t = this;
+    while (t) {
+        SubString typeName = t->Name();
+        SubString analogTypess(TypeAnalogWaveform);
+        if (typeName.FindFirstMatch(&analogTypess, 0, false) == 0) {
+            return true;
+        }
+        t = t->BaseType();
+    }
+    return false;
+}
 //------------------------------------------------------------
 Boolean TypeCommon::IsIntrinsicClusterDataType(SubString *foundTypeName) {
     TypeRef t = this;

--- a/source/core/module_typeHelpers.js
+++ b/source/core/module_typeHelpers.js
@@ -1,0 +1,306 @@
+// Using a modified UMD module format. Specifically a modified returnExports (no dependencies) version
+(function (root, globalName, factory) {
+    'use strict';
+    var buildGlobalNamespace = function () {
+        var buildArgs = Array.prototype.slice.call(arguments);
+        return globalName.split('.').reduce(function (currObj, subNamespace, currentIndex, globalNameParts) {
+            var nextValue = currentIndex === globalNameParts.length - 1 ? factory.apply(undefined, buildArgs) : {};
+            return currObj[subNamespace] === undefined ? (currObj[subNamespace] = nextValue) : currObj[subNamespace];
+        }, root);
+    };
+
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as a named module.
+        define(globalName, [], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        // Node. "CommonJS-like" for environments like Node but not strict CommonJS
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        buildGlobalNamespace();
+    }
+}(this, 'NationalInstruments.Vireo.Core.assignTypeHelpers', function () {
+    'use strict';
+
+    var assignTypeHelpers = function (Module) {
+        // Disable new-cap for the cwrap functions so the names can be the same in C and JS
+        /* eslint 'new-cap': ['error', {'capIsNewExceptions': [
+            'TypeRef_Name'
+        ]}], */
+        Module.typeHelpers = {};
+
+        var TypeRef_Name = Module.cwrap('TypeRef_Name', 'string', ['number']);
+
+        // Private instance functions
+        var validateVisitMethod = function (fn, fnName) {
+            if (typeof fn !== 'function') {
+                throw new Error('Visitor must have a method named `' + fnName + '`. Found: ' + fn);
+            }
+        };
+
+        var dispatchVisitBoolean = function (typeVisitor, valueRef, data) {
+            validateVisitMethod(typeVisitor.visitBoolean, 'visitBoolean');
+            return typeVisitor.visitBoolean(valueRef, data);
+        };
+
+        var dispatchVisitEnum = function (typeVisitor, valueRef, data) {
+            validateVisitMethod(typeVisitor.visitEnum, 'visitEnum');
+            return typeVisitor.visitEnum(typeVisitor, valueRef, data);
+        };
+
+        var dispatchVisitInteger = function (typeVisitor, valueRef, data) {
+            var typeRef = valueRef.typeRef;
+            var isSignedInteger = Module.typeHelpers.isSigned(typeRef);
+            var sizeOfInteger = Module.typeHelpers.topAQSize(typeRef);
+            var visitFn = undefined;
+            var typeName = '';
+            if (isSignedInteger === true) {
+                switch (sizeOfInteger) {
+                case 1:
+                    visitFn = typeVisitor.visitInt8;
+                    typeName = 'Int8';
+                    break;
+                case 2:
+                    visitFn = typeVisitor.visitInt16;
+                    typeName = 'Int16';
+                    break;
+                case 4:
+                    visitFn = typeVisitor.visitInt32;
+                    typeName = 'Int32';
+                    break;
+                case 8:
+                    visitFn = typeVisitor.visitInt64;
+                    typeName = 'Int64';
+                    break;
+                default:
+                    throw new Error('Unexpected size for Integer');
+                }
+            } else {
+                switch (sizeOfInteger) {
+                case 1:
+                    visitFn = typeVisitor.visitUInt8;
+                    typeName = 'UInt8';
+                    break;
+                case 2:
+                    visitFn = typeVisitor.visitUInt16;
+                    typeName = 'UInt16';
+                    break;
+                case 4:
+                    visitFn = typeVisitor.visitUInt32;
+                    typeName = 'UInt32';
+                    break;
+                case 8:
+                    visitFn = typeVisitor.visitUInt64;
+                    typeName = 'UInt64';
+                    break;
+                default:
+                    throw new Error('Unexpected size for Unsigned Integer. Found: ');
+                }
+            }
+
+            validateVisitMethod(visitFn, 'visit' + typeName);
+            return visitFn.call(typeVisitor, valueRef, data);
+        };
+
+        var dispatchVisitFloat = function (typeVisitor, valueRef, data) {
+            var typeRef = valueRef.typeRef;
+            var sizeOfFloat = Module.typeHelpers.topAQSize(typeRef);
+            var visitFn;
+            var typeName = '';
+            switch (sizeOfFloat) {
+            case 4:
+                visitFn = typeVisitor.visitSingle;
+                typeName = 'Single';
+                break;
+            case 8:
+                visitFn = typeVisitor.visitDouble;
+                typeName = 'Double';
+                break;
+            default:
+                throw new Error('Unexpected size for a Float value');
+            }
+
+            validateVisitMethod(visitFn, 'visit' + typeName);
+            return visitFn.call(typeVisitor, valueRef, data);
+        };
+
+        var dispatchVisitString = function (typeVisitor, valueRef, data) {
+            validateVisitMethod(typeVisitor.visitString, 'visitString');
+            return typeVisitor.visitString(valueRef, data);
+        };
+
+        var dispatchVisitComplex = function (typeVisitor, valueRef, data) {
+            var typeRef = valueRef.typeRef,
+                sizeOfComplex = Module.typeHelpers.topAQSize(typeRef),
+                visitFn,
+                typeName;
+            switch (sizeOfComplex) {
+            case 8:
+                visitFn = typeVisitor.visitComplexSingle;
+                typeName = 'Single';
+                break;
+            case 16:
+                visitFn = typeVisitor.visitComplexDouble;
+                typeName = 'Double';
+                break;
+            default:
+                throw new Error('Unexpected size for a Complex value');
+            }
+
+            validateVisitMethod(visitFn, 'visitComplex' + typeName);
+            return visitFn.call(typeVisitor, valueRef, data);
+        };
+
+        var dispatchVisitAnalogWaveform = function (typeVisitor, valueRef, data) {
+            validateVisitMethod(typeVisitor.visitAnalogWaveform, 'visitAnalogWaveform');
+            return typeVisitor.visitAnalogWaveform(valueRef, data);
+        };
+
+        var dispatchVisitTimestamp = function (typeVisitor, valueRef, data) {
+            validateVisitMethod(typeVisitor.visitTimestamp, 'visitTimestamp');
+            return typeVisitor.visitTimestamp(valueRef, data);
+        };
+
+        var dispatchVisitPath = function (typeVisitor, valueRef, data) {
+            validateVisitMethod(typeVisitor.visitPath, 'visitPath');
+            return typeVisitor.visitPath(valueRef, data);
+        };
+
+        var dispatchVisitArray = function (typeVisitor, valueRef, data) {
+            validateVisitMethod(typeVisitor.visitArray, 'visitArray');
+            return typeVisitor.visitArray(valueRef, data);
+        };
+
+        var dispatchVisitCluster = function (typeVisitor, valueRef, data) {
+            validateVisitMethod(typeVisitor.visitCluster, 'visitCluster');
+            return typeVisitor.visitCluster(typeVisitor, valueRef, data);
+        };
+
+        // Exported functions
+        Module.typeHelpers.topAQSize = function (typeRef) {
+            return Module._TypeRef_TopAQSize(typeRef);
+        };
+
+        Module.typeHelpers.typeName = function (typeRef) {
+            return TypeRef_Name(typeRef);
+        };
+
+        Module.typeHelpers.subElementCount = function (typeRef) {
+            return Module._TypeRef_SubElementCount(typeRef);
+        };
+
+        Module.typeHelpers.subElementByIndex = function (typeRef, index) {
+            return Module._TypeRef_GetSubElementByIndex(typeRef, index);
+        };
+
+        Module.typeHelpers.isCluster = function (typeRef) {
+            return Module._TypeRef_IsCluster(typeRef) !== 0;
+        };
+
+        Module.typeHelpers.isArray = function (typeRef) {
+            return Module._TypeRef_IsArray(typeRef) !== 0;
+        };
+
+        Module.typeHelpers.isBoolean = function (typeRef) {
+            return Module._TypeRef_IsBoolean(typeRef) !== 0;
+        };
+
+        Module.typeHelpers.isInteger = function (typeRef) {
+            return Module._TypeRef_IsInteger(typeRef) !== 0;
+        };
+
+        Module.typeHelpers.isSigned = function (typeRef) {
+            return Module._TypeRef_IsSigned(typeRef) !== 0;
+        };
+
+        Module.typeHelpers.isEnum = function (typeRef) {
+            return Module._TypeRef_IsEnum(typeRef) !== 0;
+        };
+
+        Module.typeHelpers.isFloat = function (typeRef) {
+            return Module._TypeRef_IsFloat(typeRef) !== 0;
+        };
+
+        Module.typeHelpers.isString = function (typeRef) {
+            return Module._TypeRef_IsString(typeRef) !== 0;
+        };
+
+        Module.typeHelpers.isPath = function (typeRef) {
+            return Module._TypeRef_IsPath(typeRef) !== 0;
+        };
+
+        Module.typeHelpers.isTimestamp = function (typeRef) {
+            return Module._TypeRef_IsTimestamp(typeRef) !== 0;
+        };
+
+        Module.typeHelpers.isComplex = function (typeRef) {
+            return Module._TypeRef_IsComplex(typeRef) !== 0;
+        };
+
+        Module.typeHelpers.isAnalogWaveform = function (typeRef) {
+            return Module._TypeRef_IsAnalogWaveform(typeRef) !== 0;
+        };
+
+        var typeHandlers = [
+            {
+                typeChecker: Module.typeHelpers.isBoolean,
+                dispatcher: dispatchVisitBoolean
+            },
+            {
+                typeChecker: Module.typeHelpers.isEnum,
+                dispatcher: dispatchVisitEnum
+            },
+            {
+                typeChecker: Module.typeHelpers.isInteger,
+                dispatcher: dispatchVisitInteger
+            },
+            {
+                typeChecker: Module.typeHelpers.isFloat,
+                dispatcher: dispatchVisitFloat
+            },
+            {
+                typeChecker: Module.typeHelpers.isString,
+                dispatcher: dispatchVisitString
+            },
+            {
+                typeChecker: Module.typeHelpers.isComplex,
+                dispatcher: dispatchVisitComplex
+            },
+            {
+                typeChecker: Module.typeHelpers.isAnalogWaveform,
+                dispatcher: dispatchVisitAnalogWaveform
+            },
+            {
+                typeChecker: Module.typeHelpers.isTimestamp,
+                dispatcher: dispatchVisitTimestamp
+            },
+            {
+                typeChecker: Module.typeHelpers.isPath,
+                dispatcher: dispatchVisitPath
+            },
+            {
+                typeChecker: Module.typeHelpers.isArray,
+                dispatcher: dispatchVisitArray
+            },
+            {
+                typeChecker: Module.typeHelpers.isCluster,
+                dispatcher: dispatchVisitCluster
+            }
+        ];
+
+        Module.typeHelpers.findTypeDispatcher = function (typeRef) {
+            var i = 0,
+                typeHandler;
+
+            for (i = 0; typeHandlers.length; i += 1) {
+                typeHandler = typeHandlers[i];
+                if (typeHandler.typeChecker(typeRef) === true) {
+                    return typeHandler.dispatcher;
+                }
+            }
+            return undefined;
+        };
+    };
+
+    return assignTypeHelpers;
+}));

--- a/source/core/module_typeHelpers.js
+++ b/source/core/module_typeHelpers.js
@@ -53,52 +53,52 @@
             var isSignedInteger = Module.typeHelpers.isSigned(typeRef);
             var sizeOfInteger = Module.typeHelpers.topAQSize(typeRef);
             var visitFn = undefined;
-            var typeName = '';
+            var fnName = '';
             if (isSignedInteger === true) {
                 switch (sizeOfInteger) {
                 case 1:
                     visitFn = typeVisitor.visitInt8;
-                    typeName = 'Int8';
+                    fnName = 'visitInt8';
                     break;
                 case 2:
                     visitFn = typeVisitor.visitInt16;
-                    typeName = 'Int16';
+                    fnName = 'visitInt16';
                     break;
                 case 4:
                     visitFn = typeVisitor.visitInt32;
-                    typeName = 'Int32';
+                    fnName = 'visitInt32';
                     break;
                 case 8:
                     visitFn = typeVisitor.visitInt64;
-                    typeName = 'Int64';
+                    fnName = 'visitInt64';
                     break;
                 default:
-                    throw new Error('Unexpected size for Integer');
+                    throw new Error('Unexpected size for Integer. Found: ' + sizeOfInteger);
                 }
             } else {
                 switch (sizeOfInteger) {
                 case 1:
                     visitFn = typeVisitor.visitUInt8;
-                    typeName = 'UInt8';
+                    fnName = 'visitUInt8';
                     break;
                 case 2:
                     visitFn = typeVisitor.visitUInt16;
-                    typeName = 'UInt16';
+                    fnName = 'visitUInt16';
                     break;
                 case 4:
                     visitFn = typeVisitor.visitUInt32;
-                    typeName = 'UInt32';
+                    fnName = 'visitUInt32';
                     break;
                 case 8:
                     visitFn = typeVisitor.visitUInt64;
-                    typeName = 'UInt64';
+                    fnName = 'visitUInt64';
                     break;
                 default:
-                    throw new Error('Unexpected size for Unsigned Integer. Found: ');
+                    throw new Error('Unexpected size for Unsigned Integer. Found: ' + sizeOfInteger);
                 }
             }
 
-            validateVisitMethod(visitFn, 'visit' + typeName);
+            validateVisitMethod(visitFn, fnName);
             return visitFn.call(typeVisitor, valueRef, data);
         };
 
@@ -106,21 +106,21 @@
             var typeRef = valueRef.typeRef;
             var sizeOfFloat = Module.typeHelpers.topAQSize(typeRef);
             var visitFn;
-            var typeName = '';
+            var fnName = '';
             switch (sizeOfFloat) {
             case 4:
                 visitFn = typeVisitor.visitSingle;
-                typeName = 'Single';
+                fnName = 'visitSingle';
                 break;
             case 8:
                 visitFn = typeVisitor.visitDouble;
-                typeName = 'Double';
+                fnName = 'visitDouble';
                 break;
             default:
-                throw new Error('Unexpected size for a Float value');
+                throw new Error('Unexpected size for a Float value. Found: ' + sizeOfFloat);
             }
 
-            validateVisitMethod(visitFn, 'visit' + typeName);
+            validateVisitMethod(visitFn, fnName);
             return visitFn.call(typeVisitor, valueRef, data);
         };
 
@@ -133,21 +133,21 @@
             var typeRef = valueRef.typeRef,
                 sizeOfComplex = Module.typeHelpers.topAQSize(typeRef),
                 visitFn,
-                typeName;
+                fnName;
             switch (sizeOfComplex) {
             case 8:
                 visitFn = typeVisitor.visitComplexSingle;
-                typeName = 'Single';
+                fnName = 'visitComplexSingle';
                 break;
             case 16:
                 visitFn = typeVisitor.visitComplexDouble;
-                typeName = 'Double';
+                fnName = 'visitComplexDouble';
                 break;
             default:
-                throw new Error('Unexpected size for a Complex value');
+                throw new Error('Unexpected size for a Complex value. Found: ' + sizeOfComplex);
             }
 
-            validateVisitMethod(visitFn, 'visitComplex' + typeName);
+            validateVisitMethod(visitFn, fnName);
             return visitFn.call(typeVisitor, valueRef, data);
         };
 
@@ -182,7 +182,7 @@
         };
 
         Module.typeHelpers.typeName = function (typeRef) {
-            return TypeRef_Name(typeRef);
+            return TypeRef_Name(Module.eggShell.v_userShell, typeRef);
         };
 
         Module.typeHelpers.subElementCount = function (typeRef) {

--- a/source/core/vireo.loader.js
+++ b/source/core/vireo.loader.js
@@ -16,6 +16,7 @@
         define(globalName, [
             'NationalInstruments.Vireo.Core.createVireoCore',
             'NationalInstruments.Vireo.Core.assignCoreHelpers',
+            'NationalInstruments.Vireo.Core.assignTypeHelpers',
             'NationalInstruments.Vireo.ModuleBuilders.assignEggShell',
             'NationalInstruments.Vireo.ModuleBuilders.assignHttpClient',
             'NationalInstruments.Vireo.ModuleBuilders.assignJavaScriptInvoke',
@@ -32,6 +33,7 @@
         module.exports = factory(
             vireoCore,
             require('../../source/core/module_coreHelpers.js'),
+            require('../../source/core/module_typeHelpers.js'),
             require('../../source/io/module_eggShell.js'),
             require('../../source/io/module_httpClient.js'),
             require('../../source/io/module_javaScriptInvoke.js'),
@@ -42,6 +44,7 @@
         buildGlobalNamespace(
             root.NationalInstruments.Vireo.Core.createVireoCore,
             root.NationalInstruments.Vireo.Core.assignCoreHelpers,
+            root.NationalInstruments.Vireo.Core.assignTypeHelpers,
             root.NationalInstruments.Vireo.ModuleBuilders.assignEggShell,
             root.NationalInstruments.Vireo.ModuleBuilders.assignHttpClient,
             root.NationalInstruments.Vireo.ModuleBuilders.assignJavaScriptInvoke,

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -78,6 +78,18 @@ VIREO_EXPORT TypeRef TypeRef_Next(TypeRef typeRef);
 VIREO_EXPORT UsageTypeEnum TypeRef_ElementUsageType(TypeRef typeRef);
 VIREO_EXPORT Int32 TypeRef_SubElementCount(TypeRef typeRef);
 VIREO_EXPORT TypeRef TypeRef_GetSubElementByIndex(TypeRef typeRef, Int32 index);
+VIREO_EXPORT Boolean TypeRef_IsCluster(TypeRef typeRef);
+VIREO_EXPORT Boolean TypeRef_IsArray(TypeRef typeRef);
+VIREO_EXPORT Boolean TypeRef_IsBoolean(TypeRef typeRef);
+VIREO_EXPORT Boolean TypeRef_IsInteger(TypeRef typeRef);
+VIREO_EXPORT Boolean TypeRef_IsSigned(TypeRef typeRef);
+VIREO_EXPORT Boolean TypeRef_IsEnum(TypeRef typeRef);
+VIREO_EXPORT Boolean TypeRef_IsFloat(TypeRef typeRef);
+VIREO_EXPORT Boolean TypeRef_IsString(TypeRef typeRef);
+VIREO_EXPORT Boolean TypeRef_IsPath(TypeRef typeRef);
+VIREO_EXPORT Boolean TypeRef_IsTimestamp(TypeRef typeRef);
+VIREO_EXPORT Boolean TypeRef_IsComplex(TypeRef typeRef);
+VIREO_EXPORT Boolean TypeRef_IsAnalogWaveform(TypeRef typeRef);
 //------------------------------------------------------------
 //! TypedBlock functions
 VIREO_EXPORT Int32 Data_RawBlockSize(TypedBlock* object);

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -70,7 +70,7 @@ VIREO_EXPORT Boolean TypeRef_IsValid(TypeRef typeRef);
 VIREO_EXPORT Boolean TypeRef_HasCustomDefault(TypeRef typeRef);
 VIREO_EXPORT EncodingEnum TypeRef_BitEncoding(TypeRef typeRef);
 VIREO_EXPORT Int32 TypeRef_Alignment(TypeRef typeRef);
-VIREO_EXPORT void TypeRef_Name(TypeRef typeRef, Int32* bufferSize, char* buffer);
+VIREO_EXPORT const char* TypeRef_Name(TypeRef typeRef);
 VIREO_EXPORT Int32 TypeRef_ElementOffset(TypeRef typeRef);
 VIREO_EXPORT Int32 TypeRef_Rank(TypeRef typeRef);
 VIREO_EXPORT PointerTypeEnum TypeRef_PointerType(TypeRef typeRef);

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -70,7 +70,7 @@ VIREO_EXPORT Boolean TypeRef_IsValid(TypeRef typeRef);
 VIREO_EXPORT Boolean TypeRef_HasCustomDefault(TypeRef typeRef);
 VIREO_EXPORT EncodingEnum TypeRef_BitEncoding(TypeRef typeRef);
 VIREO_EXPORT Int32 TypeRef_Alignment(TypeRef typeRef);
-VIREO_EXPORT const char* TypeRef_Name(TypeRef typeRef);
+VIREO_EXPORT const char* TypeRef_Name(TypeManagerRef typeManager, TypeRef typeRef);
 VIREO_EXPORT Int32 TypeRef_ElementOffset(TypeRef typeRef);
 VIREO_EXPORT Int32 TypeRef_Rank(TypeRef typeRef);
 VIREO_EXPORT PointerTypeEnum TypeRef_PointerType(TypeRef typeRef);

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -454,6 +454,8 @@ class TypeCommon
     static const SubString TypeTimestamp;
     static const SubString TypeComplexSingle;
     static const SubString TypeComplexDouble;
+    static const SubString TypePath;
+    static const SubString TypeAnalogWaveform;
     static const SubString TypeStaticTypeAndData;
 
     explicit TypeCommon(TypeManagerRef typeManager);
@@ -601,12 +603,16 @@ class TypeCommon
     Boolean IsA(TypeRef otherType);
     Boolean IsA(TypeRef otherType, Boolean compatibleArrays);
     Boolean IsNumeric();
+    Boolean IsInteger();
+    Boolean IsSignedInteger();
     Boolean IsInteger64();
     Boolean IsFloat();
     Boolean IsBoolean();
     Boolean IsString();
+    Boolean IsPath();
     Boolean IsTimestamp();
     Boolean IsComplex();
+    Boolean IsAnalogWaveform();
     Boolean IsIntrinsicClusterDataType(SubString *foundTypeName);  // Returns true for builtin data types such as Timestamp, Complex, etc
 
     //! Size of the type in bits including padding. If the type is bit level it's the raw bit size with no padding.

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -138,7 +138,6 @@
         var Data_WriteDouble = Module.cwrap('Data_WriteDouble', 'void', ['number', 'number']);
         var EggShell_ExecuteSlices = Module.cwrap('EggShell_ExecuteSlices', 'number', ['number', 'number', 'number']);
         var Occurrence_Set = Module.cwrap('Occurrence_Set', 'void', ['number']);
-        var TypeRef_TopAQSize = Module.cwrap('TypeRef_TopAQSize', 'number', ['number']);
         var TypeRef_Name = Module.cwrap('TypeRef_Name', 'string', ['number']);
         var TypeRef_SubElementCount = Module.cwrap('TypeRef_SubElementCount', 'number', ['number']);
         var TypeRef_GetSubElementByIndex = Module.cwrap('TypeRef_GetSubElementByIndex', 'number', ['number']);
@@ -248,7 +247,7 @@
         };
 
         Module.eggShell.typeTopAQSize = function (typePointer) {
-            return TypeRef_TopAQSize(typePointer);
+            return Module._TypeRef_TopAQSize(typePointer);
         };
 
         Module.eggShell.typeName = function (typePointer) {

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -264,58 +264,66 @@
         };
 
         Module.eggShell.typeIsCluster = function (typePointer) {
-            return Module._TypeRef_IsCluster(typePointer);
+            return Module._TypeRef_IsCluster(typePointer) !== 0;
         };
 
         Module.eggShell.typeIsArray = function (typePointer) {
-            return Module._TypeRef_IsArray(typePointer);
+            return Module._TypeRef_IsArray(typePointer) !== 0;
         };
 
         Module.eggShell.typeIsBoolean = function (typePointer) {
-            return Module._TypeRef_IsBoolean(typePointer);
+            return Module._TypeRef_IsBoolean(typePointer) !== 0;
         };
 
         Module.eggShell.typeIsInteger = function (typePointer) {
-            return Module._TypeRef_IsInteger(typePointer);
+            return Module._TypeRef_IsInteger(typePointer) !== 0;
         };
 
         Module.eggShell.typeIsSigned = function (typePointer) {
-            return Module._TypeRef_IsSigned(typePointer);
+            return Module._TypeRef_IsSigned(typePointer) !== 0;
         };
 
         Module.eggShell.typeIsEnum = function (typePointer) {
-            return Module._TypeRef_IsEnum(typePointer);
+            return Module._TypeRef_IsEnum(typePointer) !== 0;
         };
 
         Module.eggShell.typeIsFloat = function (typePointer) {
-            return Module._TypeRef_IsFloat(typePointer);
+            return Module._TypeRef_IsFloat(typePointer) !== 0;
         };
 
         Module.eggShell.typeIsString = function (typePointer) {
-            return Module._TypeRef_IsString(typePointer);
+            return Module._TypeRef_IsString(typePointer) !== 0;
         };
 
         Module.eggShell.typeIsPath = function (typePointer) {
-            return Module._TypeRef_IsPath(typePointer);
+            return Module._TypeRef_IsPath(typePointer) !== 0;
         };
 
         Module.eggShell.typeIsTimestamp = function (typePointer) {
-            return Module._TypeRef_IsTimestamp(typePointer);
+            return Module._TypeRef_IsTimestamp(typePointer) !== 0;
         };
 
         Module.eggShell.typeIsComplex = function (typePointer) {
-            return Module._TypeRef_IsComplex(typePointer);
+            return Module._TypeRef_IsComplex(typePointer) !== 0;
         };
 
         Module.eggShell.typeIsAnalogWaveform = function (typePointer) {
-            return Module._TypeRef_IsAnalogWaveform(typePointer);
+            return Module._TypeRef_IsAnalogWaveform(typePointer) !== 0;
+        };
+
+        var validateVisitMethod = function (fn, fnName) {
+            if (typeof fn !== 'function') {
+                throw new Error('Visitor must have a method named `' + fnName + '`. Found: ' + fn);
+            }
         };
 
         var dispatchVisitBoolean = function (typeVisitor, args) {
+            validateVisitMethod(typeVisitor.visitBoolean, 'visitBoolean');
             return typeVisitor.visitBoolean.apply(typeVisitor, args);
         };
 
         var dispatchVisitEnum = function (typeVisitor, args) {
+            validateVisitMethod(typeVisitor.visitEnum, 'visitEnum');
             return typeVisitor.visitEnum.apply(typeVisitor, args);
         };
 
@@ -356,60 +364,80 @@
                     visitFn = typeVisitor.visitUInt64;
                     break;
                 default:
-                    throw new Error('Unexpected size for Unsigned Integer');
+                    throw new Error('Unexpected size for Unsigned Integer. Found: ');
                 }
             }
 
+            var intName = (isSignedInteger ? '' : 'U') + 'Int' + (sizeOfInteger * 8);
+            validateVisitMethod(visitFn, 'visit' + intName);
             return visitFn.apply(typeVisitor, args);
         };
 
         var dispatchVisitFloat = function (typeVisitor, args) {
             var typeRef = args[0].typeRef;
             var sizeOfFloat = Module.eggShell.typeTopAQSize(typeRef);
+            var visitFn;
             switch (sizeOfFloat) {
             case 4:
-                return typeVisitor.visitSingle.apply(typeVisitor, args);
+                visitFn = typeVisitor.visitSingle;
+                break;
             case 8:
-                return typeVisitor.visitDouble.apply(typeVisitor, args);
+                visitFn = typeVisitor.visitDouble;
+                break;
             default:
                 throw new Error('Unexpected size for a Float value');
             }
+
+            validateVisitMethod(visitFn, 'visit' + (sizeOfFloat === 4 ? 'Single' : 'Double'));
+            return visitFn.apply(typeVisitor, args);
         };
 
         var dispatchVisitString = function (typeVisitor, args) {
+            validateVisitMethod(typeVisitor.visitString, 'visitString');
             return typeVisitor.visitString.apply(typeVisitor, args);
         };
 
         var dispatchVisitComplex = function (typeVisitor, args) {
-            var typeRef = args[0].typeRef;
-            var sizeOfComplex = Module.eggShell.typeTopAQSize(typeRef);
+            var typeRef = args[0].typeRef,
+                sizeOfComplex = Module.eggShell.typeTopAQSize(typeRef),
+                visitFn;
             switch (sizeOfComplex) {
             case 8:
-                return typeVisitor.visitComplexSingle.apply(typeVisitor, args);
+                visitFn = typeVisitor.visitComplexSingle;
+                break;
             case 16:
-                return typeVisitor.visitComplexDouble.apply(typeVisitor, args);
+                visitFn = typeVisitor.visitComplexDouble;
+                break;
             default:
                 throw new Error('Unexpected size for a Complex value');
             }
+
+            validateVisitMethod(visitFn, 'visitComplex' + (sizeOfComplex === 8 ? 'Single' : 'Double'));
+            return visitFn.apply(typeVisitor, args);
         };
 
         var dispatchVisitAnalogWaveform = function (typeVisitor, args) {
+            validateVisitMethod(typeVisitor.visitAnalogWaveform, 'visitAnalogWaveform');
             return typeVisitor.visitAnalogWaveform.apply(typeVisitor, args);
         };
 
         var dispatchVisitTimestamp = function (typeVisitor, args) {
+            validateVisitMethod(typeVisitor.visitTimestamp, 'visitTimestamp');
             return typeVisitor.visitTimestamp.apply(typeVisitor, args);
         };
 
         var dispatchVisitPath = function (typeVisitor, args) {
+            validateVisitMethod(typeVisitor.visitPath, 'visitPath');
             return typeVisitor.visitPath.apply(typeVisitor, args);
         };
 
         var dispatchVisitArray = function (typeVisitor, args) {
+            validateVisitMethod(typeVisitor.visitArray, 'visitArray');
             return typeVisitor.visitArray.apply(typeVisitor, args);
         };
 
         var dispatchVisitCluster = function (typeVisitor, args) {
+            validateVisitMethod(typeVisitor.visitCluster, 'visitCluster');
             return typeVisitor.visitCluster.apply(typeVisitor, args);
         };
 
@@ -442,11 +470,11 @@
         ];
 
         Module.eggShell.reflectOnValueRef = publicAPI.eggShell.reflectOnValueRef = function (typeVisitor, valueRef) {
-            if (typeof valueRef !== 'object') {
+            if (typeof valueRef !== 'object' || Array.isArray(valueRef)) {
                 throw new Error('valueRef must be an object. Found: ' + valueRef);
             }
 
-            if (typeof typeVisitor !== 'object') {
+            if (typeof typeVisitor !== 'object' || Array.isArray(typeVisitor)) {
                 throw new Error('typeVisitor must be an object. Found: ' + typeVisitor);
             }
 
@@ -456,18 +484,18 @@
                 i = 0;
 
             for (i = 0; i < registeredTypes.length; i += 1) {
-                if (registeredTypes[i](typeRef)) {
+                if (registeredTypes[i](typeRef) === true) {
                     foundTypeIndex = i;
                     break;
                 }
             }
 
             if (foundTypeIndex < 0) {
-                throw new Error('unexpected type');
+                throw new Error('Unexpected type. Is typeRef pointing to a valid type?. TypeRef found: ' + typeRef);
             }
 
             var dispatchFunction = typeDispatchFunctions[foundTypeIndex];
-            return dispatchFunction(typeVisitor, valueRef, args);
+            return dispatchFunction(typeVisitor, args);
         };
 
         Module.eggShell.writeDouble = publicAPI.eggShell.writeDouble = function (vi, path, value) {

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -143,6 +143,9 @@
         var v_root = EggShell_Create(0);
         var v_userShell = EggShell_Create(v_root);
 
+        Module.eggShell.v_root = v_root;
+        Module.eggShell.v_userShell = v_userShell;
+
         // Exported functions
         Module.print = function (text) {
             console.log(text);

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -263,6 +263,213 @@
             return TypeRef_GetSubElementByIndex(typePointer);
         };
 
+        Module.eggShell.typeIsCluster = function (typePointer) {
+            return Module._TypeRef_IsCluster(typePointer);
+        };
+
+        Module.eggShell.typeIsArray = function (typePointer) {
+            return Module._TypeRef_IsArray(typePointer);
+        };
+
+        Module.eggShell.typeIsBoolean = function (typePointer) {
+            return Module._TypeRef_IsBoolean(typePointer);
+        };
+
+        Module.eggShell.typeIsInteger = function (typePointer) {
+            return Module._TypeRef_IsInteger(typePointer);
+        };
+
+        Module.eggShell.typeIsSigned = function (typePointer) {
+            return Module._TypeRef_IsSigned(typePointer);
+        };
+
+        Module.eggShell.typeIsEnum = function (typePointer) {
+            return Module._TypeRef_IsEnum(typePointer);
+        };
+
+        Module.eggShell.typeIsFloat = function (typePointer) {
+            return Module._TypeRef_IsFloat(typePointer);
+        };
+
+        Module.eggShell.typeIsString = function (typePointer) {
+            return Module._TypeRef_IsString(typePointer);
+        };
+
+        Module.eggShell.typeIsPath = function (typePointer) {
+            return Module._TypeRef_IsPath(typePointer);
+        };
+
+        Module.eggShell.typeIsTimestamp = function (typePointer) {
+            return Module._TypeRef_IsTimestamp(typePointer);
+        };
+
+        Module.eggShell.typeIsComplex = function (typePointer) {
+            return Module._TypeRef_IsComplex(typePointer);
+        };
+
+        Module.eggShell.typeIsAnalogWaveform = function (typePointer) {
+            return Module._TypeRef_IsAnalogWaveform(typePointer);
+        };
+
+        var dispatchVisitBoolean = function (typeVisitor, args) {
+            return typeVisitor.visitBoolean.apply(typeVisitor, args);
+        };
+
+        var dispatchVisitEnum = function (typeVisitor, args) {
+            return typeVisitor.visitEnum.apply(typeVisitor, args);
+        };
+
+        var dispatchVisitInteger = function (typeVisitor, args) {
+            var typeRef = args[0].typeRef;
+            var isSignedInteger = Module.eggShell.typeIsSigned(typeRef);
+            var sizeOfInteger = Module.eggShell.typeTopAQSize(typeRef);
+            var visitFn = undefined;
+            if (isSignedInteger === true) {
+                switch (sizeOfInteger) {
+                case 1:
+                    visitFn = typeVisitor.visitInt8;
+                    break;
+                case 2:
+                    visitFn = typeVisitor.visitInt16;
+                    break;
+                case 4:
+                    visitFn = typeVisitor.visitInt32;
+                    break;
+                case 8:
+                    visitFn = typeVisitor.visitInt64;
+                    break;
+                default:
+                    throw new Error('Unexpected size for Integer');
+                }
+            } else {
+                switch (sizeOfInteger) {
+                case 1:
+                    visitFn = typeVisitor.visitUInt8;
+                    break;
+                case 2:
+                    visitFn = typeVisitor.visitUInt16;
+                    break;
+                case 4:
+                    visitFn = typeVisitor.visitUInt32;
+                    break;
+                case 8:
+                    visitFn = typeVisitor.visitUInt64;
+                    break;
+                default:
+                    throw new Error('Unexpected size for Unsigned Integer');
+                }
+            }
+
+            return visitFn.apply(typeVisitor, args);
+        };
+
+        var dispatchVisitFloat = function (typeVisitor, args) {
+            var typeRef = args[0].typeRef;
+            var sizeOfFloat = Module.eggShell.typeTopAQSize(typeRef);
+            switch (sizeOfFloat) {
+            case 4:
+                return typeVisitor.visitSingle.apply(typeVisitor, args);
+            case 8:
+                return typeVisitor.visitDouble.apply(typeVisitor, args);
+            default:
+                throw new Error('Unexpected size for a Float value');
+            }
+        };
+
+        var dispatchVisitString = function (typeVisitor, args) {
+            return typeVisitor.visitString.apply(typeVisitor, args);
+        };
+
+        var dispatchVisitComplex = function (typeVisitor, args) {
+            var typeRef = args[0].typeRef;
+            var sizeOfComplex = Module.eggShell.typeTopAQSize(typeRef);
+            switch (sizeOfComplex) {
+            case 8:
+                return typeVisitor.visitComplexSingle.apply(typeVisitor, args);
+            case 16:
+                return typeVisitor.visitComplexDouble.apply(typeVisitor, args);
+            default:
+                throw new Error('Unexpected size for a Complex value');
+            }
+        };
+
+        var dispatchVisitAnalogWaveform = function (typeVisitor, args) {
+            return typeVisitor.visitAnalogWaveform.apply(typeVisitor, args);
+        };
+
+        var dispatchVisitTimestamp = function (typeVisitor, args) {
+            return typeVisitor.visitTimestamp.apply(typeVisitor, args);
+        };
+
+        var dispatchVisitPath = function (typeVisitor, args) {
+            return typeVisitor.visitPath.apply(typeVisitor, args);
+        };
+
+        var dispatchVisitArray = function (typeVisitor, args) {
+            return typeVisitor.visitArray.apply(typeVisitor, args);
+        };
+
+        var dispatchVisitCluster = function (typeVisitor, args) {
+            return typeVisitor.visitCluster.apply(typeVisitor, args);
+        };
+
+        var typeDispatchFunctions = [
+            dispatchVisitBoolean,
+            dispatchVisitEnum,
+            dispatchVisitInteger,
+            dispatchVisitFloat,
+            dispatchVisitString,
+            dispatchVisitComplex,
+            dispatchVisitAnalogWaveform,
+            dispatchVisitTimestamp,
+            dispatchVisitPath,
+            dispatchVisitArray,
+            dispatchVisitCluster
+        ];
+
+        var registeredTypes = [
+            Module.eggShell.typeIsBoolean,
+            Module.eggShell.typeIsEnum,
+            Module.eggShell.typeIsInteger,
+            Module.eggShell.typeIsFloat,
+            Module.eggShell.typeIsString,
+            Module.eggShell.typeIsComplex,
+            Module.eggShell.typeIsAnalogWaveform,
+            Module.eggShell.typeIsTimestamp,
+            Module.eggShell.typeIsPath,
+            Module.eggShell.typeIsArray,
+            Module.eggShell.typeIsCluster
+        ];
+
+        Module.eggShell.reflectOnValueRef = publicAPI.eggShell.reflectOnValueRef = function (typeVisitor, valueRef) {
+            if (typeof valueRef !== 'object') {
+                throw new Error('valueRef must be an object. Found: ' + valueRef);
+            }
+
+            if (typeof typeVisitor !== 'object') {
+                throw new Error('typeVisitor must be an object. Found: ' + typeVisitor);
+            }
+
+            var typeRef = valueRef.typeRef,
+                args = Array.prototype.slice.call(arguments, 1),
+                foundTypeIndex = -1,
+                i = 0;
+
+            for (i = 0; i < registeredTypes.length; i += 1) {
+                if (registeredTypes[i](typeRef)) {
+                    foundTypeIndex = i;
+                    break;
+                }
+            }
+
+            if (foundTypeIndex < 0) {
+                throw new Error('unexpected type');
+            }
+
+            var dispatchFunction = typeDispatchFunctions[foundTypeIndex];
+            return dispatchFunction(typeVisitor, valueRef, args);
+        };
+
         Module.eggShell.writeDouble = publicAPI.eggShell.writeDouble = function (vi, path, value) {
             EggShell_WriteDouble(v_userShell, vi, path, value);
         };

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -138,9 +138,6 @@
         var Data_WriteDouble = Module.cwrap('Data_WriteDouble', 'void', ['number', 'number']);
         var EggShell_ExecuteSlices = Module.cwrap('EggShell_ExecuteSlices', 'number', ['number', 'number', 'number']);
         var Occurrence_Set = Module.cwrap('Occurrence_Set', 'void', ['number']);
-        var TypeRef_Name = Module.cwrap('TypeRef_Name', 'string', ['number']);
-        var TypeRef_SubElementCount = Module.cwrap('TypeRef_SubElementCount', 'number', ['number']);
-        var TypeRef_GetSubElementByIndex = Module.cwrap('TypeRef_GetSubElementByIndex', 'number', ['number']);
 
         // Create shell for vireo instance
         var v_root = EggShell_Create(0);
@@ -246,255 +243,23 @@
             return result;
         };
 
-        Module.eggShell.typeTopAQSize = function (typePointer) {
-            return Module._TypeRef_TopAQSize(typePointer);
-        };
-
-        Module.eggShell.typeName = function (typePointer) {
-            return TypeRef_Name(typePointer);
-        };
-
-        Module.eggShell.typeSubElementCount = function (typePointer) {
-            return TypeRef_SubElementCount(typePointer);
-        };
-
-        Module.eggShell.typeSubElementByIndex = function (typePointer) {
-            return TypeRef_GetSubElementByIndex(typePointer);
-        };
-
-        Module.eggShell.typeIsCluster = function (typePointer) {
-            return Module._TypeRef_IsCluster(typePointer) !== 0;
-        };
-
-        Module.eggShell.typeIsArray = function (typePointer) {
-            return Module._TypeRef_IsArray(typePointer) !== 0;
-        };
-
-        Module.eggShell.typeIsBoolean = function (typePointer) {
-            return Module._TypeRef_IsBoolean(typePointer) !== 0;
-        };
-
-        Module.eggShell.typeIsInteger = function (typePointer) {
-            return Module._TypeRef_IsInteger(typePointer) !== 0;
-        };
-
-        Module.eggShell.typeIsSigned = function (typePointer) {
-            return Module._TypeRef_IsSigned(typePointer) !== 0;
-        };
-
-        Module.eggShell.typeIsEnum = function (typePointer) {
-            return Module._TypeRef_IsEnum(typePointer) !== 0;
-        };
-
-        Module.eggShell.typeIsFloat = function (typePointer) {
-            return Module._TypeRef_IsFloat(typePointer) !== 0;
-        };
-
-        Module.eggShell.typeIsString = function (typePointer) {
-            return Module._TypeRef_IsString(typePointer) !== 0;
-        };
-
-        Module.eggShell.typeIsPath = function (typePointer) {
-            return Module._TypeRef_IsPath(typePointer) !== 0;
-        };
-
-        Module.eggShell.typeIsTimestamp = function (typePointer) {
-            return Module._TypeRef_IsTimestamp(typePointer) !== 0;
-        };
-
-        Module.eggShell.typeIsComplex = function (typePointer) {
-            return Module._TypeRef_IsComplex(typePointer) !== 0;
-        };
-
-        Module.eggShell.typeIsAnalogWaveform = function (typePointer) {
-            return Module._TypeRef_IsAnalogWaveform(typePointer) !== 0;
-        };
-
-        var validateVisitMethod = function (fn, fnName) {
-            if (typeof fn !== 'function') {
-                throw new Error('Visitor must have a method named `' + fnName + '`. Found: ' + fn);
-            }
-        };
-
-        var dispatchVisitBoolean = function (typeVisitor, args) {
-            validateVisitMethod(typeVisitor.visitBoolean, 'visitBoolean');
-            return typeVisitor.visitBoolean.apply(typeVisitor, args);
-        };
-
-        var dispatchVisitEnum = function (typeVisitor, args) {
-            validateVisitMethod(typeVisitor.visitEnum, 'visitEnum');
-            return typeVisitor.visitEnum.apply(typeVisitor, args);
-        };
-
-        var dispatchVisitInteger = function (typeVisitor, args) {
-            var typeRef = args[0].typeRef;
-            var isSignedInteger = Module.eggShell.typeIsSigned(typeRef);
-            var sizeOfInteger = Module.eggShell.typeTopAQSize(typeRef);
-            var visitFn = undefined;
-            if (isSignedInteger === true) {
-                switch (sizeOfInteger) {
-                case 1:
-                    visitFn = typeVisitor.visitInt8;
-                    break;
-                case 2:
-                    visitFn = typeVisitor.visitInt16;
-                    break;
-                case 4:
-                    visitFn = typeVisitor.visitInt32;
-                    break;
-                case 8:
-                    visitFn = typeVisitor.visitInt64;
-                    break;
-                default:
-                    throw new Error('Unexpected size for Integer');
-                }
-            } else {
-                switch (sizeOfInteger) {
-                case 1:
-                    visitFn = typeVisitor.visitUInt8;
-                    break;
-                case 2:
-                    visitFn = typeVisitor.visitUInt16;
-                    break;
-                case 4:
-                    visitFn = typeVisitor.visitUInt32;
-                    break;
-                case 8:
-                    visitFn = typeVisitor.visitUInt64;
-                    break;
-                default:
-                    throw new Error('Unexpected size for Unsigned Integer. Found: ');
-                }
-            }
-
-            var intName = (isSignedInteger ? '' : 'U') + 'Int' + (sizeOfInteger * 8);
-            validateVisitMethod(visitFn, 'visit' + intName);
-            return visitFn.apply(typeVisitor, args);
-        };
-
-        var dispatchVisitFloat = function (typeVisitor, args) {
-            var typeRef = args[0].typeRef;
-            var sizeOfFloat = Module.eggShell.typeTopAQSize(typeRef);
-            var visitFn;
-            switch (sizeOfFloat) {
-            case 4:
-                visitFn = typeVisitor.visitSingle;
-                break;
-            case 8:
-                visitFn = typeVisitor.visitDouble;
-                break;
-            default:
-                throw new Error('Unexpected size for a Float value');
-            }
-
-            validateVisitMethod(visitFn, 'visit' + (sizeOfFloat === 4 ? 'Single' : 'Double'));
-            return visitFn.apply(typeVisitor, args);
-        };
-
-        var dispatchVisitString = function (typeVisitor, args) {
-            validateVisitMethod(typeVisitor.visitString, 'visitString');
-            return typeVisitor.visitString.apply(typeVisitor, args);
-        };
-
-        var dispatchVisitComplex = function (typeVisitor, args) {
-            var typeRef = args[0].typeRef,
-                sizeOfComplex = Module.eggShell.typeTopAQSize(typeRef),
-                visitFn;
-            switch (sizeOfComplex) {
-            case 8:
-                visitFn = typeVisitor.visitComplexSingle;
-                break;
-            case 16:
-                visitFn = typeVisitor.visitComplexDouble;
-                break;
-            default:
-                throw new Error('Unexpected size for a Complex value');
-            }
-
-            validateVisitMethod(visitFn, 'visitComplex' + (sizeOfComplex === 8 ? 'Single' : 'Double'));
-            return visitFn.apply(typeVisitor, args);
-        };
-
-        var dispatchVisitAnalogWaveform = function (typeVisitor, args) {
-            validateVisitMethod(typeVisitor.visitAnalogWaveform, 'visitAnalogWaveform');
-            return typeVisitor.visitAnalogWaveform.apply(typeVisitor, args);
-        };
-
-        var dispatchVisitTimestamp = function (typeVisitor, args) {
-            validateVisitMethod(typeVisitor.visitTimestamp, 'visitTimestamp');
-            return typeVisitor.visitTimestamp.apply(typeVisitor, args);
-        };
-
-        var dispatchVisitPath = function (typeVisitor, args) {
-            validateVisitMethod(typeVisitor.visitPath, 'visitPath');
-            return typeVisitor.visitPath.apply(typeVisitor, args);
-        };
-
-        var dispatchVisitArray = function (typeVisitor, args) {
-            validateVisitMethod(typeVisitor.visitArray, 'visitArray');
-            return typeVisitor.visitArray.apply(typeVisitor, args);
-        };
-
-        var dispatchVisitCluster = function (typeVisitor, args) {
-            validateVisitMethod(typeVisitor.visitCluster, 'visitCluster');
-            return typeVisitor.visitCluster.apply(typeVisitor, args);
-        };
-
-        var typeDispatchFunctions = [
-            dispatchVisitBoolean,
-            dispatchVisitEnum,
-            dispatchVisitInteger,
-            dispatchVisitFloat,
-            dispatchVisitString,
-            dispatchVisitComplex,
-            dispatchVisitAnalogWaveform,
-            dispatchVisitTimestamp,
-            dispatchVisitPath,
-            dispatchVisitArray,
-            dispatchVisitCluster
-        ];
-
-        var registeredTypes = [
-            Module.eggShell.typeIsBoolean,
-            Module.eggShell.typeIsEnum,
-            Module.eggShell.typeIsInteger,
-            Module.eggShell.typeIsFloat,
-            Module.eggShell.typeIsString,
-            Module.eggShell.typeIsComplex,
-            Module.eggShell.typeIsAnalogWaveform,
-            Module.eggShell.typeIsTimestamp,
-            Module.eggShell.typeIsPath,
-            Module.eggShell.typeIsArray,
-            Module.eggShell.typeIsCluster
-        ];
-
-        Module.eggShell.reflectOnValueRef = publicAPI.eggShell.reflectOnValueRef = function (typeVisitor, valueRef) {
-            if (typeof valueRef !== 'object' || Array.isArray(valueRef)) {
+        Module.eggShell.reflectOnValueRef = publicAPI.eggShell.reflectOnValueRef = function (typeVisitor, valueRef, data) {
+            if (typeof valueRef !== 'object' || valueRef === null) {
                 throw new Error('valueRef must be an object. Found: ' + valueRef);
             }
 
-            if (typeof typeVisitor !== 'object' || Array.isArray(typeVisitor)) {
+            if (typeof typeVisitor !== 'object' || typeVisitor === null) {
                 throw new Error('typeVisitor must be an object. Found: ' + typeVisitor);
             }
 
             var typeRef = valueRef.typeRef,
-                args = Array.prototype.slice.call(arguments, 1),
-                foundTypeIndex = -1,
-                i = 0;
+                dispatchFunction = Module.typeHelpers.findTypeDispatcher(typeRef);
 
-            for (i = 0; i < registeredTypes.length; i += 1) {
-                if (registeredTypes[i](typeRef) === true) {
-                    foundTypeIndex = i;
-                    break;
-                }
+            if (dispatchFunction === undefined) {
+                throw new Error('Unexpected type. Is typeRef pointing to a valid type?. Type found: ' + typeRef === 0 ? 'invalid type' : Module.typeHelpers.typeName(typeRef));
             }
 
-            if (foundTypeIndex < 0) {
-                throw new Error('Unexpected type. Is typeRef pointing to a valid type?. TypeRef found: ' + typeRef);
-            }
-
-            var dispatchFunction = typeDispatchFunctions[foundTypeIndex];
-            return dispatchFunction(typeVisitor, args);
+            return dispatchFunction(typeVisitor, valueRef, data);
         };
 
         Module.eggShell.writeDouble = publicAPI.eggShell.writeDouble = function (vi, path, value) {

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -66,7 +66,11 @@
             'EggShell_REPL',
             'EggShell_ExecuteSlices',
             'Occurrence_Set',
-            'Pointer_stringify'
+            'Pointer_stringify',
+            'TypeRef_TopAQSize',
+            'TypeRef_Name',
+            'TypeRef_SubElementCount',
+            'TypeRef_GetSubElementByIndex',
         ]}], */
 
         Module.eggShell = {};
@@ -134,6 +138,10 @@
         var Data_WriteDouble = Module.cwrap('Data_WriteDouble', 'void', ['number', 'number']);
         var EggShell_ExecuteSlices = Module.cwrap('EggShell_ExecuteSlices', 'number', ['number', 'number', 'number']);
         var Occurrence_Set = Module.cwrap('Occurrence_Set', 'void', ['number']);
+        var TypeRef_TopAQSize = Module.cwrap('TypeRef_TopAQSize', 'number', ['number']);
+        var TypeRef_Name = Module.cwrap('TypeRef_Name', 'string', ['number']);
+        var TypeRef_SubElementCount = Module.cwrap('TypeRef_SubElementCount', 'number', ['number']);
+        var TypeRef_GetSubElementByIndex = Module.cwrap('TypeRef_GetSubElementByIndex', 'number', ['number']);
 
         // Create shell for vireo instance
         var v_root = EggShell_Create(0);
@@ -237,6 +245,22 @@
 
             Module.stackRestore(stack);
             return result;
+        };
+
+        Module.eggShell.typeTopAQSize = function (typePointer) {
+            return TypeRef_TopAQSize(typePointer);
+        };
+
+        Module.eggShell.typeName = function (typePointer) {
+            return TypeRef_Name(typePointer);
+        };
+
+        Module.eggShell.typeSubElementCount = function (typePointer) {
+            return TypeRef_SubElementCount(typePointer);
+        };
+
+        Module.eggShell.typeSubElementByIndex = function (typePointer) {
+            return TypeRef_GetSubElementByIndex(typePointer);
         };
 
         Module.eggShell.writeDouble = publicAPI.eggShell.writeDouble = function (vi, path, value) {

--- a/test-it/karma/fixtures/publicapi/MultipleTypes.via
+++ b/test-it/karma/fixtures/publicapi/MultipleTypes.via
@@ -124,6 +124,7 @@ define (MyVI dv(.VirtualInstrument (
         e(dv('\xF0\x8F\xBF\xBF') dataItem_utf8sequence_overlonglargest4byte) // U+FFFF
 
         e(dv(.String '\\"') dataItem_StringOtherJSONEscapedCharacters)
+        e(dv(.Single 123.5) dataItem_NumericSingle)
         e(dv(.Double 123.456)dataItem_NumericDouble)
         e(dv(.Double nan)dataItem_NumericDoubleNaN)
         e(dv(.Double inf)dataItem_NumericDoublePositiveInfinity)
@@ -133,6 +134,7 @@ define (MyVI dv(.VirtualInstrument (
         e(dv(.Int32 -1073741824)dataItem_Numeric32)
         e(dv(.Int64 -1152921504606846976)dataItem_Numeric64)
         e(dv(.UInt64 18446744073709551615) dataItem_NumericU64)
+        e(dv(.ComplexSingle (123.5 -20.75)) dataItem_ComplexSingle)
         e(dv(.ComplexDouble (1337.73 -9283.12))dataItem_Complex)
         e(dv(.Boolean true) booleanTrueValue)
         e(dv(.Boolean false) booleanFalseValue)

--- a/test-it/karma/publicapi/TypeReflection.Test.js
+++ b/test-it/karma/publicapi/TypeReflection.Test.js
@@ -1,4 +1,4 @@
-fdescribe('The Vireo EggShell Reflection API', function () {
+describe('The Vireo EggShell Reflection API', function () {
     'use strict';
 
     var Vireo = window.NationalInstruments.Vireo.Vireo;
@@ -12,9 +12,8 @@ fdescribe('The Vireo EggShell Reflection API', function () {
 
     var typeDescriptor = (function () {
         var returnTypeName = function (name) {
-            var typeName = name;
             return function () {
-                return typeName;
+                return name;
             };
         };
 

--- a/test-it/karma/publicapi/TypeReflection.Test.js
+++ b/test-it/karma/publicapi/TypeReflection.Test.js
@@ -1,0 +1,140 @@
+fdescribe('The Vireo EggShell Reflection API', function () {
+    'use strict';
+
+    var Vireo = window.NationalInstruments.Vireo.Vireo;
+    var vireoRunner = window.testHelpers.vireoRunner;
+    var fixtures = window.testHelpers.fixtures;
+
+    var vireo = new Vireo();
+
+    var publicApiMultipleTypesViaUrl = fixtures.convertToAbsoluteFromFixturesDir('publicapi/MultipleTypes.via');
+    var viName = 'MyVI';
+
+    var typeDescriptor = (function () {
+        var returnTypeName = function (name) {
+            var typeName = name;
+            return function () {
+                return typeName;
+            };
+        };
+
+        return {
+            visitBoolean: returnTypeName('Boolean'),
+            visitEnum: returnTypeName('Enum'),
+            visitInt8: returnTypeName('Int8'),
+            visitInt16: returnTypeName('Int16'),
+            visitInt32: returnTypeName('Int32'),
+            visitInt64: returnTypeName('Int64'),
+            visitUInt8: returnTypeName('UInt8'),
+            visitUInt16: returnTypeName('UInt16'),
+            visitUInt32: returnTypeName('UInt32'),
+            visitUInt64: returnTypeName('UInt64'),
+            visitSingle: returnTypeName('Single'),
+            visitDouble: returnTypeName('Double'),
+            visitString: returnTypeName('String'),
+            visitComplexSingle: returnTypeName('ComplexSingle'),
+            visitComplexDouble: returnTypeName('ComplexDouble'),
+            visitAnalogWaveform: returnTypeName('AnalogWaveform'),
+            visitTimestamp: returnTypeName('Timestamp'),
+            visitPath: returnTypeName('Path'),
+            visitArray: returnTypeName('Array'),
+            visitCluster: returnTypeName('Cluster')
+        };
+    }());
+
+    beforeAll(function (done) {
+        fixtures.preloadAbsoluteUrls([
+            publicApiMultipleTypesViaUrl
+        ], done);
+    });
+
+    beforeAll(function () {
+        vireoRunner.rebootAndLoadVia(vireo, publicApiMultipleTypesViaUrl);
+    });
+
+    var getTypeName = function (path) {
+        return vireo.eggShell.reflectOnValueRef(typeDescriptor, vireo.eggShell.findValueRef(viName, path));
+    };
+
+    var reflectOnEmptyVisitor = function (path) {
+        var thePath = path;
+        return function () {
+            vireo.eggShell.reflectOnValueRef({}, vireo.eggShell.findValueRef(viName, thePath));
+        };
+    };
+
+    describe('reflectOnValueRef', function () {
+        describe('error handling', function () {
+            it('throws when typeDescriptor is not an object', function () {
+                var throwingFunction = function () {
+                    vireo.eggShell.reflectOnValueRef([]);
+                };
+
+                expect(throwingFunction).toThrow();
+            });
+
+            it('throws when valueRef is not an object', function () {
+                var throwingFunction = function () {
+                    vireo.eggShell.reflectOnValueRef({}, []);
+                };
+
+                expect(throwingFunction).toThrow();
+            });
+
+            it('throws when visitor does not have visit methods for all types', function () {
+                expect(reflectOnEmptyVisitor('int8MinValue')).toThrowError(/visitInt8/);
+                expect(reflectOnEmptyVisitor('int16MinValue')).toThrowError(/visitInt16/);
+                expect(reflectOnEmptyVisitor('int32MinValue')).toThrowError(/visitInt32/);
+                expect(reflectOnEmptyVisitor('int64MinSafeInteger')).toThrowError(/visitInt64/);
+                expect(reflectOnEmptyVisitor('uInt8MinValue')).toThrowError(/visitUInt8/);
+                expect(reflectOnEmptyVisitor('uInt16MinValue')).toThrowError(/visitUInt16/);
+                expect(reflectOnEmptyVisitor('uInt32MinValue')).toThrowError(/visitUInt32/);
+                expect(reflectOnEmptyVisitor('uInt64MinSafeInteger')).toThrowError(/visitUInt64/);
+                expect(reflectOnEmptyVisitor('dataItem_NumericSingle')).toThrowError(/visitSingle/);
+                expect(reflectOnEmptyVisitor('dataItem_NumericDouble')).toThrowError(/visitDouble/);
+                expect(reflectOnEmptyVisitor('dataItem_ComplexSingle')).toThrowError(/visitComplexSingle/);
+                expect(reflectOnEmptyVisitor('dataItem_Complex')).toThrowError(/visitComplexDouble/);
+                expect(reflectOnEmptyVisitor('dataItem_String')).toThrowError(/visitString/);
+                expect(reflectOnEmptyVisitor('dataItem_Boolean')).toThrowError(/visitBoolean/);
+                expect(reflectOnEmptyVisitor('dataItem_Timestamp')).toThrowError(/visitTimestamp/);
+                expect(reflectOnEmptyVisitor('enum8alphabet')).toThrowError(/visitEnum/);
+                expect(reflectOnEmptyVisitor('wave_Double')).toThrowError(/visitAnalogWaveform/);
+                expect(reflectOnEmptyVisitor('dataItem_ClusterOfScalars')).toThrowError(/visitCluster/);
+                expect(reflectOnEmptyVisitor('dataItem_ArrayOfBoolean')).toThrowError(/visitArray/);
+            });
+        });
+
+        describe('dispatches a call on visitor', function () {
+            it('for all numerics', function () {
+                expect(getTypeName('int8MinValue')).toEqual('Int8');
+                expect(getTypeName('int16MinValue')).toEqual('Int16');
+                expect(getTypeName('int32MinValue')).toEqual('Int32');
+                expect(getTypeName('int64MinSafeInteger')).toEqual('Int64');
+                expect(getTypeName('uInt8MinValue')).toEqual('UInt8');
+                expect(getTypeName('uInt16MinValue')).toEqual('UInt16');
+                expect(getTypeName('uInt32MinValue')).toEqual('UInt32');
+                expect(getTypeName('uInt64MinSafeInteger')).toEqual('UInt64');
+                expect(getTypeName('dataItem_NumericSingle')).toEqual('Single');
+                expect(getTypeName('dataItem_NumericDouble')).toEqual('Double');
+                expect(getTypeName('dataItem_ComplexSingle')).toEqual('ComplexSingle');
+                expect(getTypeName('dataItem_Complex')).toEqual('ComplexDouble');
+            });
+
+            it('for strings', function () {
+                expect(getTypeName('dataItem_String')).toEqual('String');
+            });
+
+            it('for booleans', function () {
+                expect(getTypeName('dataItem_Boolean')).toEqual('Boolean');
+            });
+
+            it('for aggregate types', function () {
+                expect(getTypeName('dataItem_Timestamp')).toEqual('Timestamp');
+                expect(getTypeName('enum8alphabet')).toEqual('Enum');
+                expect(getTypeName('wave_Double')).toEqual('AnalogWaveform');
+                expect(getTypeName('dataItem_ClusterOfScalars')).toEqual('Cluster');
+                expect(getTypeName('dataItem_ArrayOfBoolean')).toEqual('Array');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Initial implementation of `reflectOnValueRef` which takes a `valueRef` and is able to appropriately call methods on an object passed as parameter depending on the type visiting.

Right now we can only reflect on the first level of type hierarchy. Once we have `findSubValueRef` we can continue traversing aggregate types.

I found a few things that I'm not entirely sure about, I'll leave as comments asking for suggestions.