### PR TITLE
fix links

### DIFF
--- a/VireoSDK.nuspec
+++ b/VireoSDK.nuspec
@@ -4,10 +4,10 @@
     <id>vireo</id>
     <version>$version$</version>
     <title>VireoSDK</title>
-    <authors>https://github.com/ni/VireoSDK/blob/incoming/AUTHORS</authors>
-    <owners>https://github.com/ni/VireoSDK/blob/incoming/AUTHORS</owners>
+    <authors>https://github.com/ni/VireoSDK/blob/master/AUTHORS</authors>
+    <owners>https://github.com/ni/VireoSDK/blob/master/AUTHORS</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <licenseUrl>https://github.com/ni/VireoSDK/blob/incoming/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/ni/VireoSDK/blob/master/LICENSE.txt</licenseUrl>
     <projectUrl>https://github.com/ni/VireoSDK/</projectUrl>
     <description>VireoSDK provides a subset of LabVIEW runtime functionality for smaller targets.</description>
   </metadata>


### PR DESCRIPTION
The vireo package on nuget.org was linking to a 404 error on github for the license link. This should fix that.