### PR TITLE
add callchain for propertynode if internal

### DIFF
--- a/source/io/JavaScriptInvoke.cpp
+++ b/source/io/JavaScriptInvoke.cpp
@@ -150,7 +150,13 @@ VIREO_FUNCTION_SIGNATUREV(JavaScriptInvoke, JavaScriptInvokeParamBlock)
                 &errorClusterPtr->status,
                 &errorClusterPtr->code,
                 errorClusterPtr->source);
-            AddCallChainToSourceIfErrorPresent(errorClusterPtr, "JavaScriptInvoke");
+
+            if (isInternalFunction) {
+                AddCallChainToSourceIfErrorPresent(errorClusterPtr, (const char*)functionName->Begin());
+            } else {
+                AddCallChainToSourceIfErrorPresent(errorClusterPtr, "JavaScriptInvoke");
+            }
+
             InstructionCore* instructionCorePtr = clump->WaitOnObservableObject(_this);
             return instructionCorePtr;
         }

--- a/test-it/karma/javascriptinvoke/InternalFunction.Test.js
+++ b/test-it/karma/javascriptinvoke/InternalFunction.Test.js
@@ -62,6 +62,7 @@ describe('A JavaScript function invoke', function () {
             expect(viPathParser('error2.status')).toBeTrue();
             expect(viPathParser('error2.code')).toBe(777);
             expect(viPathParser('error2.source')).toContain('this is the error message');
+            expect(viPathParser('error2.source')).toContain('in MyVI');
             expect(viPathParser('returnValue2')).toBe(12);
             done();
         });

--- a/test-it/karma/javascriptinvoke/InternalFunction.Test.js
+++ b/test-it/karma/javascriptinvoke/InternalFunction.Test.js
@@ -62,7 +62,7 @@ describe('A JavaScript function invoke', function () {
             expect(viPathParser('error2.status')).toBeTrue();
             expect(viPathParser('error2.code')).toBe(777);
             expect(viPathParser('error2.source')).toContain('this is the error message');
-            expect(viPathParser('error2.source')).toContain('in MyVI');
+            expect(viPathParser('error2.source')).toContain('NI_InternalFunctionSetsError');
             expect(viPathParser('returnValue2')).toBe(12);
             done();
         });


### PR DESCRIPTION
The functionName will be something like PropertyNode_PropertyRead or PropertyNode_PropertyWrite, which we want to show the user instead of "JavaScriptInvoke" if they were indeed using a property node.