### PR TITLE
Allowing data to be passed into occurEvent for control events

### DIFF
--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -1128,16 +1128,14 @@ void OccurEvent(UInt32 eventOracleIndex, UInt32 controlID, UInt32 eventType, UIn
     EventOracle::TheEventOracle().OccurEvent(eventOracleIndex, eData);
 }
 
-VIREO_EXPORT void OccurEvent(UInt32 eventOracleIndex, UInt32 controlID, UInt32 eventType)
+VIREO_EXPORT void OccurEvent(UInt32 eventOracleIndex, UInt32 controlID, UInt32 eventType, TypeRef eventDataType, void *eventData)
 {
-    // TODO(spathiwa,sid): Add event data arg
-
     RefNum ref = kNotARefNum;
     EventControlUID eventIndexControlID = 0;
     if (eventOracleIndex > kAppEventOracleIdx) {
         EventOracle::TheEventOracle().GetControlInfoForEventOracleIndex(eventOracleIndex, &eventIndexControlID, &ref);
         if (controlID == eventIndexControlID)
-            OccurEvent(eventOracleIndex, controlID, eventType, ref, nullptr, nullptr);
+            OccurEvent(eventOracleIndex, controlID, eventType, ref, eventDataType, eventData);
         else
             THREAD_EXEC()->LogEvent(EventLog::kSoftDataError, "OccurEvent: eventOracleIndex %d does not match controlID %d, expected %d",
                                     eventOracleIndex, controlID, eventIndexControlID);

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -1128,8 +1128,9 @@ void OccurEvent(UInt32 eventOracleIndex, UInt32 controlID, UInt32 eventType, UIn
     EventOracle::TheEventOracle().OccurEvent(eventOracleIndex, eData);
 }
 
-VIREO_EXPORT void OccurEvent(UInt32 eventOracleIndex, UInt32 controlID, UInt32 eventType, TypeRef eventDataType, void *eventData)
+VIREO_EXPORT void OccurEvent(TypeManagerRef tm, UInt32 eventOracleIndex, UInt32 controlID, UInt32 eventType, TypeRef eventDataType, void *eventData)
 {
+    TypeManagerScope scope(tm);
     RefNum ref = kNotARefNum;
     EventControlUID eventIndexControlID = 0;
     if (eventOracleIndex > kAppEventOracleIdx) {

--- a/source/core/module_eventHelpers.js
+++ b/source/core/module_eventHelpers.js
@@ -36,9 +36,6 @@
         var unRegisterForControlEvent = function () {
             throw new Error('No event un-registration callback was supplied');
         };
-        var writeEventData = function () {
-            throw new Error('No event data write callback was supplied');
-        };
 
         Module.eventHelpers.jsRegisterForControlEvent = function (
             viNamePointer,
@@ -76,18 +73,10 @@
             unRegisterForControlEvent = fn;
         };
 
-        publicAPI.eventHelpers.setWriteEventDataFunction = Module.eventHelpers.setWriteEventDataFunction = function (fn) {
-            if (typeof fn !== 'function') {
-                throw new Error('WriteEventData must be a callable function');
-            }
-
-            writeEventData = fn;
-        };
-
-        publicAPI.eventHelpers.occurEvent = Module.eventHelpers.occurEvent = function (eventOracleIndex, controlId, eventType, eventDataTypeValueRef, eventData) {
+        publicAPI.eventHelpers.occurEvent = Module.eventHelpers.occurEvent = function (eventOracleIndex, controlId, eventType, typeVisitor, eventDataTypeValueRef, eventData) {
             // Allocate space for the event data using the type information passed in to occurEvent
             var allocatedDataValueRef = Module.eggShell.allocateData(eventDataTypeValueRef.typeRef);
-            writeEventData(allocatedDataValueRef, eventData);
+            Module.eggShell.reflectOnValueRef(typeVisitor, allocatedDataValueRef, eventData);
             Module._OccurEvent(eventOracleIndex, controlId, eventType, allocatedDataValueRef.typeRef, allocatedDataValueRef.dataRef);
             // Now that the data has been passed to Vireo, which should copy it, deallocate the memory
             Module.eggShell.deallocateData(allocatedDataValueRef);

--- a/source/core/module_eventHelpers.js
+++ b/source/core/module_eventHelpers.js
@@ -73,10 +73,10 @@
             unRegisterForControlEvent = fn;
         };
 
-        publicAPI.eventHelpers.occurEvent = Module.eventHelpers.occurEvent = function (eventOracleIndex, controlId, eventType, typeVisitor, eventDataTypeValueRef, eventData) {
+        publicAPI.eventHelpers.occurEvent = Module.eventHelpers.occurEvent = function (eventOracleIndex, controlId, eventType, writeCallback, eventDataTypeValueRef, eventData) {
             // Allocate space for the event data using the type information passed in to occurEvent
             var allocatedDataValueRef = Module.eggShell.allocateData(eventDataTypeValueRef.typeRef);
-            Module.eggShell.reflectOnValueRef(typeVisitor, allocatedDataValueRef, eventData);
+            writeCallback(allocatedDataValueRef, eventData);
             Module._OccurEvent(eventOracleIndex, controlId, eventType, allocatedDataValueRef.typeRef, allocatedDataValueRef.dataRef);
             // Now that the data has been passed to Vireo, which should copy it, deallocate the memory
             Module.eggShell.deallocateData(allocatedDataValueRef);

--- a/source/core/module_eventHelpers.js
+++ b/source/core/module_eventHelpers.js
@@ -27,7 +27,6 @@
     // Static Private Variables (all vireo instances)
 
     var assignEventHelpers = function (Module, publicAPI) {
-
         Module.eventHelpers = {};
         publicAPI.eventHelpers = {};
 
@@ -39,7 +38,7 @@
         };
         var writeEventData = function () {
             throw new Error('No event data write callback was supplied');
-        }
+        };
 
         Module.eventHelpers.jsRegisterForControlEvent = function (
             viNamePointer,
@@ -85,8 +84,7 @@
             writeEventData = fn;
         };
 
-        publicAPI.eventHelpers.occurEvent = Module.eventHelpers.occurEvent = function(eventOracleIndex, controlId, eventType, eventDataTypeValueRef, eventData) {
-
+        publicAPI.eventHelpers.occurEvent = Module.eventHelpers.occurEvent = function (eventOracleIndex, controlId, eventType, eventDataTypeValueRef, eventData) {
             var allocatedDataValueRef = Module.eggShell.allocateData(eventDataTypeValueRef.typeRef);
 
             writeEventData(allocatedDataValueRef, eventData);

--- a/source/core/module_eventHelpers.js
+++ b/source/core/module_eventHelpers.js
@@ -77,7 +77,7 @@
             // Allocate space for the event data using the type information passed in to occurEvent
             var allocatedDataValueRef = Module.eggShell.allocateData(eventDataTypeValueRef.typeRef);
             writeCallback(allocatedDataValueRef, eventData);
-            Module._OccurEvent(eventOracleIndex, controlId, eventType, allocatedDataValueRef.typeRef, allocatedDataValueRef.dataRef);
+            Module._OccurEvent(Module.eggShell.v_userShell, eventOracleIndex, controlId, eventType, allocatedDataValueRef.typeRef, allocatedDataValueRef.dataRef);
             // Now that the data has been passed to Vireo, which should copy it, deallocate the memory
             Module.eggShell.deallocateData(allocatedDataValueRef);
         };

--- a/source/core/module_eventHelpers.js
+++ b/source/core/module_eventHelpers.js
@@ -85,12 +85,11 @@
         };
 
         publicAPI.eventHelpers.occurEvent = Module.eventHelpers.occurEvent = function (eventOracleIndex, controlId, eventType, eventDataTypeValueRef, eventData) {
+            // Allocate space for the event data using the type information passed in to occurEvent
             var allocatedDataValueRef = Module.eggShell.allocateData(eventDataTypeValueRef.typeRef);
-
             writeEventData(allocatedDataValueRef, eventData);
-
             Module._OccurEvent(eventOracleIndex, controlId, eventType, allocatedDataValueRef.typeRef, allocatedDataValueRef.dataRef);
-
+            // Now that the data has been passed to Vireo, which should copy it, deallocate the memory
             Module.eggShell.deallocateData(allocatedDataValueRef);
         };
     };

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -11,8 +11,8 @@ describe('ValueChanged event tests', function () {
     var updateBooleanOnValueChangeEvent = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeStaticControlEvent.via');
     var updateMultipleEventStructuresOnValueChange = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeStaticControlEventWithMultipleRegistrations.via');
 
-    var getEventDataValueRef = function(viName) {
-        return vireo.eggShell.findValueRef(viName, "valueChangedEventDataBool");
+    var getEventDataValueRef = function (viName) {
+        return vireo.eggShell.findValueRef(viName, 'valueChangedEventDataBool');
     };
 
     beforeAll(function (done) {
@@ -71,8 +71,11 @@ describe('ValueChanged event tests', function () {
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'UpdateBooleanOnValueChangeEvent');
 
         setTimeout(function () {
-            const valueRef = getEventDataValueRef("UpdateBooleanOnValueChangeEvent")
-            const data = { OldValue:false, NewValue:true };
+            const valueRef = getEventDataValueRef('UpdateBooleanOnValueChangeEvent');
+            const data = {
+                OldValue: false,
+                NewValue: true
+            };
             vireo.eventHelpers.occurEvent(1, 18, 2, valueRef, data);
         }, 20);
 
@@ -90,8 +93,11 @@ describe('ValueChanged event tests', function () {
 
         var unregisteredControlId = 19;
         setTimeout(function () {
-            const valueRef = getEventDataValueRef('UpdateBooleanOnValueChangeEvent')
-            const data = { OldValue:false, NewValue:true };
+            const valueRef = getEventDataValueRef('UpdateBooleanOnValueChangeEvent');
+            const data = {
+                OldValue: false,
+                NewValue: true
+            };
             vireo.eventHelpers.occurEvent(1, unregisteredControlId, 2, valueRef, data);
         }, 20);
 
@@ -120,8 +126,11 @@ describe('ValueChanged event tests', function () {
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'MultipleEventStructuresListeningToSameControl');
 
         setTimeout(function () {
-            const valueRef = getEventDataValueRef('MultipleEventStructuresListeningToSameControl')
-            const data = { OldValue:false, NewValue:true };
+            const valueRef = getEventDataValueRef('MultipleEventStructuresListeningToSameControl');
+            const data = {
+                OldValue: false,
+                NewValue: true
+            };
             vireo.eventHelpers.occurEvent(1, 18, 2, valueRef, data);
         }, 20);
 

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -1,4 +1,4 @@
-describe('ValueChanged event tests', function () {
+describe('The Vireo Control Event', function () {
     'use strict';
 
     var Vireo = window.NationalInstruments.Vireo.Vireo;
@@ -59,7 +59,7 @@ describe('ValueChanged event tests', function () {
         });
     });
 
-    it('Verify registration callback is called on parse and unregister callback on exit', function (done) {
+    it('registration callback is called on parse and unregister callback on exit', function (done) {
         var registerCallbackExecuted = false;
         var unregisterCallbackExecuted = false;
         vireo.eventHelpers.setRegisterForControlEventsFunction(function (viName, controlId, eventId, eventOracleIndex) {
@@ -89,7 +89,7 @@ describe('ValueChanged event tests', function () {
         });
     });
 
-    it('Verify event occurrence updates boolean terminal value', function (done) {
+    it('occurrence updates boolean terminal value', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, updateBooleanOnValueChangeEvent);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'UpdateBooleanOnValueChangeEvent');
 
@@ -110,7 +110,7 @@ describe('ValueChanged event tests', function () {
         });
     });
 
-    it('Verify value change on an unregistered control does not update boolean terminal value', function (done) {
+    it('on an unregistered control does not update boolean terminal value', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, updateBooleanOnValueChangeEvent);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'UpdateBooleanOnValueChangeEvent');
 
@@ -132,7 +132,7 @@ describe('ValueChanged event tests', function () {
         });
     });
 
-    it('Verify that time out event occurs when value change is not triggered', function (done) {
+    it('time out event occurs when value change is not triggered', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, updateBooleanOnValueChangeEvent);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'UpdateBooleanOnValueChangeEvent');
 
@@ -144,7 +144,7 @@ describe('ValueChanged event tests', function () {
         });
     });
 
-    it('Verify event occurrence notifies all registered event structures', function (done) {
+    it('occurrence notifies all registered event structures', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, updateMultipleEventStructuresOnValueChange);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'MultipleEventStructuresListeningToSameControl');
 
@@ -165,7 +165,7 @@ describe('ValueChanged event tests', function () {
         });
     });
 
-    it('Verify event occurrence passes correct old and new value', function (done) {
+    it('for value change occurrence passes correct old and new value', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, updateNumericOnValueChangeEvent);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'UpdateNumericOnValueChangeEvent');
         var oldValue = 12;

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -36,6 +36,10 @@ describe('ValueChanged event tests', function () {
         };
     }());
 
+    var writeData = function (valueRef, data) {
+        vireo.eggShell.reflectOnValueRef(typeVisitor, valueRef, data);
+    };
+
     beforeAll(function (done) {
         fixtures.preloadAbsoluteUrls([
             valueChangedEventRegisterAndUnregister,
@@ -95,7 +99,7 @@ describe('ValueChanged event tests', function () {
                 OldValue: false,
                 NewValue: true
             };
-            vireo.eventHelpers.occurEvent(1, 18, 2, typeVisitor, valueRef, data);
+            vireo.eventHelpers.occurEvent(1, 18, 2, writeData, valueRef, data);
         }, 20);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
@@ -117,7 +121,7 @@ describe('ValueChanged event tests', function () {
                 OldValue: false,
                 NewValue: true
             };
-            vireo.eventHelpers.occurEvent(1, unregisteredControlId, 2, typeVisitor, valueRef, data);
+            vireo.eventHelpers.occurEvent(1, unregisteredControlId, 2, writeData, valueRef, data);
         }, 20);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
@@ -150,7 +154,7 @@ describe('ValueChanged event tests', function () {
                 OldValue: false,
                 NewValue: true
             };
-            vireo.eventHelpers.occurEvent(1, 18, 2, typeVisitor, valueRef, data);
+            vireo.eventHelpers.occurEvent(1, 18, 2, writeData, valueRef, data);
         }, 20);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
@@ -173,7 +177,7 @@ describe('ValueChanged event tests', function () {
                 OldValue: oldValue,
                 NewValue: newValue
             };
-            vireo.eventHelpers.occurEvent(1, 18, 2, typeVisitor, valueRef, data);
+            vireo.eventHelpers.occurEvent(1, 18, 2, writeData, valueRef, data);
         }, 20);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -11,6 +11,10 @@ describe('ValueChanged event tests', function () {
     var updateBooleanOnValueChangeEvent = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeStaticControlEvent.via');
     var updateMultipleEventStructuresOnValueChange = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeStaticControlEventWithMultipleRegistrations.via');
 
+    var getEventDataValueRef = function(viName) {
+        return vireo.eggShell.findValueRef(viName, "valueChangedEventDataBool");
+    };
+
     beforeAll(function (done) {
         fixtures.preloadAbsoluteUrls([
             valueChangedEventRegisterAndUnregister,
@@ -26,6 +30,9 @@ describe('ValueChanged event tests', function () {
         });
         vireo.eventHelpers.setUnRegisterForControlEventsFunction(function () {
             // no-op
+        });
+        vireo.eventHelpers.setWriteEventDataFunction(function (valueRef, eventData) {
+            vireo.eggShell.writeJSON(valueRef, JSON.stringify(eventData));
         });
     });
 
@@ -64,7 +71,9 @@ describe('ValueChanged event tests', function () {
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'UpdateBooleanOnValueChangeEvent');
 
         setTimeout(function () {
-            vireo.eventHelpers.occurEvent(1, 18, 2);
+            const valueRef = getEventDataValueRef("UpdateBooleanOnValueChangeEvent")
+            const data = { OldValue:false, NewValue:true };
+            vireo.eventHelpers.occurEvent(1, 18, 2, valueRef, data);
         }, 20);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
@@ -81,7 +90,9 @@ describe('ValueChanged event tests', function () {
 
         var unregisteredControlId = 19;
         setTimeout(function () {
-            vireo.eventHelpers.occurEvent(1, unregisteredControlId, 2);
+            const valueRef = getEventDataValueRef('UpdateBooleanOnValueChangeEvent')
+            const data = { OldValue:false, NewValue:true };
+            vireo.eventHelpers.occurEvent(1, unregisteredControlId, 2, valueRef, data);
         }, 20);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
@@ -109,7 +120,9 @@ describe('ValueChanged event tests', function () {
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'MultipleEventStructuresListeningToSameControl');
 
         setTimeout(function () {
-            vireo.eventHelpers.occurEvent(1, 18, 2);
+            const valueRef = getEventDataValueRef('MultipleEventStructuresListeningToSameControl')
+            const data = { OldValue:false, NewValue:true };
+            vireo.eventHelpers.occurEvent(1, 18, 2, valueRef, data);
         }, 20);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -9,16 +9,38 @@ describe('ValueChanged event tests', function () {
 
     var valueChangedEventRegisterAndUnregister = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeEventRegistration.via');
     var updateBooleanOnValueChangeEvent = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeStaticControlEvent.via');
+    var updateNumericOnValueChangeEvent = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeNumericStaticControlEvent.via');
     var updateMultipleEventStructuresOnValueChange = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeStaticControlEventWithMultipleRegistrations.via');
 
-    var getEventDataValueRef = function (viName) {
-        return vireo.eggShell.findValueRef(viName, 'valueChangedEventDataBool');
+    var getEventDataValueRef = function (viName, controlName) {
+        return vireo.eggShell.findValueRef(viName, 'valueChangedEventData' + controlName);
     };
+
+    var typeVisitor = (function () {
+        return {
+            visitCluster: function (valueRef, data) {
+                var that = this;
+                var valueRefObject = vireo.eggShell.readValueRefObject(valueRef);
+
+                Object.keys(valueRefObject).forEach(function (name) {
+                    vireo.eggShell.reflectOnValueRef(that, valueRefObject[name], data[name]);
+                });
+            },
+            visitBoolean: function (valueRef, data) {
+                vireo.eggShell.writeDouble(valueRef, data ? 1 : 0);
+            },
+            visitInt32: function (valueRef, data) {
+                var dataNum = parseFloat(data);
+                vireo.eggShell.writeDouble(valueRef, dataNum);
+            }
+        };
+    }());
 
     beforeAll(function (done) {
         fixtures.preloadAbsoluteUrls([
             valueChangedEventRegisterAndUnregister,
             updateBooleanOnValueChangeEvent,
+            updateNumericOnValueChangeEvent,
             updateMultipleEventStructuresOnValueChange
         ], done);
     });
@@ -30,9 +52,6 @@ describe('ValueChanged event tests', function () {
         });
         vireo.eventHelpers.setUnRegisterForControlEventsFunction(function () {
             // no-op
-        });
-        vireo.eventHelpers.setWriteEventDataFunction(function (valueRef, eventData) {
-            vireo.eggShell.writeJSON(valueRef, JSON.stringify(eventData));
         });
     });
 
@@ -71,12 +90,12 @@ describe('ValueChanged event tests', function () {
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'UpdateBooleanOnValueChangeEvent');
 
         setTimeout(function () {
-            const valueRef = getEventDataValueRef('UpdateBooleanOnValueChangeEvent');
+            const valueRef = getEventDataValueRef('UpdateBooleanOnValueChangeEvent', 'Bool');
             const data = {
                 OldValue: false,
                 NewValue: true
             };
-            vireo.eventHelpers.occurEvent(1, 18, 2, valueRef, data);
+            vireo.eventHelpers.occurEvent(1, 18, 2, typeVisitor, valueRef, data);
         }, 20);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
@@ -93,12 +112,12 @@ describe('ValueChanged event tests', function () {
 
         var unregisteredControlId = 19;
         setTimeout(function () {
-            const valueRef = getEventDataValueRef('UpdateBooleanOnValueChangeEvent');
+            const valueRef = getEventDataValueRef('UpdateBooleanOnValueChangeEvent', 'Bool');
             const data = {
                 OldValue: false,
                 NewValue: true
             };
-            vireo.eventHelpers.occurEvent(1, unregisteredControlId, 2, valueRef, data);
+            vireo.eventHelpers.occurEvent(1, unregisteredControlId, 2, typeVisitor, valueRef, data);
         }, 20);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
@@ -126,18 +145,43 @@ describe('ValueChanged event tests', function () {
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'MultipleEventStructuresListeningToSameControl');
 
         setTimeout(function () {
-            const valueRef = getEventDataValueRef('MultipleEventStructuresListeningToSameControl');
+            const valueRef = getEventDataValueRef('MultipleEventStructuresListeningToSameControl', 'Bool');
             const data = {
                 OldValue: false,
                 NewValue: true
             };
-            vireo.eventHelpers.occurEvent(1, 18, 2, valueRef, data);
+            vireo.eventHelpers.occurEvent(1, 18, 2, typeVisitor, valueRef, data);
         }, 20);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrintError).toBeEmptyString();
             expect(viPathParser('eventStructure1Notified')).toEqual(true);
             expect(viPathParser('eventStructure2Notified')).toEqual(true);
+            done();
+        });
+    });
+
+    it('Verify event occurrence passes correct old and new value', function (done) {
+        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, updateNumericOnValueChangeEvent);
+        var viPathParser = vireoRunner.createVIPathParser(vireo, 'UpdateNumericOnValueChangeEvent');
+        var oldValue = 12;
+        var newValue = 13;
+
+        setTimeout(function () {
+            const valueRef = getEventDataValueRef('UpdateNumericOnValueChangeEvent', 'Numeric');
+            const data = {
+                OldValue: oldValue,
+                NewValue: newValue
+            };
+            vireo.eventHelpers.occurEvent(1, 18, 2, typeVisitor, valueRef, data);
+        }, 20);
+
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrintError).toBeEmptyString();
+            expect(viPathParser('eventOccurred')).toEqual(true);
+            expect(viPathParser('oldValueInEvent')).toEqual(oldValue);
+            expect(viPathParser('newValueInEvent')).toEqual(newValue);
+            expect(viPathParser('eventTimedOut')).toEqual(false);
             done();
         });
     });

--- a/test-it/karma/fixtures/events/ValueChangeEventRegistration.via
+++ b/test-it/karma/fixtures/events/ValueChangeEventRegistration.via
@@ -28,6 +28,10 @@ define (ValueChangedEventRegisterAndUnregister dv(.VirtualInstrument (
             e(.UInt32 Index)
         ) timeoutData)
         e(dv(ControlRefNum ControlReference("18")) controlRef)
+        e(c(
+            e(.Boolean OldValue)
+            e(.Boolean NewValue)
+        ) valueChangedEventDataBool)
     )
         clump(1
 

--- a/test-it/karma/fixtures/events/ValueChangeNumericStaticControlEvent.via
+++ b/test-it/karma/fixtures/events/ValueChangeNumericStaticControlEvent.via
@@ -1,0 +1,54 @@
+define (UpdateNumericOnValueChangeEvent dv(.VirtualInstrument (
+    Events: c(
+        e(c( // Event Struct 0
+           e(c(  // Event spec 0
+               e(dv(UInt32 1000) eventSource)  // event source enum
+               e(dv(UInt32 2) eventType)  // ValueChanged
+               e(dv(ControlRefNum ControlReference("18")) controlUID)  // for static control refs
+               e(dv(UInt32 0) dynIndex)    // zero - statically registered
+           ))
+           e(dv(.EventSpec (0 1 0 0)))
+        ))
+    )
+    Locals: c(   // Data Space
+        e(.ErrorCluster error)
+        e(c(
+            e(.UInt32 Source)
+            e(.UInt32 Type)
+            e(.UInt32 Time)
+            e(.UInt32 Index)
+            e(.ControlRefNum ControlRef)
+            e(.Int32 OldValue)
+            e(.Int32 NewValue)
+        ) eventData)
+        e(c(
+            e(.UInt32 Source)
+            e(.UInt32 Type)
+            e(.UInt32 Time)
+            e(.UInt32 Index)
+        ) timeoutData)
+        e(.Boolean eventOccurred)
+        e(.Int32 oldValueInEvent)
+        e(.Int32 newValueInEvent)
+        e(.Boolean eventTimedOut)
+        e(c(
+            e(.Int32 OldValue)
+            e(.Int32 NewValue)
+        ) valueChangedEventDataNumeric)
+    )
+    clump(1
+        Printf("Waiting on Events\n")
+        WaitForEventsAndDispatch(100 * 0 0 eventData 1 1 timeoutData 2)
+        Branch(0)
+        Perch(1)
+        Copy(true eventOccurred)
+        Copy(eventData.OldValue oldValueInEvent)
+        Copy(eventData.NewValue newValueInEvent)
+        Branch(0)
+        Perch(2)
+        Printf("Timeout Event\n")
+        Copy(true eventTimedOut)
+        Perch(0)
+    )
+)))
+enqueue(UpdateNumericOnValueChangeEvent)

--- a/test-it/karma/fixtures/events/ValueChangeStaticControlEvent.via
+++ b/test-it/karma/fixtures/events/ValueChangeStaticControlEvent.via
@@ -29,6 +29,10 @@ define (UpdateBooleanOnValueChangeEvent dv(.VirtualInstrument (
         ) timeoutData)
         e(.Boolean eventOccurred)
         e(.Boolean eventTimedOut)
+        e(c(
+            e(.Boolean OldValue)
+            e(.Boolean NewValue)
+        ) valueChangedEventDataBool)
     )
     clump(1
         Printf("Waiting on Events\n")

--- a/test-it/karma/fixtures/events/ValueChangeStaticControlEventWithMultipleRegistrations.via
+++ b/test-it/karma/fixtures/events/ValueChangeStaticControlEventWithMultipleRegistrations.via
@@ -115,6 +115,10 @@ define (MultipleEventStructuresListeningToSameControl dv(.VirtualInstrument (
         ce(dv(.Int32 1)c92)
         ce(dv(.Int32 0)c93)
         ce(dv(.Int32 1)c94)
+        e(c(
+            e(.Boolean OldValue)
+            e(.Boolean NewValue)
+        ) valueChangedEventDataBool)
     )
     clump(1
         Printf("Starting\n")


### PR DESCRIPTION
These changes allow the update service to pass event data into occurEvent. I've add the TypeRef and data parameters to the OccurEvent C interface. I've also modified occurEvent method in eventHelpers to utilize the new allocateData and deallocateData methods to create space in Vireo's memory for the event data before using a callback method to write the data into the value reference.