### PR TITLE
Create nuget package for vireo executable for tests.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,4 +47,4 @@ deploy:
   provider: NuGet
   artifact: '/.*\.nupkg/'
   api_key:
-    secure: oy2ddkxen2s24ubtzqwquvpk7wu5uofe5dodhngw3zlz2u
+    secure: CTuSIf5+uQFtl563xNMg4BC5WnAnYV1MfeVavlVgsP4P+zJVsrdWSjydgMEJYQb5

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,6 +20,8 @@ install:
   - cd emsdk && git checkout 2da530aa5e6d6bcaf994ed1b2613a98872a428c8 && cd ..
   - ps: emsdk\emsdk install sdk-1.37.36-64bit
   - ps: emsdk\emsdk activate sdk-1.37.36-64bit
+  - ps: $env:package_version = (Get-Content -Raw -Path package.json | ConvertFrom-Json).version
+  - ps: Update-AppveyorBuild -Version "$env:package_version-$env:APPVEYOR_BUILD_NUMBERtest"
 platform:
   - Win32
 configuration:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,8 +20,6 @@ install:
   - cd emsdk && git checkout 2da530aa5e6d6bcaf994ed1b2613a98872a428c8 && cd ..
   - ps: emsdk\emsdk install sdk-1.37.36-64bit
   - ps: emsdk\emsdk activate sdk-1.37.36-64bit
-  - ps: $env:package_version = (Get-Content -Raw -Path package.json | ConvertFrom-Json).version
-  - ps: Update-AppveyorBuild -Version "$env:package_version-$env:APPVEYOR_BUILD_NUMBERtest"
 platform:
   - Win32
 configuration:
@@ -35,7 +33,8 @@ build:
   project: Vireo_VS/VireoCommandLine.sln
 after_build:
   - cmd /c make-it\appveyor-support\setup-env-and-make-vjs.bat
-  - nuget pack VireoSDK.nuspec
+  - ps: $env:package_version = (Get-Content -Raw -Path package.json | ConvertFrom-Json).version
+  - ps: nuget pack VireoSDK.nuspec -properties version="$env:package_version.$env:APPVEYOR_BUILD_NUMBER"
 test_script:
   - make testjs
   - make testnative

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,13 +41,14 @@ test_script:
   - make testhttpbin
   - npm run test -- --browsers FirefoxHeadless
   - npm run test -- --browsers IE --skip-tags FailsIE
-  # Using the same naming convention as rust https://forge.rust-lang.org/platform-support.html	
+  
+# Using the same naming convention as rust https://forge.rust-lang.org/platform-support.html	
 after_test:	
   - set ESH_i686_DEBUG=esh_%APPVEYOR_REPO_TAG_NAME%_i686-pc-windows-msvc_debug.zip	
   - 7z a %ESH_i686_DEBUG% %APPVEYOR_BUILD_FOLDER%\dist\Debug\esh.exe %APPVEYOR_BUILD_FOLDER%\dist\Debug\esh.pdb %APPVEYOR_BUILD_FOLDER%\README.md %APPVEYOR_BUILD_FOLDER%\LICENSE.txt
 artifacts:
   - path: '%ESH_i686_DEBUG%'
-    name: '%ESH_i686_DEBUG%'	
+    name: '%ESH_i686_DEBUG%'
     type: Zip
   - path: '*.nupkg'
 deploy:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,7 +41,14 @@ test_script:
   - make testhttpbin
   - npm run test -- --browsers FirefoxHeadless
   - npm run test -- --browsers IE --skip-tags FailsIE
+  # Using the same naming convention as rust https://forge.rust-lang.org/platform-support.html	
+after_test:	
+  - set ESH_i686_DEBUG=esh_%APPVEYOR_REPO_TAG_NAME%_i686-pc-windows-msvc_debug.zip	
+  - 7z a %ESH_i686_DEBUG% %APPVEYOR_BUILD_FOLDER%\dist\Debug\esh.exe %APPVEYOR_BUILD_FOLDER%\dist\Debug\esh.pdb %APPVEYOR_BUILD_FOLDER%\README.md %APPVEYOR_BUILD_FOLDER%\LICENSE.txt
 artifacts:
+  - path: '%ESH_i686_DEBUG%'
+    name: '%ESH_i686_DEBUG%'	
+    type: Zip
   - path: '*.nupkg'
 deploy:
   - provider: GitHub

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,20 +41,10 @@ test_script:
   - npm run test -- --browsers FirefoxHeadless
   - npm run test -- --browsers IE --skip-tags FailsIE
 
-# Using the same naming convention as rust https://forge.rust-lang.org/platform-support.html
-after_test:
-  - set ESH_i686_DEBUG=esh_%APPVEYOR_REPO_TAG_NAME%_i686-pc-windows-msvc_debug.zip
-  - 7z a %ESH_i686_DEBUG% %APPVEYOR_BUILD_FOLDER%\dist\Debug\esh.exe %APPVEYOR_BUILD_FOLDER%\dist\Debug\esh.pdb %APPVEYOR_BUILD_FOLDER%\README.md %APPVEYOR_BUILD_FOLDER%\LICENSE.txt
 artifacts:
-  - path: '%ESH_i686_DEBUG%'
-    name: '%ESH_i686_DEBUG%'
-    type: Zip
+  - path: '*.nupkg'
 deploy:
-  provider: GitHub
-  description: $(APPVEYOR_REPO_COMMIT_MESSAGE)
-  auth_token:
-    secure: Asuu2xJwFoy8ML6DIsZf2mqlgdO2b1dQRCJALbYpUFNP/3DjuhBPDcWiSxTK6iw/
-  artifact: '%ESH_i686_DEBUG%'
-  force_update: true
-  on:
-    appveyor_repo_tag: true
+  provider: NuGet
+  artifact: '/.*\.nupkg/'
+  api_key:
+    secure: oy2ddkxen2s24ubtzqwquvpk7wu5uofe5dodhngw3zlz2u

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,11 +40,20 @@ test_script:
   - make testhttpbin
   - npm run test -- --browsers FirefoxHeadless
   - npm run test -- --browsers IE --skip-tags FailsIE
-
 artifacts:
   - path: '*.nupkg'
 deploy:
-  provider: NuGet
-  artifact: '/.*\.nupkg/'
-  api_key:
-    secure: CTuSIf5+uQFtl563xNMg4BC5WnAnYV1MfeVavlVgsP4P+zJVsrdWSjydgMEJYQb5
+  - provider: GitHub
+    description: $(APPVEYOR_REPO_COMMIT_MESSAGE)
+    auth_token:
+      secure: Asuu2xJwFoy8ML6DIsZf2mqlgdO2b1dQRCJALbYpUFNP/3DjuhBPDcWiSxTK6iw/
+    artifact: '%ESH_i686_DEBUG%'
+    force_update: true	
+    tag: $(APPVEYOR_REPO_TAG_NAME)	
+    on:	
+      appveyor_repo_tag: true
+
+  - provider: NuGet
+    artifact: '/.*\.nupkg/'
+    api_key:
+      secure: +HxCQLCj0U9w1/MNf7waD7PrbcC8KEM3ZNanofeyLt1j7kU0DbszxasZXtHWtSSE

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,6 +33,7 @@ build:
   project: Vireo_VS/VireoCommandLine.sln
 after_build:
   - cmd /c make-it\appveyor-support\setup-env-and-make-vjs.bat
+  - nuget pack VireoSDK.nuspec
 test_script:
   - make testjs
   - make testnative

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,10 +41,10 @@ test_script:
   - make testhttpbin
   - npm run test -- --browsers FirefoxHeadless
   - npm run test -- --browsers IE --skip-tags FailsIE
-  
-# Using the same naming convention as rust https://forge.rust-lang.org/platform-support.html	
-after_test:	
-  - set ESH_i686_DEBUG=esh_%APPVEYOR_REPO_TAG_NAME%_i686-pc-windows-msvc_debug.zip	
+
+# Using the same naming convention as rust https://forge.rust-lang.org/platform-support.html
+after_test:
+  - set ESH_i686_DEBUG=esh_%APPVEYOR_REPO_TAG_NAME%_i686-pc-windows-msvc_debug.zip
   - 7z a %ESH_i686_DEBUG% %APPVEYOR_BUILD_FOLDER%\dist\Debug\esh.exe %APPVEYOR_BUILD_FOLDER%\dist\Debug\esh.pdb %APPVEYOR_BUILD_FOLDER%\README.md %APPVEYOR_BUILD_FOLDER%\LICENSE.txt
 artifacts:
   - path: '%ESH_i686_DEBUG%'

--- a/VireoSDK.nuspec
+++ b/VireoSDK.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>vireo</id>
-    <version>1.1.0</version>
+    <version>$version$</version>
     <title>VireoSDK</title>
     <authors>https://github.com/ni/VireoSDK/blob/incoming/AUTHORS</authors>
     <owners>https://github.com/ni/VireoSDK/blob/incoming/AUTHORS</owners>

--- a/VireoSDK.nuspec
+++ b/VireoSDK.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>vireo</id>
+    <version>10.0.0</version>
+    <title>VireoSDK</title>
+    <authors>https://github.com/ni/VireoSDK/blob/incoming/AUTHORS</authors>
+    <owners>https://github.com/ni/VireoSDK/blob/incoming/AUTHORS</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <licenseUrl>https://github.com/ni/VireoSDK/blob/incoming/LICENSE.txt</licenseUrl>
+    <projectUrl>https://github.com/ni/VireoSDK/</projectUrl>
+    <description>VireoSDK provides a subset of LabVIEW runtime functionality for smaller targets.</description>
+  </metadata>
+  <files>
+    <file src="dist/Release/esh.exe" target="" />
+  </files>
+</package>

--- a/VireoSDK.nuspec
+++ b/VireoSDK.nuspec
@@ -12,6 +12,6 @@
     <description>VireoSDK provides a subset of LabVIEW runtime functionality for smaller targets.</description>
   </metadata>
   <files>
-    <file src="dist/Release/esh.exe" target="" />
+    <file src="dist/Debug/esh.exe" target="" />
   </files>
 </package>

--- a/VireoSDK.nuspec
+++ b/VireoSDK.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>vireo</id>
-    <version>10.0.0</version>
+    <version>1.1.0</version>
     <title>VireoSDK</title>
     <authors>https://github.com/ni/VireoSDK/blob/incoming/AUTHORS</authors>
     <owners>https://github.com/ni/VireoSDK/blob/incoming/AUTHORS</owners>


### PR DESCRIPTION
The .nuspec file is what defines the nuget package. As part of the appveyor build I get the `npm version` of vireo and use that to set the nuget version. The "provider" section in the appveyor.yml then knows how to publish the nuget package to Nuget.org.