### PR TITLE
Multi register events

### DIFF
--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -178,6 +178,8 @@ class EventOracle {
     static EventOracle _s_singleton;
 
  public:
+    typedef enum { kNewRegistration, kAddedToNewQueue, kNoChange } EventInsertStatus;
+
     size_t size(EventQueueID qID) const { return _qObject[qID].size(); }
     void OccurEvent(EventOracleIndex eventOracleIdx, const EventData &eData);
     bool GetControlInfoForEventOracleIndex(EventOracleIndex eventOracleIdx, EventControlUID *controlID, RefNum *controlRef);
@@ -195,10 +197,10 @@ class EventOracle {
             _qObject[qID].DeleteQueue();
     }
     Int32 GetPendingEventInfo(EventQueueID *pActiveQID, Int32 nQueues, RefNumVal *dynRegRefs, Int32 *dynIndexBase);
-    bool RegisterForEvent(EventQueueID qID, EventSource eSource, EventType eType, EventControlUID controlUID, RefNum ref,
+    EventInsertStatus RegisterForEvent(EventQueueID qID, EventSource eSource, EventType eType, EventControlUID controlUID, RefNum ref,
                           EventOracleIndex *oracleIdxPtr = nullptr);
     bool UnregisterForEvent(EventQueueID qID, EventSource eSource, EventType eType, EventOracleIndex eventOracleIndex, RefNum ref);
-    bool EventListInsert(EventOracleIndex eventOracleIndex, EventRegQueueID eventRegQueueID, EventSource eSource, EventType eType);
+    EventInsertStatus EventListInsert(EventOracleIndex eventOracleIndex, EventRegQueueID eventRegQueueID, EventSource eSource, EventType eType);
     bool EventListRemove(EventOracleIndex eventOracleIndex, EventRegQueueID eventRegQueueID, EventSource eSource, EventType eType);
     bool GetNewQueueObject(EventQueueID *qID, OccurrenceCore *occurrence);
 
@@ -246,8 +248,8 @@ bool EventOracle::GetControlInfoForEventOracleIndex(EventOracleIndex eventOracle
 }
 
 // EventListInsert -- add registration entry at given eventOracleIndex for event source/type/ref, watching the given QueueID
-bool EventOracle::EventListInsert(EventOracleIndex eventOracleIndex, EventRegQueueID eventRegQueueID, EventSource eSource, EventType eType) {
-    bool added = false;
+EventOracle::EventInsertStatus EventOracle::EventListInsert(EventOracleIndex eventOracleIndex, EventRegQueueID eventRegQueueID, EventSource eSource, EventType eType) {
+    EventInsertStatus added = kNoChange;
     EventRegList &eRegList = _eventReg[eventOracleIndex]._eRegList;
     EventRegList::iterator eRegIter = eRegList.begin(), eRegIterEnd = eRegList.end();
     while (eRegIter != eRegIterEnd && (eRegIter->_eventSource != eSource || eRegIter->_eventType != eType))
@@ -258,13 +260,13 @@ bool EventOracle::EventListInsert(EventOracleIndex eventOracleIndex, EventRegQue
             ++rqIter;
         if (rqIter == rqIterEnd) {  // ref/qID not found, add it
             eRegIter->_qIDList.push_back(eventRegQueueID);
-            added = true;
+            added = kAddedToNewQueue;
         }
     } else {  // first registration for this event source/type
         EventRegInfo eventRegInfo(eSource, eType);
         eventRegInfo._qIDList.push_back(eventRegQueueID);
         eRegList.push_back(eventRegInfo);
-        added = true;
+        added = kNewRegistration;
     }
     return added;
 }
@@ -298,26 +300,25 @@ bool EventOracle::EventListRemove(EventOracleIndex eventOracleIndex, EventRegQue
 // RegisterForEvent -- register for given event source/type on either a static control (controlUID) or dynamic reference (ref),
 // queueing events into the specified event queue [qID].  The event oracle index (bucket) allocated is returned for quicker lookup;
 // all events for the same control are bucketed together.  User events are always in the application index (kAppEventOracleIdx) bucket.
-bool EventOracle::RegisterForEvent(EventQueueID qID, EventSource eSource, EventType eType, EventControlUID controlUID,
+EventOracle::EventInsertStatus EventOracle::RegisterForEvent(EventQueueID qID, EventSource eSource, EventType eType, EventControlUID controlUID,
                                    RefNum ref, EventOracleIndex *oracleIdxPtr) {
     EventOracleIndex eventOracleIndex = kNotAnEventOracleIdx;
     if (oracleIdxPtr)
         *oracleIdxPtr = eventOracleIndex;
     if (UInt32(qID) >= _qObject.size()) {
         THREAD_EXEC()->LogEvent(EventLog::kHardDataError, "RegisterForEvents with invalid QueueiD");
-        return false;
+        return kNoChange;
     }
     if (!controlUID) {
         if (!ref) {
             THREAD_EXEC()->LogEvent(EventLog::kHardDataError, "RegisterForEvents must pass either controlUID or dynamic ref");
-            return false;
+            return kNoChange;
         }
         eventOracleIndex = kAppEventOracleIdx;
     } else {
         // TODO(spathiwa) -- finish; control should be queried for its cached eventOracleIndex if it previously registered
         // eventOracleIndex = ...
     }
-    bool newEventOracleIndex = true;
     if (eventOracleIndex == kNotAnEventOracleIdx) {  // no eventOracleIndex, allocate a new one
         size_t size = _eventReg.size(), idx = kAppEventOracleIdx+1;
         while (UInt32(idx) < size && !_eventReg[idx]._eRegList.empty() && _eventReg[idx]._controlUID != controlUID) {
@@ -326,7 +327,6 @@ bool EventOracle::RegisterForEvent(EventQueueID qID, EventSource eSource, EventT
         if (idx < size) {  // we found an unused index, or one already for this control ID
             _eventReg[idx]._controlUID = controlUID;
             _eventReg[idx]._controlRef = ref;
-            newEventOracleIndex = false;
         } else {
             EventOracleObj eo(controlUID, ref);
             _eventReg.push_back(eo);
@@ -336,7 +336,7 @@ bool EventOracle::RegisterForEvent(EventQueueID qID, EventSource eSource, EventT
         if (oracleIdxPtr)
             *oracleIdxPtr = eventOracleIndex;
     }
-    return EventListInsert(eventOracleIndex, EventRegQueueID(qID, ref), eSource, eType) && newEventOracleIndex;
+    return EventListInsert(eventOracleIndex, EventRegQueueID(qID, ref), eSource, eType);
 }
 
 // UnregisterForEvent -- unregister for given event source/type on either a static control (controlUID) or dynamic reference (ref),
@@ -576,10 +576,10 @@ void RegisterForStaticEvents(VirtualInstrument *vi) {
                         EventType eventType = eventSpecRef[eventSpecIndex].eventType;
                         EventSource eSource = eventSpecRef[eventSpecIndex].eventSource;
 
-                        bool newlyAdded = EventOracle::TheEventOracle().RegisterForEvent(qID, eSource, eventType, controlID, controlRef, &eventOracleIdx);
+                        EventOracle::EventInsertStatus status = EventOracle::TheEventOracle().RegisterForEvent(qID, eSource, eventType, controlID, controlRef, &eventOracleIdx);
                         // gPlatform.IO.Printf("Static Register for VI %*s controlID %d, event %d, eventOracleIdx %d\n",
                         //                     viName->Length(), viName->Begin(), controlID, eventType, eventOracleIdx);
-                        if (eventOracleIdx > kAppEventOracleIdx && newlyAdded) {
+                        if (eventOracleIdx > kAppEventOracleIdx && status == EventOracle::kNewRegistration) {
                             eventInfo->controlIDInfoMap[controlRef] = EventControlInfo(eventOracleIdx, controlID);
 #if kVireoOS_emscripten
                             jsRegisterForControlEvent(viName, controlID, eventType, eventOracleIdx);

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -248,7 +248,8 @@ bool EventOracle::GetControlInfoForEventOracleIndex(EventOracleIndex eventOracle
 }
 
 // EventListInsert -- add registration entry at given eventOracleIndex for event source/type/ref, watching the given QueueID
-EventOracle::EventInsertStatus EventOracle::EventListInsert(EventOracleIndex eventOracleIndex, EventRegQueueID eventRegQueueID, EventSource eSource, EventType eType) {
+EventOracle::EventInsertStatus EventOracle::EventListInsert(EventOracleIndex eventOracleIndex, EventRegQueueID eventRegQueueID, EventSource eSource,
+                                   EventType eType) {
     EventInsertStatus added = kNoChange;
     EventRegList &eRegList = _eventReg[eventOracleIndex]._eRegList;
     EventRegList::iterator eRegIter = eRegList.begin(), eRegIterEnd = eRegList.end();
@@ -576,7 +577,8 @@ void RegisterForStaticEvents(VirtualInstrument *vi) {
                         EventType eventType = eventSpecRef[eventSpecIndex].eventType;
                         EventSource eSource = eventSpecRef[eventSpecIndex].eventSource;
 
-                        EventOracle::EventInsertStatus status = EventOracle::TheEventOracle().RegisterForEvent(qID, eSource, eventType, controlID, controlRef, &eventOracleIdx);
+                        EventOracle::EventInsertStatus status = EventOracle::TheEventOracle().RegisterForEvent(qID, eSource, eventType, controlID, controlRef,
+                                            &eventOracleIdx);
                         // gPlatform.IO.Printf("Static Register for VI %*s controlID %d, event %d, eventOracleIdx %d\n",
                         //                     viName->Length(), viName->Begin(), controlID, eventType, eventOracleIdx);
                         if (eventOracleIdx > kAppEventOracleIdx && status == EventOracle::kNewRegistration) {

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -99,7 +99,7 @@ describe('The Vireo Control Event', function () {
             expect(controlId).toBe(18);
             expect(eventId).toBe(2);
             expect(eventOracleIndex).toBe(1);
-            registerCallbackExecutedCount++;
+            registerCallbackExecutedCount += 1;
         });
 
         vireo.eventHelpers.setUnRegisterForControlEventsFunction(function (viName, controlId, eventId, eventOracleIndex) {
@@ -107,7 +107,7 @@ describe('The Vireo Control Event', function () {
             expect(controlId).toBe(18);
             expect(eventId).toBe(2);
             expect(eventOracleIndex).toBe(1);
-            unregisterCallbackExecutedCount++;
+            unregisterCallbackExecutedCount += 1;
         });
 
         expect(registerCallbackExecutedCount).toBe(0);

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -8,6 +8,7 @@ describe('The Vireo Control Event', function () {
     var vireo;
 
     var valueChangedEventRegisterAndUnregister = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeEventRegistration.via');
+    var valueChangedMultipleEventRegisterAndUnregister = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeMultipleEventRegistration.via');
     var updateBooleanOnValueChangeEvent = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeStaticControlEvent.via');
     var updateNumericOnValueChangeEvent = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeNumericStaticControlEvent.via');
     var updateMultipleEventStructuresOnValueChange = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeStaticControlEventWithMultipleRegistrations.via');
@@ -43,6 +44,7 @@ describe('The Vireo Control Event', function () {
     beforeAll(function (done) {
         fixtures.preloadAbsoluteUrls([
             valueChangedEventRegisterAndUnregister,
+            valueChangedMultipleEventRegisterAndUnregister,
             updateBooleanOnValueChangeEvent,
             updateNumericOnValueChangeEvent,
             updateMultipleEventStructuresOnValueChange
@@ -85,6 +87,36 @@ describe('The Vireo Control Event', function () {
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrintError).toBeEmptyString();
             expect(unregisterCallbackExecuted).toBeTrue();
+            done();
+        });
+    });
+
+    it('registration and unregistration callbacks are called only once for each control/event combination', function (done) {
+        var registerCallbackExecutedCount = 0;
+        var unregisterCallbackExecutedCount = 0;
+        vireo.eventHelpers.setRegisterForControlEventsFunction(function (viName, controlId, eventId, eventOracleIndex) {
+            expect(viName).toBe('ValueChangedMultipleEventRegisterAndUnregister');
+            expect(controlId).toBe(18);
+            expect(eventId).toBe(2);
+            expect(eventOracleIndex).toBe(1);
+            registerCallbackExecutedCount++;
+        });
+
+        vireo.eventHelpers.setUnRegisterForControlEventsFunction(function (viName, controlId, eventId, eventOracleIndex) {
+            expect(viName).toBe('ValueChangedMultipleEventRegisterAndUnregister');
+            expect(controlId).toBe(18);
+            expect(eventId).toBe(2);
+            expect(eventOracleIndex).toBe(1);
+            unregisterCallbackExecutedCount++;
+        });
+
+        expect(registerCallbackExecutedCount).toBe(0);
+        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, valueChangedMultipleEventRegisterAndUnregister);
+        expect(registerCallbackExecutedCount).toBe(1);
+
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrintError).toBeEmptyString();
+            expect(unregisterCallbackExecutedCount).toBe(1);
             done();
         });
     });

--- a/test-it/karma/fixtures/events/ValueChangeMultipleEventRegistration.via
+++ b/test-it/karma/fixtures/events/ValueChangeMultipleEventRegistration.via
@@ -1,0 +1,76 @@
+define (ValueChangedMultipleEventRegisterAndUnregister dv(.VirtualInstrument (
+    Events: c(
+        e(c( // Event Struct 0
+           e(c(  // Event spec 0
+               e(dv(UInt32 1000) eventSource)  // event source enum
+               e(dv(UInt32 2) eventType)  // ValueChanged
+               e(dv(ControlRefNum ControlReference("18")) controlUID)  // for static control refs
+               e(dv(UInt32 0) dynIndex)    // zero - statically registered
+           ))
+           e(dv(.EventSpec (0 1 0 0)))
+        ))
+        e(c( // Event Struct 1
+           e(c(  // Event spec 0
+               e(dv(UInt32 1000) eventSource)  // event source enum
+               e(dv(UInt32 2) eventType)  // ValueChanged
+               e(dv(ControlRefNum ControlReference("18")) controlUID)  // for static control refs
+               e(dv(UInt32 0) dynIndex)    // zero - statically registered
+           ))
+        ))
+    )
+    Locals: c(   // Data Space
+        e(.ErrorCluster error)
+        e(c(
+            e(.UInt32 Source)
+            e(.UInt32 Type)
+            e(.UInt32 Time)
+            e(.UInt32 Index)
+            e(.ControlRefNum ControlRef)
+            e(.Boolean OldValue)
+            e(.Boolean NewValue)
+        ) eventData)
+        e(c(
+            e(.UInt32 Source)
+            e(.UInt32 Type)
+            e(.UInt32 Time)
+            e(.UInt32 Index)
+        ) timeoutData)
+        e(dv(ControlRefNum ControlReference("18")) controlRef)
+        e(c(
+            e(.Boolean OldValue)
+            e(.Boolean NewValue)
+        ) valueChangedEventDataBool)
+    )
+        clump(1
+
+        // _OccurEvent(controlRef 1000 2)  // Vireo unit test fires here; karma test fires event in JS
+
+        Printf("Waiting on Events\n")
+        WaitForEventsAndDispatch(50 * 0 0 eventData 1 1 timeoutData 2)
+        Branch(0)
+        Perch(1)
+        Printf("Value Changed Event %z %z\n" eventData.Source eventData.Type)
+        Printf("// ControlRef %z\n" eventData.ControlRef)
+        Branch(0)
+        Perch(2)
+        Printf("Timeout Event\n")
+        Perch(0)
+    )
+        clump(1
+
+        // _OccurEvent(controlRef 1000 2)  // Vireo unit test fires here; karma test fires event in JS
+
+        Printf("Waiting on Events\n")
+        WaitForEventsAndDispatch(50 * 0 0 eventData 1 1 timeoutData 2)
+        Branch(0)
+        Perch(1)
+        Printf("Value Changed Event %z %z\n" eventData.Source eventData.Type)
+        Printf("// ControlRef %z\n" eventData.ControlRef)
+        Branch(0)
+        Perch(2)
+        Printf("Timeout Event\n")
+        Perch(0)
+    )
+)))
+
+enqueue(ValueChangedMultipleEventRegisterAndUnregister)


### PR DESCRIPTION
Fixing an issue where we would call into jsRegisterForControlEvent multiple times for the same event on the same control. In order to fix this, I've modified RegisterForEvents so that it returns an enum indicating whether this was a registration for a new event on a control, a new event queue looking at an already registered event, or if somehow no change occurred. Only in the case of a new event being registered on a control should we call into jsRegisterForControlEvent.