### PR TITLE
Minor refactor of event matching so static control refs match on the ref

### DIFF
--- a/source/include/VirtualInstrument.h
+++ b/source/include/VirtualInstrument.h
@@ -53,8 +53,8 @@ struct EventStructInfo {
 
 struct EventControlInfo {
     EventOracleIndex eventOracleIndex;
-    RefNum refnum;
-    explicit EventControlInfo(EventOracleIndex eoIdx = 0, RefNum ref = 0) : eventOracleIndex(eoIdx), refnum(ref) { }
+    EventControlUID controlID;
+    explicit EventControlInfo(EventOracleIndex eoIdx = 0, EventControlUID ctlID = 0) : eventOracleIndex(eoIdx), controlID(ctlID) { }
 };
 
 struct EventInfo {

--- a/test-it/ViaTests/ValueChangeStaticControlEvent1.via
+++ b/test-it/ViaTests/ValueChangeStaticControlEvent1.via
@@ -48,6 +48,7 @@ define (StaticControlRef%2Egviweb dv(.VirtualInstrument (
         ) timeoutData)
         e(.Boolean local2)
         e(.Boolean local3)
+        e(dv(ControlRefNum ControlReference("18")) controlRef)
     )
         clump(1
 	// Note:  No explicit register is generated here, unlike the JavaScriptRefNum static version.
@@ -56,7 +57,7 @@ define (StaticControlRef%2Egviweb dv(.VirtualInstrument (
 	// Since the controlRefnum is a Vireo-side reference, OccurEvent will look up the refnum from the eventOracleIdx
 	// and put it in the EventData; the JS code which calls OccurEvent does not need to supply it.
 
-        _OccurEvent(18 1000 2)  // for testing
+        _OccurEvent(controlRef 1000 2)  // for testing
 
 	// Imagine event loop around this:
         Printf("Waiting on Events\n")


### PR DESCRIPTION
...and not the controlID, so this doesn't have to change if the controlID
becomes a larger GUID (64-bit or string).

This does not yet remove the controlID from OccurEvent or
jsRegister/UnregisterControlEvent; we can't do that until we're actually ready to
change the type to something else throughout the stack;
jsRegister/UnregisterControlEvent does need to pass the controlID to
associate it with the eventOracleIndex, even if it's a string or larger GUID.