### PR TITLE
Vireo ResizeArray implementation

### DIFF
--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -283,8 +283,12 @@ VIREO_EXPORT EggShellResult EggShell_ResizeArray(TypeManagerRef tm, const TypeRe
                                                  Int32 newDimensionsLength, Int32 newDimensions[])
 {
     TypeManagerScope scope(tm);
-    if (actualType == nullptr || !actualType->IsValid() || !actualType->IsArray()) {
+    if (actualType == nullptr || !actualType->IsValid()) {
         return kEggShellResult_InvalidTypeRef;
+    }
+
+    if(!actualType->IsArray()) {
+        return kEggShellResult_UnexpectedObjectType;
     }
 
     if (actualType->Rank() != newDimensionsLength) {

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -279,18 +279,22 @@ VIREO_EXPORT Int32 EggShell_GetArrayDimLength(TypeManagerRef tm, const char* viN
 }
 //------------------------------------------------------------
 //! Resizes a variable size Array symbol to have new dimension lengths specified by newLengths, it also initializes cells for non-flat data.
-//! Caller is expected to allocate an array newLengths of size rank for the duration of function invocation.
-VIREO_EXPORT EggShellResult EggShell_ResizeArray(TypeManagerRef tm, const TypeRef actualType, const void* pData, Int32 rank, Int32 newLengths[])
+VIREO_EXPORT EggShellResult EggShell_ResizeArray(TypeManagerRef tm, const TypeRef actualType, const void* pData,
+                                                 Int32 newDimensionsLength, Int32 newDimensions[])
 {
     TypeManagerScope scope(tm);
     if (actualType == nullptr || !actualType->IsValid() || !actualType->IsArray()) {
-        return kEggShellResult_UnexpectedObjectType;  // TODO(mraj): use memos new invalid type eggShellResult
+        return kEggShellResult_InvalidTypeRef;
+    }
+
+    if (actualType->Rank() != newDimensionsLength) {
+        return kEggShellResult_MismatchedArrayRank;
     }
 
     TypedArrayCoreRef arrayObject = *(TypedArrayCoreRef*)pData;
     VIREO_ASSERT(TypedArrayCore::ValidateHandle(arrayObject));
 
-    if (!arrayObject->ResizeDimensions(rank, newLengths, true, false)) {
+    if (!arrayObject->ResizeDimensions(newDimensionsLength, newDimensions, true, false)) {
         return kEggShellResult_UnableToCreateReturnBuffer;
     }
     return kEggShellResult_Success;

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -287,7 +287,7 @@ VIREO_EXPORT EggShellResult EggShell_ResizeArray(TypeManagerRef tm, const TypeRe
         return kEggShellResult_InvalidTypeRef;
     }
 
-    if(!actualType->IsArray()) {
+    if (!actualType->IsArray()) {
         return kEggShellResult_UnexpectedObjectType;
     }
 

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -22,6 +22,7 @@ typedef enum {
     kEggShellResult_InvalidResultPointer = 3,
     kEggShellResult_UnableToCreateReturnBuffer = 4,
     kEggShellResult_InvalidTypeRef = 5,
+    kEggShellResult_MismatchedArrayRank = 6,
 } EggShellResult;
 //------------------------------------------------------------
 //! TypeManager functions
@@ -47,7 +48,8 @@ VIREO_EXPORT const char* EggShell_ReadValueString(TypeManagerRef tm, const char*
 VIREO_EXPORT EggShellResult EggShell_GetPointer(TypeManagerRef tm,
         const char* viName, const char* elementName, void** dataPointer, void** typePointer);
 VIREO_EXPORT Int32 EggShell_GetArrayDimLength(TypeManagerRef tm, const char* viName, const char* eltName, Int32 dim);
-VIREO_EXPORT EggShellResult EggShell_ResizeArray(TypeManagerRef tm, const TypeRef actualType, const void* pData, Int32 rank, Int32 newLengths[]);
+VIREO_EXPORT EggShellResult EggShell_ResizeArray(TypeManagerRef tm, const TypeRef actualType, const void* pData,
+                                                 Int32 newDimensionsLength, Int32 newDimensions[]);
 VIREO_EXPORT EggShellResult Data_ValidateArrayType(TypeManagerRef tm, TypeRef typeRef);
 VIREO_EXPORT void* Data_GetStringBegin(StringRef stringObject);
 VIREO_EXPORT Int32 Data_GetStringLength(StringRef stringObject);

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -47,8 +47,7 @@ VIREO_EXPORT const char* EggShell_ReadValueString(TypeManagerRef tm, const char*
 VIREO_EXPORT EggShellResult EggShell_GetPointer(TypeManagerRef tm,
         const char* viName, const char* elementName, void** dataPointer, void** typePointer);
 VIREO_EXPORT Int32 EggShell_GetArrayDimLength(TypeManagerRef tm, const char* viName, const char* eltName, Int32 dim);
-VIREO_EXPORT Int32 EggShell_ResizeArray(TypeManagerRef tm, const char* viName, const char* eltName,
-                                        Int32 rank, Int32* newLengths);
+VIREO_EXPORT EggShellResult EggShell_ResizeArray(TypeManagerRef tm, const TypeRef actualType, const void* pData, Int32 rank, Int32 newLengths[]);
 VIREO_EXPORT EggShellResult Data_ValidateArrayType(TypeManagerRef tm, TypeRef typeRef);
 VIREO_EXPORT void* Data_GetStringBegin(StringRef stringObject);
 VIREO_EXPORT Int32 Data_GetStringLength(StringRef stringObject);

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -572,13 +572,6 @@
         };
 
         Module.eggShell.resizeArray = publicAPI.eggShell.resizeArray = function (valueRef, newDimensions) {
-            if (!Module.typeHelpers.isArray(valueRef.typeRef)) {
-                throw new Error('Performing resizeArray failed for the following reason: ' + eggShellResultEnum[EGGSHELL_RESULT.UNEXPECTED_OBJECT_TYPE] +
-                    ' (error code: ' + EGGSHELL_RESULT.UNEXPECTED_OBJECT_TYPE + ')' +
-                    ' (typeRef: ' + valueRef.typeRef + ')' +
-                    ' (dataRef: ' + valueRef.dataRef + ')');
-            }
-
             if (!Array.isArray(newDimensions)) {
                 throw new Error('Expected newDimensions to be an array of dimension lengths, instead got: ' + newDimensions);
             }

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -84,7 +84,8 @@
             UNEXPECTED_OBJECT_TYPE: 2,
             INVALID_RESULT_POINTER: 3,
             UNABLE_TO_CREATE_RETURN_BUFFER: 4,
-            INVALID_TYPE_REF: 5
+            INVALID_TYPE_REF: 5,
+            MISMATCHED_ARRAY_RANK: 6
         };
         var eggShellResultEnum = {};
         eggShellResultEnum[EGGSHELL_RESULT.SUCCESS] = 'Success';
@@ -93,6 +94,7 @@
         eggShellResultEnum[EGGSHELL_RESULT.INVALID_RESULT_POINTER] = 'InvalidResultPointer';
         eggShellResultEnum[EGGSHELL_RESULT.UNABLE_TO_CREATE_RETURN_BUFFER] = 'UnableToCreateReturnBuffer';
         eggShellResultEnum[EGGSHELL_RESULT.INVALID_TYPE_REF] = 'InvalidTypeRef';
+        eggShellResultEnum[EGGSHELL_RESULT.MISMATCHED_ARRAY_RANK] = 'MismatchedArrayRank';
 
         // Keep in sync with NIError in DataTypes.h
         var niErrorEnum = {
@@ -577,18 +579,22 @@
                     ' (dataRef: ' + valueRef.dataRef + ')');
             }
 
-            var rank = Module.typeHelpers.typeRank(valueRef.typeRef);
-            if (rank !== newDimensions.length) {
-                throw new Error('Current array is of rank ' + rank + ' and resize was called with only ' + newDimensions.length + ' dimensions specified.');
+            if (!Array.isArray(newDimensions)) {
+                throw new Error('Expected newDimensions to be an array of dimension lengths, instead got: ' + newDimensions);
             }
-
             var stack = Module.stackSave();
-            var dimensionsPointer = Module.stackAlloc(rank * LENGTH_SIZE);
-            var i;
-            for (i = 0; i < newDimensions.length; i += 1) {
-                Module.setValue(dimensionsPointer + (i * LENGTH_SIZE), newDimensions[i], 'i32');
+            var newDimensionsLength = newDimensions.length;
+            var dimensionsPointer = Module.stackAlloc(newDimensionsLength * LENGTH_SIZE);
+            var i, currentDimension;
+            for (i = 0; i < newDimensionsLength; i += 1) {
+                currentDimension = newDimensions[i];
+
+                if (typeof currentDimension !== 'number') {
+                    throw new Error('Expected all dimensions of newDimensions to be numeric values for dimension length, instead got' + currentDimension);
+                }
+                Module.setValue(dimensionsPointer + (i * LENGTH_SIZE), currentDimension, 'i32');
             }
-            var eggShellResult = Module._EggShell_ResizeArray(Module.eggShell.v_userShell, valueRef.typeRef, valueRef.dataRef, rank, dimensionsPointer);
+            var eggShellResult = Module._EggShell_ResizeArray(Module.eggShell.v_userShell, valueRef.typeRef, valueRef.dataRef, newDimensionsLength, dimensionsPointer);
             if (eggShellResult !== 0) {
                 throw new Error('Resizing the array failed for the following reason: ' + eggShellResultEnum[eggShellResult] +
                 ' (error code: ' + eggShellResult + ')' +

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -36,7 +36,6 @@
             'EggShell_WriteValueString',
             'EggShell_GetPointer',
             'EggShell_GetArrayDimLength',
-            'EggShell_ResizeArray',
             'Data_ValidateArrayType',
             'Data_GetStringBegin',
             'Data_GetStringLength',
@@ -115,7 +114,6 @@
         var EggShell_WriteValueString = Module.cwrap('EggShell_WriteValueString', 'void', ['number', 'string', 'string', 'string', 'string']);
         var EggShell_GetPointer = Module.cwrap('EggShell_GetPointer', 'number', ['number', 'string', 'string', 'number', 'number']);
         var EggShell_GetArrayDimLength = Module.cwrap('EggShell_GetArrayDimLength', 'number', ['number', 'string', 'string', 'number']);
-        var EggShell_ResizeArray = Module.cwrap('EggShell_ResizeArray', 'number', ['number', 'string', 'string', 'number', 'number']);
         var Data_ValidateArrayType = Module.cwrap('Data_ValidateArrayType', 'number', ['number', 'number']);
         var Data_GetStringBegin = Module.cwrap('Data_GetStringBegin', 'number', []);
         var Data_GetStringLength = Module.cwrap('Data_GetStringLength', 'number', []);
@@ -425,8 +423,7 @@
         };
 
         Module.eggShell.getArrayDimensions = publicAPI.eggShell.getArrayDimensions = function (valueRef) {
-            var TypedArrayConstructor = findCompatibleTypedArrayConstructor(valueRef.typeRef);
-            if (TypedArrayConstructor === undefined) {
+            if (!Module.typeHelpers.isArray(valueRef.typeRef)) {
                 throw new Error('Performing getArrayDimensions failed for the following reason: ' + eggShellResultEnum[EGGSHELL_RESULT.UNEXPECTED_OBJECT_TYPE] +
                     ' (error code: ' + EGGSHELL_RESULT.UNEXPECTED_OBJECT_TYPE + ')' +
                     ' (typeRef: ' + valueRef.typeRef + ')' +
@@ -572,20 +569,33 @@
             return EggShell_GetArrayDimLength(Module.eggShell.v_userShell, vi, path, dim);
         };
 
-        Module.eggShell.resizeArray = publicAPI.eggShell.resizeArray = function (vi, path, newDimensionSizes) {
-            var int32Byte = 4;
-            var rank = newDimensionSizes.length;
-            var newLengths = Module._malloc(rank * int32Byte);
-
-            for (var i = 0; i < rank; i += 1) {
-                Module.setValue(newLengths + (i * int32Byte), newDimensionSizes[i], 'i32');
+        Module.eggShell.resizeArray = publicAPI.eggShell.resizeArray = function (valueRef, newDimensions) {
+            if (!Module.typeHelpers.isArray(valueRef.typeRef)) {
+                throw new Error('Performing resizeArray failed for the following reason: ' + eggShellResultEnum[EGGSHELL_RESULT.UNEXPECTED_OBJECT_TYPE] +
+                    ' (error code: ' + EGGSHELL_RESULT.UNEXPECTED_OBJECT_TYPE + ')' +
+                    ' (typeRef: ' + valueRef.typeRef + ')' +
+                    ' (dataRef: ' + valueRef.dataRef + ')');
             }
 
-            var success = EggShell_ResizeArray(Module.eggShell.v_userShell, vi, path, rank, newLengths);
+            var rank = Module.typeHelpers.typeRank(valueRef.typeRef);
+            if (rank !== newDimensions.length) {
+                throw new Error('Current array is of rank ' + rank + ' and resize was called with only ' + newDimensions.length + ' dimensions specified.');
+            }
 
-            Module._free(newLengths);
-
-            return success;
+            var stack = Module.stackSave();
+            var dimensionsPointer = Module.stackAlloc(rank * LENGTH_SIZE);
+            var i;
+            for (i = 0; i < newDimensions.length; i += 1) {
+                Module.setValue(dimensionsPointer + (i * LENGTH_SIZE), newDimensions[i], 'i32');
+            }
+            var eggShellResult = Module._EggShell_ResizeArray(Module.eggShell.v_userShell, valueRef.typeRef, valueRef.dataRef, rank, dimensionsPointer);
+            if (eggShellResult !== 0) {
+                throw new Error('Resizing the array failed for the following reason: ' + eggShellResultEnum[eggShellResult] +
+                ' (error code: ' + eggShellResult + ')' +
+                ' (typeRef: ' + valueRef.typeRef + ')' +
+                ' (dataRef: ' + valueRef.dataRef + ')');
+            }
+            Module.stackRestore(stack);
         };
 
         Module.eggShell.dataReadString = function (stringPointer) {

--- a/test-it/ViaTests/ArrayDemo.via
+++ b/test-it/ViaTests/ArrayDemo.via
@@ -10,6 +10,7 @@ define(ArrayDemo dv(.VirtualInstrument (
 
     e(a(.Int32 * *)   variableArray2d)
     e(a(.Int32 2 3)   fixedArray2d)
+    e(a(.Int32 0 0)   fixedArray2dEmpty)
     e(a(.Int32 1 2 3) fixedArray3d)
   )
     clump(1

--- a/test-it/karma/publicapi/GetArrayDimensions.Test.js
+++ b/test-it/karma/publicapi/GetArrayDimensions.Test.js
@@ -42,6 +42,7 @@ describe('The Vireo EggShell getArrayDimensions api', function () {
             expect(getArrayDimensions('fixedArray1dwithDefaults')).toEqual([5]);
             expect(getArrayDimensions('boundedArray1dwithDefaults')).toEqual([4]);
             expect(getArrayDimensions('fixedArray2d')).toEqual([2, 3]);
+            expect(getArrayDimensions('fixedArray2dEmpty')).toEqual([0, 0]);
             expect(getArrayDimensions('fixedArray3d')).toEqual([1, 2, 3]);
             done();
         });

--- a/test-it/karma/publicapi/ResizeArray.Test.js
+++ b/test-it/karma/publicapi/ResizeArray.Test.js
@@ -5,74 +5,134 @@ describe('Arrays in Vireo', function () {
     var vireoRunner = window.testHelpers.vireoRunner;
     var fixtures = window.testHelpers.fixtures;
 
-    // Sharing Vireo instances across tests make them run soooo much faster
     var vireo = new Vireo();
-    var viaPath = fixtures.convertToAbsoluteFromViaTestsDir('ArrayDemo.via');
-    var viName = 'ArrayDemo';
+    var testsArrayDemoViaUrl = fixtures.convertToAbsoluteFromViaTestsDir('ArrayDemo.via');
+    var publicApiMultipleTypesViaUrl = fixtures.convertToAbsoluteFromFixturesDir('publicapi/MultipleTypes.via');
     var runSlicesAsync;
 
-    var resizeArray = function (path, dimensions) {
+    var resizeArrayHelper = function (viName, path, dimensions) {
         var valueRef = vireo.eggShell.findValueRef(viName, path);
         vireo.eggShell.resizeArray(valueRef, dimensions);
     };
 
-    var getArrayDimensions = function (path) {
+    var getArrayDimensionsHelper = function (viName, path) {
         var valueRef = vireo.eggShell.findValueRef(viName, path);
         return vireo.eggShell.getArrayDimensions(valueRef);
     };
 
     beforeAll(function (done) {
         fixtures.preloadAbsoluteUrls([
-            viaPath
+            testsArrayDemoViaUrl,
+            publicApiMultipleTypesViaUrl
         ], done);
     });
 
-    beforeEach(function () {
-        runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, viaPath);
-    });
+    describe('when using array types', function () {
+        var viName = 'ArrayDemo';
+        var resizeArray = resizeArrayHelper.bind(undefined, viName);
+        var getArrayDimensions = getArrayDimensionsHelper.bind(undefined, viName);
 
-    it('can be resized when they are variable size 1D array', function (done) {
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeNonEmptyString();
-            expect(rawPrintError).toBeEmptyString();
+        beforeAll(function () {
+            runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, testsArrayDemoViaUrl);
+        });
 
-            resizeArray('variableArray1d', [5]);
-            expect(getArrayDimensions('variableArray1d')).toEqual([5]);
-            done();
+        it('can be resized when they are variable size 1D array', function (done) {
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeNonEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+
+                resizeArray('variableArray1d', [5]);
+                expect(getArrayDimensions('variableArray1d')).toEqual([5]);
+                done();
+            });
+        });
+
+        it('can be resized when they are 1d array with defaults', function (done) {
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeNonEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+
+                resizeArray('variableArray1dwithDefaults', [6]);
+                expect(getArrayDimensions('variableArray1dwithDefaults')).toEqual([6]);
+
+                done();
+            });
+        });
+
+        it('cannot be resized if they are fixed 2d arrays', function (done) {
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeNonEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+
+                expect(resizeArray.bind(undefined, 'fixedArray2d', [3, 4])).toThrowError(/UnableToCreateReturnBuffer/);
+
+                done();
+            });
+        });
+
+        it('can be resized when they are variable 2d array', function (done) {
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeNonEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+
+                resizeArray('variableArray2d', [3, 4]);
+                expect(getArrayDimensions('variableArray2d')).toEqual([3, 4]);
+
+                done();
+            });
+        });
+
+        it('throws for dimension arrays that are invalid arrays', function (done) {
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeNonEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+
+                expect(resizeArray.bind(undefined, 'variableArray2d', 'notAnArray')).toThrowError(/to be an array/);
+
+                done();
+            });
+        });
+
+        it('throws for dimension arrays with non-numeric dimensions', function (done) {
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeNonEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+
+                expect(resizeArray.bind(undefined, 'variableArray2d', ['pen', 'pineapple'])).toThrowError(/numeric values/);
+
+                done();
+            });
+        });
+
+        it('throws for new dimensions with wrong rank', function (done) {
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeNonEmptyString();
+                expect(rawPrintError).toBeEmptyString();
+
+                expect(resizeArray.bind(undefined, 'variableArray2d', [1])).toThrowError(/MismatchedArrayRank/);
+
+                done();
+            });
         });
     });
 
-    it('can be resized when they are 1d array with defaults', function (done) {
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeNonEmptyString();
-            expect(rawPrintError).toBeEmptyString();
-            resizeArray('variableArray1dwithDefaults', [6]);
-            expect(getArrayDimensions('variableArray1dwithDefaults')).toEqual([6]);
+    describe('when using non-array types', function () {
+        var viName = 'MyVI';
+        var resizeArray = resizeArrayHelper.bind(undefined, viName);
 
-            done();
+        beforeAll(function () {
+            runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiMultipleTypesViaUrl);
         });
-    });
 
-    it('cannot be resized if they are fixed 2d arrays', function (done) {
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeNonEmptyString();
-            expect(rawPrintError).toBeEmptyString();
+        it('will throw for a boolean type', function (done) {
+            runSlicesAsync(function (rawPrint, rawPrintError) {
+                expect(rawPrint).toBeEmptyString();
+                expect(rawPrintError).toBeEmptyString();
 
-            expect(resizeArray.bind(undefined, 'fixedArray2d', [3, 4])).toThrowError(/UnableToCreateReturnBuffer/);
+                expect(resizeArray.bind(undefined, 'dataItem_Boolean', [3, 4])).toThrowError(/UnexpectedObjectType/);
 
-            done();
-        });
-    });
-
-    it('can be resized when they are variable 2d array', function (done) {
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeNonEmptyString();
-            expect(rawPrintError).toBeEmptyString();
-
-            resizeArray('variableArray2d', [3, 4]);
-            expect(getArrayDimensions('variableArray2d')).toEqual([3, 4]);
-
-            done();
+                done();
+            });
         });
     });
 });

--- a/test-it/karma/publicapi/ResizeArray.Test.js
+++ b/test-it/karma/publicapi/ResizeArray.Test.js
@@ -11,6 +11,22 @@ describe('Arrays in Vireo', function () {
     var viName = 'ArrayDemo';
     var runSlicesAsync;
 
+    var resizeArray = function (path, dimensions) {
+        var valueRef = vireo.eggShell.findValueRef(viName, path);
+        vireo.eggShell.resizeArray(valueRef, dimensions);
+    };
+
+    var getArrayDimensions = function (path) {
+        var valueRef = vireo.eggShell.findValueRef(viName, path);
+        return vireo.eggShell.getArrayDimensions(valueRef);
+    };
+
+    beforeAll(function (done) {
+        fixtures.preloadAbsoluteUrls([
+            viaPath
+        ], done);
+    });
+
     beforeEach(function () {
         runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, viaPath);
     });
@@ -20,67 +36,41 @@ describe('Arrays in Vireo', function () {
             expect(rawPrint).toBeNonEmptyString();
             expect(rawPrintError).toBeEmptyString();
 
-            var resized = vireo.eggShell.resizeArray(viName, 'variableArray1d', [5]);
-            expect(resized).toBe(0);
-            expect(vireo.eggShell.getArrayDimLength(viName, 'variableArray1d', 0)).toBe(5);
+            resizeArray('variableArray1d', [5]);
+            expect(getArrayDimensions('variableArray1d')).toEqual([5]);
             done();
         });
     });
 
     it('can be resized when they are 1d array with defaults', function (done) {
-        var variableName = 'variableArray1dwithDefaults';
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeNonEmptyString();
             expect(rawPrintError).toBeEmptyString();
+            resizeArray('variableArray1dwithDefaults', [6]);
+            expect(getArrayDimensions('variableArray1dwithDefaults')).toEqual([6]);
 
-            var resized = vireo.eggShell.resizeArray(viName, variableName, [6]);
-
-            expect(resized).toBe(0);
-            expect(vireo.eggShell.getArrayDimLength(viName, variableName, 0)).toBe(6);
-
-            done();
-        });
-    });
-
-    it('returns error code 1 if the array does not exist', function (done) {
-        var variableName = 'imaginaryArrayThatDoesNotExist';
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeNonEmptyString();
-            expect(rawPrintError).toBeEmptyString();
-
-            var resized = vireo.eggShell.resizeArray(viName, variableName, [6]);
-            expect(resized).toBe(1);
             done();
         });
     });
 
     it('cannot be resized if they are fixed 2d arrays', function (done) {
-        var variableName = 'fixedArray2d';
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeNonEmptyString();
             expect(rawPrintError).toBeEmptyString();
 
-            var resized = vireo.eggShell.resizeArray(viName, variableName, [3, 4]);
-
-            expect(resized).toBe(2);
-            expect(vireo.eggShell.getArrayDimLength(viName, variableName, 0)).toBe(2);
-            expect(vireo.eggShell.getArrayDimLength(viName, variableName, 1)).toBe(3);
+            expect(resizeArray.bind(undefined, 'fixedArray2d', [3, 4])).toThrowError(/UnableToCreateReturnBuffer/);
 
             done();
         });
     });
 
     it('can be resized when they are variable 2d array', function (done) {
-        var variableName = 'variableArray2d';
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeNonEmptyString();
             expect(rawPrintError).toBeEmptyString();
 
-            var resized = vireo.eggShell.resizeArray(viName, variableName, [3, 4]);
-
-            expect(resized).toBe(0);
-            expect(vireo.eggShell.getArrayDimLength(viName, variableName, 0)).toBe(3);
-            expect(vireo.eggShell.getArrayDimLength(viName, variableName, 1)).toBe(4);
+            resizeArray('variableArray2d', [3, 4]);
+            expect(getArrayDimensions('variableArray2d')).toEqual([3, 4]);
 
             done();
         });


### PR DESCRIPTION
Changes the existing resizeArray implementation to use the valueRef interface. Also allows getArrayDimensions to work with all valid Array types.