### PR TITLE
Adding Internal functions to JSInvoke

### DIFF
--- a/source/io/JavaScriptInvoke.cpp
+++ b/source/io/JavaScriptInvoke.cpp
@@ -24,8 +24,8 @@ namespace Vireo {
 #if kVireoOS_emscripten
 extern "C" {
     // JavaScript function prototypes
-    // Parameters: occurrence, functionName, returnValue, parameters*, parametersCount, isInternalFunction, errorStatus*, errorCode*, errorSource*
-    extern void jsJavaScriptInvoke(OccurrenceRef, StringRef, void *, void *, Int32, Boolean, Boolean *, Int32 *, StringRef);
+    extern void jsJavaScriptInvoke(OccurrenceRef occurrence, StringRef functionName, void *returnValue, void *parameters, Int32 parametersCount, 
+                                    Boolean isInternalFunction, Boolean *errorStatus, Int32 *errorCode, StringRef errorSource);
 }
 #endif
 

--- a/source/io/JavaScriptInvoke.cpp
+++ b/source/io/JavaScriptInvoke.cpp
@@ -24,8 +24,7 @@ namespace Vireo {
 #if kVireoOS_emscripten
 extern "C" {
     // JavaScript function prototypes
-    // Parameters: occurrence, functionName, returnValue, parameters*, parametersCount, errorCheckingEnabled, errorStatus*, errorCode*, errorSource*
-    // Remark : errorCheckingEnabled is currently unused. It was added to support an optional error checking feature just like the SLI does.
+    // Parameters: occurrence, functionName, returnValue, parameters*, parametersCount, isInternalFunction, errorStatus*, errorCode*, errorSource*
     extern void jsJavaScriptInvoke(OccurrenceRef, StringRef, void *, void *, Int32, Boolean, Boolean *, Int32 *, StringRef);
 }
 #endif
@@ -105,11 +104,11 @@ VIREO_EXPORT void* JavaScriptInvoke_GetParameterPointer(StaticTypeAndData *param
 }
 
 //------------------------------------------------------------
-// arguments: occurrence, errorCheckingEnabled, errorCluster, functionName, returnValue, then variable number of inputs that can be nullptr or any type
+// arguments: occurrence, isInternalFunction, errorCluster, functionName, returnValue, then variable number of inputs that can be nullptr or any type
 struct JavaScriptInvokeParamBlock : public VarArgInstruction
 {
     _ParamDef(OccurrenceRef, occurrence);
-    _ParamDef(Boolean, errorCheckingEnabled);
+    _ParamDef(Boolean, isInternalFunction);
     _ParamDef(ErrorCluster, errorCluster);
     _ParamDef(StringRef, functionName);
     _ParamImmediateDef(StaticTypeAndData, returnValue[1]);
@@ -131,8 +130,8 @@ VIREO_FUNCTION_SIGNATUREV(JavaScriptInvoke, JavaScriptInvokeParamBlock)
     Observer* pObserver = clump->GetObservationStates(2);
     if (!pObserver) {
         StringRef functionName = _Param(functionName);
-        Boolean errorCheckingEnabled = _Param(errorCheckingEnabled);
-        const Int32 configurationParameters = 4;  // occurrence, errorCheckingEnabled, errorCluster and functionName
+        Boolean isInternalFunction = _Param(isInternalFunction);
+        const Int32 configurationParameters = 4;  // occurrence, isInternalFunction, errorCluster and functionName
         const Int32 staticTypeAndDataParameters = 2;  // Two parameters are inserted, one for type another for data. See StaticTypeAndData definition.
         Int32 userParametersCount = (_ParamVarArgCount() - configurationParameters - staticTypeAndDataParameters) / staticTypeAndDataParameters;
         StaticTypeAndData *returnValuePtr = _ParamImmediate(returnValue);
@@ -147,7 +146,7 @@ VIREO_FUNCTION_SIGNATUREV(JavaScriptInvoke, JavaScriptInvokeParamBlock)
                 returnValuePtr,
                 parametersPtr,
                 userParametersCount,
-                errorCheckingEnabled,
+                isInternalFunction,
                 &errorClusterPtr->status,
                 &errorClusterPtr->code,
                 errorClusterPtr->source);
@@ -170,7 +169,7 @@ VIREO_FUNCTION_SIGNATUREV(JavaScriptInvoke, JavaScriptInvokeParamBlock)
 //------------------------------------------------------------
 DEFINE_VIREO_BEGIN(JavaScriptInvoke)
     DEFINE_VIREO_REQUIRE(Synchronization)
-    DEFINE_VIREO_FUNCTION(JavaScriptInvoke, "p(i(VarArgCount argumentCount) i(Occurrence occurrence) i(Boolean errorCheckingEnabled)"
+    DEFINE_VIREO_FUNCTION(JavaScriptInvoke, "p(i(VarArgCount argumentCount) i(Occurrence occurrence) i(Boolean isInternalFunction)"
         "io(ErrorCluster errorCluster) i(String functionName) o(StaticTypeAndData returnValue) io(StaticTypeAndData functionParameters))")
 DEFINE_VIREO_END()
 

--- a/source/io/JavaScriptInvoke.cpp
+++ b/source/io/JavaScriptInvoke.cpp
@@ -24,7 +24,7 @@ namespace Vireo {
 #if kVireoOS_emscripten
 extern "C" {
     // JavaScript function prototypes
-    extern void jsJavaScriptInvoke(OccurrenceRef occurrence, StringRef functionName, void *returnValue, void *parameters, Int32 parametersCount, 
+    extern void jsJavaScriptInvoke(OccurrenceRef occurrence, StringRef functionName, void *returnValue, void *parameters, Int32 parametersCount,
                                     Boolean isInternalFunction, Boolean *errorStatus, Int32 *errorCode, StringRef errorSource);
 }
 #endif

--- a/source/io/module_javaScriptInvoke.js
+++ b/source/io/module_javaScriptInvoke.js
@@ -415,20 +415,17 @@
                 if (completionCallbackStatus.invocationState === completionCallbackInvocationEnum.REJECTED) {
                     throw new Error('The call to ' + functionName + ' threw an error, so this callback cannot be invoked.');
                 }
-                var errorStatus = Module.eggShell.dataReadBoolean(errorStatusPointer);
-                if (!errorStatus) {
-                    if (!(returnValue instanceof Error)) {
-                        tryUpdateReturnValue(functionName, returnTypeName, returnValuePointer, returnValue, errorStatusPointer, errorCodePointer, errorSourcePointer, completionCallbackStatus);
-                    } else {
-                        if (isInternalFunction) {
-                            throw returnValue;
-                        }
-                        var newErrorStatus = true;
-                        var newErrorCode = ERRORS.kNIUnableToSetReturnValueInJavaScriptInvoke.CODE;
-                        var errorMessage = Module.coreHelpers.formatMessageWithException(ERRORS.kNIUnableToSetReturnValueInJavaScriptInvoke.MESSAGE + '\nfunction: ' + functionName, returnValue);
-                        var newErrorSource = Module.coreHelpers.createSourceFromMessage(errorMessage);
-                        Module.coreHelpers.mergeErrors(newErrorStatus, newErrorCode, newErrorSource, errorStatusPointer, errorCodePointer, errorSourcePointer);
+                if (!(returnValue instanceof Error)) {
+                    tryUpdateReturnValue(functionName, returnTypeName, returnValuePointer, returnValue, errorStatusPointer, errorCodePointer, errorSourcePointer, completionCallbackStatus);
+                } else {
+                    if (isInternalFunction) {
+                        throw returnValue;
                     }
+                    var newErrorStatus = true;
+                    var newErrorCode = ERRORS.kNIUnableToSetReturnValueInJavaScriptInvoke.CODE;
+                    var errorMessage = Module.coreHelpers.formatMessageWithException(ERRORS.kNIUnableToSetReturnValueInJavaScriptInvoke.MESSAGE + '\nfunction: ' + functionName, returnValue);
+                    var newErrorSource = Module.coreHelpers.createSourceFromMessage(errorMessage);
+                    Module.coreHelpers.mergeErrors(newErrorStatus, newErrorCode, newErrorSource, errorStatusPointer, errorCodePointer, errorSourcePointer);
                 }
                 Module.eggShell.setOccurrenceAsync(occurrencePointer);
             };
@@ -550,10 +547,7 @@
 
             // assume synchronous invocation since the completion callback was never retrieved
             if (completionCallbackStatus.retrievalState === completionCallbackRetrievalEnum.AVAILABLE) {
-                var errorStatus = Module.eggShell.dataReadBoolean(errorStatusPointer);
-                if (!errorStatus) {
-                    tryUpdateReturnValue(functionName, returnTypeName, returnValuePointer, returnValue, errorStatusPointer, errorCodePointer, errorSourcePointer, completionCallbackStatus);
-                }
+                tryUpdateReturnValue(functionName, returnTypeName, returnValuePointer, returnValue, errorStatusPointer, errorCodePointer, errorSourcePointer, completionCallbackStatus);
                 Module.eggShell.setOccurrence(occurrencePointer);
             }
             return;

--- a/test-it/karma/fixtures/javascriptinvoke/InternalFunctions.via
+++ b/test-it/karma/fixtures/javascriptinvoke/InternalFunctions.via
@@ -1,0 +1,26 @@
+define(MyVI dv(VirtualInstrument (
+    Locals: c(
+        e(c(
+            e(.Boolean status)
+            e(.Int32 code)
+            e(.String source)
+        ) error1)
+        e(c(
+            e(.Boolean status)
+            e(.Int32 code)
+            e(.String source)
+        ) error2)
+        e(dv(.Int32 1) value1)
+        e(dv(.Int32 11) value2)
+        e(dv(.Int32 0) returnValue1)
+        e(dv(.Int32 0) returnValue2)
+        e(.Occurrence occurrence1)
+        e(.Occurrence occurrence2)
+    )
+    clump (
+        JavaScriptInvoke(occurrence1 true error1 'NI_InternalFunction' returnValue1 value1)
+        JavaScriptInvoke(occurrence2 true error2 'NI_InternalFunctionSetsError' returnValue2 value2)
+    )
+) ) )
+
+enqueue(MyVI)

--- a/test-it/karma/javascriptinvoke/InternalFunction.Test.js
+++ b/test-it/karma/javascriptinvoke/InternalFunction.Test.js
@@ -19,7 +19,7 @@ describe('A JavaScript function invoke', function () {
         vireo = new Vireo();
     });
 
-    it('internal function succesfully works', function (done) {
+    it('internal function works', function (done) {
         var runSlices = vireoRunner.rebootAndLoadVia(vireo, jsInternalFunctionsUrl);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
 
@@ -45,7 +45,7 @@ describe('A JavaScript function invoke', function () {
         });
     });
 
-    it('internal function succesfully sets error and return value is unset', function (done) {
+    it('internal function successfully sets error and return value is unset', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsInternalFunctionsUrl);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
 
@@ -65,5 +65,13 @@ describe('A JavaScript function invoke', function () {
             expect(viPathParser('returnValue2')).toBe(0);
             done();
         });
+    });
+
+    it('registerInternalFunctions successfully errors if we add non-function', function () {
+        expect(function () {
+            vireo.javaScriptInvoke.registerInternalFunctions({
+                NI_InternalFunctionThatIsNotAFunction: { }
+            });
+        }).toThrow();
     });
 });

--- a/test-it/karma/javascriptinvoke/InternalFunction.Test.js
+++ b/test-it/karma/javascriptinvoke/InternalFunction.Test.js
@@ -62,7 +62,7 @@ describe('A JavaScript function invoke', function () {
             expect(viPathParser('error2.status')).toBeTrue();
             expect(viPathParser('error2.code')).toBe(777);
             expect(viPathParser('error2.source')).toContain('this is the error message');
-            expect(viPathParser('returnValue2')).toBe(0);
+            expect(viPathParser('returnValue2')).toBe(12);
             done();
         });
     });
@@ -71,6 +71,21 @@ describe('A JavaScript function invoke', function () {
         expect(function () {
             vireo.javaScriptInvoke.registerInternalFunctions({
                 NI_InternalFunctionThatIsNotAFunction: { }
+            });
+        }).toThrow();
+    });
+
+    it('registerInternalFunctions successfully errors if we add a duplicate function', function () {
+        expect(function () {
+            vireo.javaScriptInvoke.registerInternalFunctions({
+                NI_InternalFunctionDuplicate: function () {
+                    return 1;
+                }
+            });
+            vireo.javaScriptInvoke.registerInternalFunctions({
+                NI_InternalFunctionDuplicate: function () {
+                    return 2;
+                }
             });
         }).toThrow();
     });


### PR DESCRIPTION
Adding the concept of internal functions to JavaScriptInvoke calls, by re-using an unused parameter errorCheckingEnabled.