### PR TITLE
Update PropertyNode JS Callbacks

### DIFF
--- a/source/io/module_propertyNode.js
+++ b/source/io/module_propertyNode.js
@@ -56,9 +56,8 @@
             viNamePointer,
             controlIdPointer,
             propertyNamePointer,
-            propertyTypeNamePointer,
-            tempVariableVINamePointer,
-            tempVariablePathPointer,
+            tempVariableTypePointer,
+            tempVariableDataPointer,
             errorStatusPointer,
             errorCodePointer,
             errorSourcePointer) {
@@ -69,12 +68,10 @@
             var viName = Module.eggShell.dataReadString(viNamePointer);
             var controlId = Module.eggShell.dataReadString(controlIdPointer);
             var propertyName = Module.eggShell.dataReadString(propertyNamePointer);
-            var propertyTypeName = Module.eggShell.dataReadString(propertyTypeNamePointer);
-            var tempVariablePath = Module.eggShell.dataReadString(tempVariablePathPointer);
-            var tempVariableVIName = Module.eggShell.dataReadString(tempVariableVINamePointer);
+            var valueRef = Module.eggShell.createValueRef(tempVariableTypePointer, tempVariableDataPointer);
 
             try {
-                writeProperty(viName, controlId, propertyName, propertyTypeName, tempVariableVIName, tempVariablePath);
+                writeProperty(viName, controlId, propertyName, valueRef);
             } catch (ex) {
                 newErrorStatus = true;
                 newErrorCode = ERRORS.kNIObjectReferenceIsInvalid.CODE;
@@ -89,9 +86,8 @@
             viNamePointer,
             controlIdPointer,
             propertyNamePointer,
-            propertyTypeNamePointer,
-            tempVariableVINamePointer,
-            tempVariablePathPointer,
+            tempVariableTypePointer,
+            tempVariableDataPointer,
             errorStatusPointer,
             errorCodePointer,
             errorSourcePointer) {
@@ -102,12 +98,10 @@
             var viName = Module.eggShell.dataReadString(viNamePointer);
             var controlId = Module.eggShell.dataReadString(controlIdPointer);
             var propertyName = Module.eggShell.dataReadString(propertyNamePointer);
-            var propertyTypeName = Module.eggShell.dataReadString(propertyTypeNamePointer);
-            var tempVariablePath = Module.eggShell.dataReadString(tempVariablePathPointer);
-            var tempVariableVIName = Module.eggShell.dataReadString(tempVariableVINamePointer);
+            var valueRef = Module.eggShell.createValueRef(tempVariableTypePointer, tempVariableDataPointer);
 
             try {
-                readProperty(viName, controlId, propertyName, propertyTypeName, tempVariableVIName, tempVariablePath);
+                readProperty(viName, controlId, propertyName, valueRef);
             } catch (ex) {
                 newErrorStatus = true;
                 newErrorCode = ERRORS.kNIObjectReferenceIsInvalid.CODE;

--- a/test-it/karma/propertynode/PropertyNodeSequential.Test.js
+++ b/test-it/karma/propertynode/PropertyNodeSequential.Test.js
@@ -33,69 +33,50 @@ describe('The Vireo PropertyNode', function () {
         spy = jasmine.createSpy();
     });
 
+    var propertyNodeCallbackTest = function (viaPath, viName, controlId, propertyName, done) {
+        runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, viaPath);
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrint).toBeEmptyString();
+            expect(rawPrintError).toBeEmptyString();
+
+            var callCount = spy.calls.count();
+            for (var i = 0; i < callCount; i += 1) {
+                var args = spy.calls.argsFor(i);
+                expect(args[0]).toEqual(viName);
+                expect(args[1]).toEqual(controlId);
+                expect(args[2]).toEqual(propertyName);
+                expectValidValueRef(args[3]);
+            }
+
+            done();
+        });
+    };
+
     it('sequential read read operations invoke JavaScript callbacks with correct parameters', function (done) {
         var viName = '%3A%3AWeb%20Server%3A%3AInteractive%3A%3AWebApp%3A%3AReadRead%2Egviweb',
             controlId = '1';
 
         vireo.propertyNode.setPropertyReadFunction(spy);
-        runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, propertyNodeReadRead);
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeEmptyString();
-            expect(rawPrintError).toBeEmptyString();
 
-            var callCount = spy.calls.count();
-            for (var i = 0; i < callCount; i += 1) {
-                var args = spy.calls.argsFor(i);
-                expect(args[0]).toEqual(viName);
-                expect(args[1]).toEqual(controlId);
-                expect(args[2]).toEqual(propertyName);
-                expectValidValueRef(args[3]);
-            }
-
-            done();
-        });
+        propertyNodeCallbackTest(propertyNodeReadRead, viName, controlId, propertyName, done);
     });
 
     it('sequential write write operations invoke JavaScript callbacks with correct parameters', function (done) {
         var viName = '%3A%3AWeb%20Server%3A%3AInteractive%3A%3AWebApp%3A%3AWriteWrite%2Egviweb',
             controlId = '1';
+
         vireo.propertyNode.setPropertyWriteFunction(spy);
 
-        runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, propertyNodeWriteWrite);
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeEmptyString();
-            expect(rawPrintError).toBeEmptyString();
-            var callCount = spy.calls.count();
-            for (var i = 0; i < callCount; i += 1) {
-                var args = spy.calls.argsFor(i);
-                expect(args[0]).toEqual(viName);
-                expect(args[1]).toEqual(controlId);
-                expect(args[2]).toEqual(propertyName);
-                expectValidValueRef(args[3]);
-            }
-            done();
-        });
+        propertyNodeCallbackTest(propertyNodeWriteWrite, viName, controlId, propertyName, done);
     });
 
     it('sequential write read operations invoke JavaScript callbacks with correct parameters', function (done) {
         var viName = '%3A%3AWeb%20Server%3A%3AInteractive%3A%3AWebApp%3A%3AWriteRead%2Egviweb',
             controlId = '1';
+
         vireo.propertyNode.setPropertyWriteFunction(spy);
         vireo.propertyNode.setPropertyReadFunction(spy);
 
-        runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, propertyNodeWriteRead);
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeEmptyString();
-            expect(rawPrintError).toBeEmptyString();
-            var callCount = spy.calls.count();
-            for (var i = 0; i < callCount; i += 1) {
-                var args = spy.calls.argsFor(i);
-                expect(args[0]).toEqual(viName);
-                expect(args[1]).toEqual(controlId);
-                expect(args[2]).toEqual(propertyName);
-                expectValidValueRef(args[3]);
-            }
-            done();
-        });
+        propertyNodeCallbackTest(propertyNodeWriteRead, viName, controlId, propertyName, done);
     });
 });

--- a/test-it/karma/propertynode/PropertyNodeSequential.Test.js
+++ b/test-it/karma/propertynode/PropertyNodeSequential.Test.js
@@ -4,7 +4,6 @@ describe('The Vireo PropertyNode', function () {
     var Vireo = window.NationalInstruments.Vireo.Vireo;
     var vireoRunner = window.testHelpers.vireoRunner;
     var fixtures = window.testHelpers.fixtures;
-    var spyHelpers = window.testHelpers.spyHelpers;
 
     var vireo, spy, runSlicesAsync;
 
@@ -12,6 +11,14 @@ describe('The Vireo PropertyNode', function () {
     var propertyNodeWriteRead = fixtures.convertToAbsoluteFromFixturesDir('propertynode/WriteRead.via');
     var propertyNodeWriteWrite = fixtures.convertToAbsoluteFromFixturesDir('propertynode/WriteWrite.via');
     var propertyName = 'Value';
+
+    var expectValidValueRef = function (valueRef) {
+        expect(valueRef).toBeObject();
+        expect(valueRef.typeRef).toBeDefined();
+        expect(valueRef.dataRef).toBeDefined();
+        expect(valueRef.typeRef).toBeNumber();
+        expect(valueRef.dataRef).toBeNumber();
+    };
 
     beforeAll(function (done) {
         fixtures.preloadAbsoluteUrls([
@@ -27,56 +34,67 @@ describe('The Vireo PropertyNode', function () {
     });
 
     it('sequential read read operations invoke JavaScript callbacks with correct parameters', function (done) {
-        var viName = '%3A%3AWeb%20Server%3A%3AInteractive%3A%3AWebApp%3A%3AReadRead%2Egviweb';
+        var viName = '%3A%3AWeb%20Server%3A%3AInteractive%3A%3AWebApp%3A%3AReadRead%2Egviweb',
+            controlId = '1';
+
         vireo.propertyNode.setPropertyReadFunction(spy);
-
-        var expectedCallArgs = [
-            [viName, '1', propertyName, 'Boolean', viName, 'local3'],
-            [viName, '1', propertyName, 'Boolean', viName, 'local6']
-        ];
-
         runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, propertyNodeReadRead);
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
             expect(rawPrintError).toBeEmptyString();
-            spyHelpers.verifySpyArgumentsForCalls(spy, expectedCallArgs);
+
+            var callCount = spy.calls.count();
+            for (var i = 0; i < callCount; i += 1) {
+                var args = spy.calls.argsFor(i);
+                expect(args[0]).toEqual(viName);
+                expect(args[1]).toEqual(controlId);
+                expect(args[2]).toEqual(propertyName);
+                expectValidValueRef(args[3]);
+            }
+
             done();
         });
     });
 
     it('sequential write write operations invoke JavaScript callbacks with correct parameters', function (done) {
-        var viName = '%3A%3AWeb%20Server%3A%3AInteractive%3A%3AWebApp%3A%3AWriteWrite%2Egviweb';
+        var viName = '%3A%3AWeb%20Server%3A%3AInteractive%3A%3AWebApp%3A%3AWriteWrite%2Egviweb',
+            controlId = '1';
         vireo.propertyNode.setPropertyWriteFunction(spy);
-
-        var expectedCallArgs = [
-            [viName, '1', propertyName, 'Boolean', viName, 'c1'],
-            [viName, '1', propertyName, 'Boolean', viName, 'c4']
-        ];
 
         runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, propertyNodeWriteWrite);
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
             expect(rawPrintError).toBeEmptyString();
-            spyHelpers.verifySpyArgumentsForCalls(spy, expectedCallArgs);
+            var callCount = spy.calls.count();
+            for (var i = 0; i < callCount; i += 1) {
+                var args = spy.calls.argsFor(i);
+                expect(args[0]).toEqual(viName);
+                expect(args[1]).toEqual(controlId);
+                expect(args[2]).toEqual(propertyName);
+                expectValidValueRef(args[3]);
+            }
             done();
         });
     });
 
     it('sequential write read operations invoke JavaScript callbacks with correct parameters', function (done) {
-        var viName = '%3A%3AWeb%20Server%3A%3AInteractive%3A%3AWebApp%3A%3AWriteRead%2Egviweb';
+        var viName = '%3A%3AWeb%20Server%3A%3AInteractive%3A%3AWebApp%3A%3AWriteRead%2Egviweb',
+            controlId = '1';
         vireo.propertyNode.setPropertyWriteFunction(spy);
         vireo.propertyNode.setPropertyReadFunction(spy);
-
-        var expectedCallArgs = [
-            [viName, '1', propertyName, 'Boolean', viName, 'c1'],
-            [viName, '1', propertyName, 'Boolean', viName, 'local6']
-        ];
 
         runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, propertyNodeWriteRead);
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
             expect(rawPrintError).toBeEmptyString();
-            spyHelpers.verifySpyArgumentsForCalls(spy, expectedCallArgs);
+            var callCount = spy.calls.count();
+            for (var i = 0; i < callCount; i += 1) {
+                var args = spy.calls.argsFor(i);
+                expect(args[0]).toEqual(viName);
+                expect(args[1]).toEqual(controlId);
+                expect(args[2]).toEqual(propertyName);
+                expectValidValueRef(args[3]);
+            }
             done();
         });
     });

--- a/test-it/karma/propertynode/PropertyNodeSubSubVI.Test.js
+++ b/test-it/karma/propertynode/PropertyNodeSubSubVI.Test.js
@@ -9,18 +9,31 @@ describe('The Vireo PropertyNode', function () {
 
     var viaUrl = fixtures.convertToAbsoluteFromFixturesDir('propertynode/ControlRefNestedSubVIReadWrite.via');
 
+    var expectValidValueRef = function (valueRef) {
+        expect(valueRef).toBeObject();
+        expect(valueRef.typeRef).toBeDefined();
+        expect(valueRef.dataRef).toBeDefined();
+        expect(valueRef.typeRef).toBeNumber();
+        expect(valueRef.dataRef).toBeNumber();
+    };
+
     beforeAll(function (done) {
         fixtures.preloadAbsoluteUrls([
             viaUrl
         ], done);
     });
 
-
     beforeEach(function () {
         vireo = new Vireo();
     });
 
     describe('can pass control reference to nested sub-sub-vi and ', function () {
+        var topVIName = 'topVI',
+            subVIName = 'subSubVI',
+            controlRefId = '1',
+            propertyName = 'Value';
+
+
         it('callback is invoked with expected parameters', function (done) {
             var spyRead = jasmine.createSpy();
             var spyWrite = jasmine.createSpy();
@@ -31,8 +44,20 @@ describe('The Vireo PropertyNode', function () {
             runSlicesAsync(function (rawPrint, rawPrintError) {
                 expect(rawPrint).toBeEmptyString();
                 expect(rawPrintError).toBeEmptyString();
-                expect(spyRead.calls.argsFor(0)).toEqual(['topVI', '1', 'Value', 'Double', 'subSubVI', 'doubleLocal']);
-                expect(spyWrite.calls.argsFor(0)).toEqual(['topVI', '1', 'Value', 'Double', 'subSubVI', 'doubleLocal']);
+                var readArgs = spyRead.calls.argsFor(0);
+
+                expect(readArgs[0]).toEqual(topVIName);
+                expect(readArgs[1]).toEqual(controlRefId);
+                expect(readArgs[2]).toEqual(propertyName);
+                expectValidValueRef(readArgs[3]);
+
+                var writeArgs = spyWrite.calls.argsFor(0);
+                expect(writeArgs[0]).toEqual(topVIName);
+                expect(writeArgs[1]).toEqual(controlRefId);
+                expect(writeArgs[2]).toEqual(propertyName);
+                expectValidValueRef(writeArgs[3]);
+
+
                 done();
             });
         });
@@ -42,18 +67,24 @@ describe('The Vireo PropertyNode', function () {
                 doubleLocal: 1234.5678
             };
 
-            var readFromVireo = function (viName, fpId, propertyName, propertyTypeName, propertyVIName, propertyPath) {
-                var parser = vireoRunner.createVIPathParser(vireo, propertyVIName);
-                var readValue = parser(propertyPath);
-                var expectedVal = expectedValues[propertyPath];
+            var readFromVireo = function (viName, fpId, propertyName, tempVarValueRef) {
+                // var parser = vireoRunner.createVIPathParser(vireo, propertyVIName);
+                // var readValue = parser(propertyPath);
+                var readValue = vireo.eggShell.readDouble(tempVarValueRef);
+
+                var expectedVal = expectedValues.doubleLocal;
                 expect(readValue).toEqual(expectedVal);
             };
 
             vireo.propertyNode.setPropertyWriteFunction(readFromVireo);
             var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, viaUrl);
+            var parser = vireoRunner.createVIPathParser(vireo, subVIName);
             runSlicesAsync(function (rawPrint, rawPrintError) {
                 expect(rawPrint).toBeEmptyString();
                 expect(rawPrintError).toBeEmptyString();
+                expect(parser('error.status')).toBeFalse();
+                expect(parser('error.code')).toBe(0);
+                expect(parser('error.source')).toBeEmptyString();
                 done();
             });
         });
@@ -62,11 +93,12 @@ describe('The Vireo PropertyNode', function () {
         it('callback writes to vireo with passed parameters', function (done) {
             var indexToRead = 0;
             var valuesToRead = [3.14];
-            var writeToVireo = function (viName, fpId, propertyName, propertyTypeName, propertyViName, propertyPath) {
-                var writer = vireoRunner.createVIPathWriter(vireo, propertyViName);
+            var writeToVireo = function (viName, fpId, propertyName, tempVarValueRef) {
+                // var writer = vireoRunner.createVIPathWriter(vireo, propertyViName);
                 var valueRead = valuesToRead[indexToRead];
                 indexToRead += 1;
-                writer(propertyPath, valueRead);
+                vireo.eggShell.writeDouble(tempVarValueRef, valueRead);
+                // writer(propertyPath, valueRead);
             };
             var nestSubVIName = 'subSubVI';
 

--- a/test-it/karma/propertynode/PropertyNodeSubSubVI.Test.js
+++ b/test-it/karma/propertynode/PropertyNodeSubSubVI.Test.js
@@ -33,7 +33,6 @@ describe('The Vireo PropertyNode', function () {
             controlRefId = '1',
             propertyName = 'Value';
 
-
         it('callback is invoked with expected parameters', function (done) {
             var spyRead = jasmine.createSpy();
             var spyWrite = jasmine.createSpy();
@@ -57,7 +56,6 @@ describe('The Vireo PropertyNode', function () {
                 expect(writeArgs[2]).toEqual(propertyName);
                 expectValidValueRef(writeArgs[3]);
 
-
                 done();
             });
         });
@@ -68,10 +66,7 @@ describe('The Vireo PropertyNode', function () {
             };
 
             var readFromVireo = function (viName, fpId, propertyName, tempVarValueRef) {
-                // var parser = vireoRunner.createVIPathParser(vireo, propertyVIName);
-                // var readValue = parser(propertyPath);
                 var readValue = vireo.eggShell.readDouble(tempVarValueRef);
-
                 var expectedVal = expectedValues.doubleLocal;
                 expect(readValue).toEqual(expectedVal);
             };
@@ -93,12 +88,10 @@ describe('The Vireo PropertyNode', function () {
         it('callback writes to vireo with passed parameters', function (done) {
             var indexToRead = 0;
             var valuesToRead = [3.14];
-            var writeToVireo = function (viName, fpId, propertyName, tempVarValueRef) {
-                // var writer = vireoRunner.createVIPathWriter(vireo, propertyViName);
+            var writeToVireo = function (viName, controlId, propertyName, tempVarValueRef) {
                 var valueRead = valuesToRead[indexToRead];
                 indexToRead += 1;
                 vireo.eggShell.writeDouble(tempVarValueRef, valueRead);
-                // writer(propertyPath, valueRead);
             };
             var nestSubVIName = 'subSubVI';
 

--- a/test-it/karma/propertynode/PropertyNodeUnwiredError.Test.js
+++ b/test-it/karma/propertynode/PropertyNodeUnwiredError.Test.js
@@ -30,93 +30,38 @@ describe('The Vireo PropertyNode', function () {
 
     beforeEach(function () {
         vireo = new Vireo();
+        spy = jasmine.createSpy();
     });
 
-    describe('property read', function () {
-        beforeEach(function () {
-            spy = jasmine.createSpy();
-            vireo.propertyNode.setPropertyReadFunction(spy);
+    var unwiredErrorTest = function (viaPath, viName, expectedControlRefs, propertyName, done) {
+        runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, viaPath);
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrint).toBeEmptyString();
+            expect(rawPrintError).toBeEmptyString();
+
+            var callCount = spy.calls.count();
+            expect(callCount).toEqual(expectedControlRefs.length);
+            for (var i = 0; i < callCount; i += 1) {
+                var args = spy.calls.argsFor(i);
+                expect(args[0]).toEqual(viName);
+                expect(args[1]).toEqual(expectedControlRefs[i]);
+                expect(args[2]).toEqual(propertyName);
+                expectValidValueRef(args[3]);
+            }
+
+            done();
         });
+    };
 
-        it('callback is invoked with no wired error terminal', function (done) {
-            var expectedControlRefs = [
-                '1',
-                '2',
-                '3',
-                '4',
-                '5',
-                '6',
-                '7',
-                '8',
-                '9',
-                '10',
-                '11',
-                '12',
-                '13',
-                '14',
-                '15'
-            ];
-
-            runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiPropertyNodeRead);
-            runSlicesAsync(function (rawPrint, rawPrintError) {
-                expect(rawPrint).toBeEmptyString();
-                expect(rawPrintError).toBeEmptyString();
-
-                var callCount = spy.calls.count();
-                for (var i = 0; i < callCount; i += 1) {
-                    var args = spy.calls.argsFor(i);
-                    expect(args[0]).toEqual(propertyReadVIName);
-                    expect(args[1]).toEqual(expectedControlRefs[i]);
-                    expect(args[2]).toEqual(propertyName);
-                    expectValidValueRef(args[3]);
-                }
-
-                done();
-            });
-        });
+    it('property read callback is invoked with no wired error terminal', function (done) {
+        var expectedControlRefs = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15'];
+        vireo.propertyNode.setPropertyReadFunction(spy);
+        unwiredErrorTest(publicApiPropertyNodeRead, propertyReadVIName, expectedControlRefs, propertyName, done);
     });
 
-    describe('property write', function () {
-        beforeEach(function () {
-            spy = jasmine.createSpy();
-            vireo.propertyNode.setPropertyReadFunction(spy);
-        });
-
-        it('callback is invoked with no wired error terminal', function (done) {
-            var expectedControlRefs = [
-                '1',
-                '2',
-                '3',
-                '4',
-                '5',
-                '6',
-                '7',
-                '8',
-                '9',
-                '10',
-                '11',
-                '12',
-                '13',
-                '14',
-                '15'
-            ];
-
-            runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiPropertyNodeWrite);
-            runSlicesAsync(function (rawPrint, rawPrintError) {
-                expect(rawPrint).toBeEmptyString();
-                expect(rawPrintError).toBeEmptyString();
-
-                var callCount = spy.calls.count();
-                for (var i = 0; i < callCount; i += 1) {
-                    var args = spy.calls.argsFor(i);
-                    expect(args[0]).toEqual(propertyWriteVIName);
-                    expect(args[1]).toEqual(expectedControlRefs[i]);
-                    expect(args[2]).toEqual(propertyName);
-                    expectValidValueRef(args[3]);
-                }
-
-                done();
-            });
-        });
+    it('property write callback is invoked with no wired error terminal', function (done) {
+        var expectedControlRefs = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15'];
+        vireo.propertyNode.setPropertyWriteFunction(spy);
+        unwiredErrorTest(publicApiPropertyNodeWrite, propertyWriteVIName, expectedControlRefs, propertyName, done);
     });
 });

--- a/test-it/karma/propertynode/PropertyNodeUnwiredError.Test.js
+++ b/test-it/karma/propertynode/PropertyNodeUnwiredError.Test.js
@@ -4,7 +4,6 @@ describe('The Vireo PropertyNode', function () {
     var Vireo = window.NationalInstruments.Vireo.Vireo;
     var vireoRunner = window.testHelpers.vireoRunner;
     var fixtures = window.testHelpers.fixtures;
-    var spyHelpers = window.testHelpers.spyHelpers;
 
     var vireo, spy, runSlicesAsync;
 
@@ -13,6 +12,14 @@ describe('The Vireo PropertyNode', function () {
     var propertyReadVIName = '%3AWeb%20Server%3AInteractive%3AWebApp%3AMain%2Egviweb';
     var propertyWriteVIName = 'MyVI';
     var propertyName = 'Value';
+
+    var expectValidValueRef = function (valueRef) {
+        expect(valueRef).toBeObject();
+        expect(valueRef.typeRef).toBeDefined();
+        expect(valueRef.dataRef).toBeDefined();
+        expect(valueRef.typeRef).toBeNumber();
+        expect(valueRef.dataRef).toBeNumber();
+    };
 
     beforeAll(function (done) {
         fixtures.preloadAbsoluteUrls([
@@ -32,29 +39,38 @@ describe('The Vireo PropertyNode', function () {
         });
 
         it('callback is invoked with no wired error terminal', function (done) {
-            var expectedCallArgs = [
-                [propertyReadVIName, '1', propertyName, 'Boolean', propertyReadVIName, 'local_Boolean'],
-                [propertyReadVIName, '2', propertyName, 'Int8', propertyReadVIName, 'local_Int8'],
-                [propertyReadVIName, '3', propertyName, 'Int16', propertyReadVIName, 'local_Int16'],
-                [propertyReadVIName, '4', propertyName, 'Int32', propertyReadVIName, 'local_Int32'],
-                [propertyReadVIName, '5', propertyName, 'Int64', propertyReadVIName, 'local_Int64'],
-                [propertyReadVIName, '6', propertyName, 'UInt8', propertyReadVIName, 'local_UInt8'],
-                [propertyReadVIName, '7', propertyName, 'UInt16', propertyReadVIName, 'local_UInt16'],
-                [propertyReadVIName, '8', propertyName, 'UInt32', propertyReadVIName, 'local_UInt32'],
-                [propertyReadVIName, '9', propertyName, 'UInt64', propertyReadVIName, 'local_UInt64'],
-                [propertyReadVIName, '10', propertyName, 'Single', propertyReadVIName, 'local_Single'],
-                [propertyReadVIName, '11', propertyName, 'Double', propertyReadVIName, 'local_Double'],
-                [propertyReadVIName, '12', propertyName, 'ComplexSingle', propertyReadVIName, 'local_ComplexSingle'],
-                [propertyReadVIName, '13', propertyName, 'ComplexDouble', propertyReadVIName, 'local_ComplexDouble'],
-                [propertyReadVIName, '14', propertyName, 'String', propertyReadVIName, 'local_String'],
-                [propertyReadVIName, '15', propertyName, 'Timestamp', propertyReadVIName, 'local_Timestamp']
+            var expectedControlRefs = [
+                '1',
+                '2',
+                '3',
+                '4',
+                '5',
+                '6',
+                '7',
+                '8',
+                '9',
+                '10',
+                '11',
+                '12',
+                '13',
+                '14',
+                '15'
             ];
 
             runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiPropertyNodeRead);
             runSlicesAsync(function (rawPrint, rawPrintError) {
                 expect(rawPrint).toBeEmptyString();
                 expect(rawPrintError).toBeEmptyString();
-                spyHelpers.verifySpyArgumentsForCalls(spy, expectedCallArgs);
+
+                var callCount = spy.calls.count();
+                for (var i = 0; i < callCount; i += 1) {
+                    var args = spy.calls.argsFor(i);
+                    expect(args[0]).toEqual(propertyReadVIName);
+                    expect(args[1]).toEqual(expectedControlRefs[i]);
+                    expect(args[2]).toEqual(propertyName);
+                    expectValidValueRef(args[3]);
+                }
+
                 done();
             });
         });
@@ -67,29 +83,38 @@ describe('The Vireo PropertyNode', function () {
         });
 
         it('callback is invoked with no wired error terminal', function (done) {
-            var expectedCallArgs = [
-                [propertyWriteVIName, 'dataItem_Boolean', propertyName, 'Boolean', propertyWriteVIName, 'local_Boolean'],
-                [propertyWriteVIName, 'dataItem_Int8', propertyName, 'Int8', propertyWriteVIName, 'local_Int8'],
-                [propertyWriteVIName, 'dataItem_Int16', propertyName, 'Int16', propertyWriteVIName, 'local_Int16'],
-                [propertyWriteVIName, 'dataItem_Int32', propertyName, 'Int32', propertyWriteVIName, 'local_Int32'],
-                [propertyWriteVIName, 'dataItem_Int64', propertyName, 'Int64', propertyWriteVIName, 'local_Int64'],
-                [propertyWriteVIName, 'dataItem_UInt8', propertyName, 'UInt8', propertyWriteVIName, 'local_UInt8'],
-                [propertyWriteVIName, 'dataItem_UInt16', propertyName, 'UInt16', propertyWriteVIName, 'local_UInt16'],
-                [propertyWriteVIName, 'dataItem_UInt32', propertyName, 'UInt32', propertyWriteVIName, 'local_UInt32'],
-                [propertyWriteVIName, 'dataItem_UInt64', propertyName, 'UInt64', propertyWriteVIName, 'local_UInt64'],
-                [propertyWriteVIName, 'dataItem_Single', propertyName, 'Single', propertyWriteVIName, 'local_Single'],
-                [propertyWriteVIName, 'dataItem_Double', propertyName, 'Double', propertyWriteVIName, 'local_Double'],
-                [propertyWriteVIName, 'dataItem_ComplexSingle', propertyName, 'ComplexSingle', propertyWriteVIName, 'local_ComplexSingle'],
-                [propertyWriteVIName, 'dataItem_ComplexDouble', propertyName, 'ComplexDouble', propertyWriteVIName, 'local_ComplexDouble'],
-                [propertyWriteVIName, 'dataItem_String', propertyName, 'String', propertyWriteVIName, 'local_String'],
-                [propertyWriteVIName, 'dataItem_Timestamp', propertyName, 'Timestamp', propertyWriteVIName, 'local_Timestamp']
+            var expectedControlRefs = [
+                '1',
+                '2',
+                '3',
+                '4',
+                '5',
+                '6',
+                '7',
+                '8',
+                '9',
+                '10',
+                '11',
+                '12',
+                '13',
+                '14',
+                '15'
             ];
 
             runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiPropertyNodeWrite);
             runSlicesAsync(function (rawPrint, rawPrintError) {
                 expect(rawPrint).toBeEmptyString();
                 expect(rawPrintError).toBeEmptyString();
-                spyHelpers.verifySpyArgumentsForCalls(spy, expectedCallArgs);
+
+                var callCount = spy.calls.count();
+                for (var i = 0; i < callCount; i += 1) {
+                    var args = spy.calls.argsFor(i);
+                    expect(args[0]).toEqual(propertyWriteVIName);
+                    expect(args[1]).toEqual(expectedControlRefs[i]);
+                    expect(args[2]).toEqual(propertyName);
+                    expectValidValueRef(args[3]);
+                }
+
                 done();
             });
         });

--- a/test-it/karma/utilities/TestHelpers.SpyHelpers.js
+++ b/test-it/karma/utilities/TestHelpers.SpyHelpers.js
@@ -6,6 +6,7 @@
     var verifySpyArgumentsForCalls = function (spy, expectedCallArgs) {
         var i;
         var callsCount = spy.calls.count();
+        expect(callsCount).toEqual(expectedCallArgs.length);
         for (i = 0; i < callsCount; i += 1) {
             expect(spy.calls.argsFor(i)).toEqual(expectedCallArgs[i]);
         }


### PR DESCRIPTION
After #471 made it to master, the concept of a valueRef was available in our vireo eggshell API. In this branch we take advantage of this new object and modify the property read/write JS callbacks to use this instead of the temporary variable VI name and its path.
This results in:
- Less code, deleted function `FindVINameAndPropertyPathForValue` in PropertyNode.cpp and a few `STACK_VAR`s.
- A couple of parameters less passed to JS, see `module_PropertyNode.js`
- Improved performance since we are no longer reading the temporary variable VIName, Type name and Path as strings every time.

I refactored all related tests too, improving a little bit their readability. 
I still need to run a LVjsCI once I have that we can merge this branch to master.