### PR TITLE
Expanded type support for `writeTypedArray`

### DIFF
--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -573,18 +573,16 @@
             return typedArray;
         };
 
-        Module.eggShell.writeTypedArray = function (valueRef, typedArrayValue) {
+        Module.eggShell.writeTypedArray = publicAPI.eggShell.writeTypedArray = function (valueRef, typedArrayValue) {
             var TypedArrayConstructor = findCompatibleTypedArrayConstructor(valueRef.typeRef);
-
-            // TODO: (gleon) For now this function will only work for writing to strings
-            // we can support more types by modifying this function moving forward.
-            if (TypedArrayConstructor === undefined || Module.typeHelpers.isString(valueRef.typeRef) === false) {
+            if (TypedArrayConstructor === undefined || !(typedArrayValue instanceof TypedArrayConstructor)) {
                 throw new Error('Performing writeTypedArray failed for the following reason: ' + eggShellResultEnum[EGGSHELL_RESULT.UNEXPECTED_OBJECT_TYPE] +
                     ' (error code: ' + EGGSHELL_RESULT.UNEXPECTED_OBJECT_TYPE + ')' +
                     ' (typeRef: ' + valueRef.typeRef + ')' +
                     ' (dataRef: ' + valueRef.dataRef + ')');
             }
 
+            // TODO: (gleon) For now this function will only work for 1D arrays
             var totalLength = typedArrayValue.length;
             Module.eggShell.resizeArray(valueRef, [totalLength]);
             var arrayBegin = Module.eggShell.dataGetArrayBegin(valueRef.dataRef);

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -582,9 +582,12 @@
                     ' (dataRef: ' + valueRef.dataRef + ')');
             }
 
-            // TODO: (gleon) For now this function will only work for 1D arrays
+            var arrayTotalLength = Module.eggShell.dataGetArrayLength(valueRef.dataRef);
             var totalLength = typedArrayValue.length;
-            Module.eggShell.resizeArray(valueRef, [totalLength]);
+            if (totalLength !== arrayTotalLength) {
+                throw new Error('TypedArray total length must be ' + arrayTotalLength + ' instead got ' + totalLength);
+            }
+
             var arrayBegin = Module.eggShell.dataGetArrayBegin(valueRef.dataRef);
             var typedArray = new TypedArrayConstructor(Module.buffer, arrayBegin, totalLength);
             typedArray.set(typedArrayValue);

--- a/source/io/module_httpClient.js
+++ b/source/io/module_httpClient.js
@@ -874,6 +874,7 @@
                 Module.eggShell.writeDouble(statusCodeValueRef, responseData.status);
 
                 if (bodyValueRef !== undefined) {
+                    Module.eggShell.resizeArray(bodyValueRef, [responseData.body.length]);
                     Module.eggShell.writeTypedArray(bodyValueRef, responseData.body);
                 }
 

--- a/test-it/karma/publicapi/TypedArray.Test.js
+++ b/test-it/karma/publicapi/TypedArray.Test.js
@@ -26,20 +26,24 @@ describe('The Vireo EggShell Typed Array api', function () {
         return typedArray;
     };
 
-    var writeTypedArray = function (path, typedArrayValue) {
+    var writeTypedArrayTest = function (path, value) {
         var valueRef = vireo.eggShell.findValueRef(viName, path);
-        vireo.eggShell.writeTypedArray(valueRef, typedArrayValue);
+        vireo.eggShell.writeTypedArray(valueRef, value);
+        var valueRead = vireo.eggShell.readTypedArray(valueRef);
+        expect(valueRead).toEqual(value);
     };
 
-    var writeTypedArrayTest = function (path, value) {
-        writeTypedArray(path, value);
-        var valueRead = readTypedArray(path);
+    var resizeAndWriteTypedArrayTest = function (path, value, newDimensions) {
+        var valueRef = vireo.eggShell.findValueRef(viName, path);
+        vireo.eggShell.resizeArray(valueRef, newDimensions);
+        vireo.eggShell.writeTypedArray(valueRef, value);
+        var valueRead = vireo.eggShell.readTypedArray(valueRef);
         expect(valueRead).toEqual(value);
     };
 
     var tryWriteTypedArrayTest = function (path, value) {
         return function () {
-            writeTypedArray(path, value);
+            writeTypedArrayTest(path, value);
         };
     };
 
@@ -115,28 +119,58 @@ describe('The Vireo EggShell Typed Array api', function () {
         });
     });
 
-    it('can write arrays for specific optimized types', function (done) {
+    it('errors while trying to write an array of different size', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiArrayTypesOptimizedViaUrl);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
             expect(rawPrintError).toBeEmptyString();
 
-            writeTypedArrayTest('arrayInt8', new Int8Array([8, 6, 7, 0, -128, 127]));
-            writeTypedArrayTest('arrayInt16', new Int16Array([8, 6, 7, 5, 3, 0, 9, 5, 3, 0, 9, 0, -32768, 32767]));
-            writeTypedArrayTest('arrayInt32', new Int32Array([-2147483648, 2147483647, 5, 3, 0, 9, 0]));
-            writeTypedArrayTest('arrayUInt8', new Uint8Array([255, 8, 6, 7, 5, 3, 0, 9, 0, 255]));
-            writeTypedArrayTest('arrayUInt16', new Uint16Array([1, 2, 3, 8, 6, 7, 5, 3, 0, 9, 0, 65535]));
-            writeTypedArrayTest('arrayUInt32', new Uint32Array([8, 6, 7, 7, 9, 111, 5, 3, 0, 9, 0, 4294967295]));
-            writeTypedArrayTest('arraySingle', new Float32Array([Infinity, NaN, -Infinity, -16777216, 16777216, Math.fround(1.1), Math.fround(2.2), +0, -0, 0]));
-            writeTypedArrayTest('arrayDouble', new Float64Array([+0, -0, Infinity, NaN, -Infinity, -9007199254740992, 9007199254740992]));
-            writeTypedArrayTest('arrayInt8Empty', new Int8Array([0, 1, 2, 3]));
-            writeTypedArrayTest('arrayEnum8', new Uint8Array([3, 2, 1, 255]));
-            writeTypedArrayTest('arrayEnum16', new Uint16Array([5, 4, 3, 2, 1, 0]));
-            writeTypedArrayTest('arrayEnum32', new Uint32Array([0, 1, 2, 3, 4, 5]));
-            writeTypedArrayTest('arrayBoolean', new Uint8Array([1, 0, 1, 0, 1, 1, 1]));
-            writeTypedArrayTest('stringHello', new Uint8Array([0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x57, 0x6F, 0x72, 0x6C, 0x64]));
+            expect(tryWriteTypedArrayTest('arrayInt8Empty', new Int8Array([255]))).toThrowError(/length/);
+            expect(tryWriteTypedArrayTest('array2DInt8Empty', new Int8Array([255]))).toThrowError(/length/);
+            expect(tryWriteTypedArrayTest('array3DInt8Empty', new Int8Array([255]))).toThrowError(/length/);
+            expect(tryWriteTypedArrayTest('arrayBoolean', new Uint8Array([1, 0]))).toThrowError(/length/);
+
+            done();
+        });
+    });
+
+    it('can write arrays for specific optimized types with same length', function (done) {
+        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiArrayTypesOptimizedViaUrl);
+
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrint).toBeEmptyString();
+            expect(rawPrintError).toBeEmptyString();
+
+            writeTypedArrayTest('arrayInt8', new Int8Array([4, 3, 2, 1, 8, 6, 7, 0, -128, 127]));
+            writeTypedArrayTest('arrayInt16', new Int16Array([-8, -6, 7, 5, -3, 0, 9, 0, -32768, 32767]));
+            writeTypedArrayTest('arrayInt32', new Int32Array([-2147483648, 2147483647, 5, 3, 0, 9, 0, 1024, 9000, 11]));
+            writeTypedArrayTest('arrayUInt8', new Uint8Array([255, 8, 6, 7, 5, 3, 9, 0, 255]));
+            writeTypedArrayTest('arrayUInt16', new Uint16Array([1, 2, 3, 8, 3, 0, 9, 0, 65535]));
+            writeTypedArrayTest('arrayUInt32', new Uint32Array([4294967295, 6, 7, 7, 9, 111, 5, 3, 4294967295]));
+            writeTypedArrayTest('arraySingle', new Float32Array([Infinity, NaN, -Infinity, -16777216, 16777216, Math.fround(1.1), Math.fround(2.2), +0, -0]));
+            writeTypedArrayTest('arrayDouble', new Float64Array([3.14, 6.28, +0, -0, Infinity, NaN, -Infinity, -9007199254740992, 9007199254740992]));
+            writeTypedArrayTest('arrayEnum8', new Uint8Array([10, 9, 8]));
+            writeTypedArrayTest('arrayEnum16', new Uint16Array([7, 6, 5]));
+            writeTypedArrayTest('arrayEnum32', new Uint32Array([4, 3, 2]));
+            writeTypedArrayTest('arrayBoolean', new Uint8Array([1, 1, 1, 1]));
+            writeTypedArrayTest('stringHello', new Uint8Array([0x48, 0x6F, 0x6C, 0x61, 0x00]));
             writeTypedArrayTest('stringControlCharacters', new Uint8Array([31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]));
+
+            done();
+        });
+    });
+
+    it('can write arrays for specific optimized types with different lengths after resizing array', function (done) {
+        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiArrayTypesOptimizedViaUrl);
+
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrint).toBeEmptyString();
+            expect(rawPrintError).toBeEmptyString();
+
+            resizeAndWriteTypedArrayTest('arrayInt8Empty', new Int8Array([1, 2, 3, 4, 5]), [5]);
+            resizeAndWriteTypedArrayTest('array2DInt8Empty', new Int8Array([0, 1, 2, 3]), [2, 2]);
+            resizeAndWriteTypedArrayTest('array3DInt8Empty', new Int8Array([1, 2, 3, 4, 5, 6, 7, 8]), [2, 2, 2]);
 
             done();
         });
@@ -162,19 +196,6 @@ describe('The Vireo EggShell Typed Array api', function () {
             expect(tryWriteTypedArrayTest('arrayEnum32', new Float64Array())).toThrowError(/UnexpectedObjectType/);
             expect(tryWriteTypedArrayTest('arrayBoolean', new Int32Array())).toThrowError(/UnexpectedObjectType/);
             expect(tryWriteTypedArrayTest('stringHello', new Uint16Array())).toThrowError(/UnexpectedObjectType/);
-            done();
-        });
-    });
-
-    it('errors when writing arrays where rank > 1', function (done) {
-        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiArrayTypesOptimizedViaUrl);
-
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeEmptyString();
-            expect(rawPrintError).toBeEmptyString();
-
-            expect(tryWriteTypedArrayTest('array2DInt32', new Int32Array())).toThrowError(/MismatchedArrayRank/);
-            expect(tryWriteTypedArrayTest('array3DInt32', new Int32Array())).toThrowError(/MismatchedArrayRank/);
             done();
         });
     });

--- a/test-it/karma/publicapi/TypedArray.Test.js
+++ b/test-it/karma/publicapi/TypedArray.Test.js
@@ -26,6 +26,23 @@ describe('The Vireo EggShell Typed Array api', function () {
         return typedArray;
     };
 
+    var writeTypedArray = function (path, typedArrayValue) {
+        var valueRef = vireo.eggShell.findValueRef(viName, path);
+        vireo.eggShell.writeTypedArray(valueRef, typedArrayValue);
+    };
+
+    var writeTypedArrayTest = function (path, value) {
+        writeTypedArray(path, value);
+        var valueRead = readTypedArray(path);
+        expect(valueRead).toEqual(value);
+    };
+
+    var tryWriteTypedArrayTest = function (path, value) {
+        return function () {
+            writeTypedArray(path, value);
+        };
+    };
+
     it('can read arrays for specific optimized types', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiArrayTypesOptimizedViaUrl);
 
@@ -94,6 +111,70 @@ describe('The Vireo EggShell Typed Array api', function () {
                 readTypedArray('scalarUInt32');
             }).toThrowError(/UnexpectedObjectType/);
 
+            done();
+        });
+    });
+
+    it('can write arrays for specific optimized types', function (done) {
+        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiArrayTypesOptimizedViaUrl);
+
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrint).toBeEmptyString();
+            expect(rawPrintError).toBeEmptyString();
+
+            writeTypedArrayTest('arrayInt8', new Int8Array([8, 6, 7, 0, -128, 127]));
+            writeTypedArrayTest('arrayInt16', new Int16Array([8, 6, 7, 5, 3, 0, 9, 5, 3, 0, 9, 0, -32768, 32767]));
+            writeTypedArrayTest('arrayInt32', new Int32Array([-2147483648, 2147483647, 5, 3, 0, 9, 0]));
+            writeTypedArrayTest('arrayUInt8', new Uint8Array([255, 8, 6, 7, 5, 3, 0, 9, 0, 255]));
+            writeTypedArrayTest('arrayUInt16', new Uint16Array([1, 2, 3, 8, 6, 7, 5, 3, 0, 9, 0, 65535]));
+            writeTypedArrayTest('arrayUInt32', new Uint32Array([8, 6, 7, 7, 9, 111, 5, 3, 0, 9, 0, 4294967295]));
+            writeTypedArrayTest('arraySingle', new Float32Array([Infinity, NaN, -Infinity, -16777216, 16777216, Math.fround(1.1), Math.fround(2.2), +0, -0, 0]));
+            writeTypedArrayTest('arrayDouble', new Float64Array([+0, -0, Infinity, NaN, -Infinity, -9007199254740992, 9007199254740992]));
+            writeTypedArrayTest('arrayInt8Empty', new Int8Array([0, 1, 2, 3]));
+            writeTypedArrayTest('arrayEnum8', new Uint8Array([3, 2, 1, 255]));
+            writeTypedArrayTest('arrayEnum16', new Uint16Array([5, 4, 3, 2, 1, 0]));
+            writeTypedArrayTest('arrayEnum32', new Uint32Array([0, 1, 2, 3, 4, 5]));
+            writeTypedArrayTest('arrayBoolean', new Uint8Array([1, 0, 1, 0, 1, 1, 1]));
+            writeTypedArrayTest('stringHello', new Uint8Array([0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x57, 0x6F, 0x72, 0x6C, 0x64]));
+            writeTypedArrayTest('stringControlCharacters', new Uint8Array([31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]));
+
+            done();
+        });
+    });
+
+    it('errors when writing mismatched types', function (done) {
+        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiArrayTypesOptimizedViaUrl);
+
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrint).toBeEmptyString();
+            expect(rawPrintError).toBeEmptyString();
+            expect(tryWriteTypedArrayTest('arrayInt8', [])).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('arrayInt8', new Int16Array())).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('arrayInt16', new Uint16Array())).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('arrayInt32', new Int8Array())).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('arrayUInt8', new Int16Array())).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('arrayUInt16', new Int32Array())).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('arrayUInt32', new Uint16Array())).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('arraySingle', new Int16Array())).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('arrayDouble', new Float32Array())).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('arrayEnum8', new Float32Array())).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('arrayEnum16', new Int16Array())).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('arrayEnum32', new Float64Array())).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('arrayBoolean', new Int32Array())).toThrowError(/UnexpectedObjectType/);
+            expect(tryWriteTypedArrayTest('stringHello', new Uint16Array())).toThrowError(/UnexpectedObjectType/);
+            done();
+        });
+    });
+
+    it('errors when writing arrays where rank > 1', function (done) {
+        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, publicApiArrayTypesOptimizedViaUrl);
+
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrint).toBeEmptyString();
+            expect(rawPrintError).toBeEmptyString();
+
+            expect(tryWriteTypedArrayTest('array2DInt32', new Int32Array())).toThrowError(/MismatchedArrayRank/);
+            expect(tryWriteTypedArrayTest('array3DInt32', new Int32Array())).toThrowError(/MismatchedArrayRank/);
             done();
         });
     });


### PR DESCRIPTION
In #511 I added `writeTypedArray` to vireo's module and didn't expose it to the public API.
In this PR I'm adding the rest of supported TypedArrays.
This work will be needed for refactoring JSInvoke part that @sanmut is working on.