### PR TITLE
Adding support for JavaScriptRefNum to events

### DIFF
--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -549,6 +549,7 @@ static inline EventSource GetEventSourceForEventType(EventType eType) {
     return eSource;
 }
 
+// TODO(segaljared): Move this to a more convenient location for general use in the future
 void GetVIName(VirtualInstrument *vi, StringRef viName) {
     PercentEncodedSubString encodedStr(vi->VIName(), true, false);
     SubString encodedSubstr = encodedStr.GetSubString();

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -608,7 +608,7 @@ void RegisterForStaticEvents(VirtualInstrument *vi) {
     vi->SetEventInfo(eventInfo);
 }
 
-void ConfigureEventSpecForJSRef(VirtualInstrument *vi, UInt32 eventStructIndex, UInt32 eventSpecIndex, JavaScriptRefNum jsReference) {
+void ConfigureEventSpecForJSRef(VirtualInstrument *vi, Int32 eventStructIndex, Int32 eventSpecIndex, JavaScriptRefNum jsReference) {
     TypedObjectRef eventStructSpecsRef = vi->EventSpecs();
     Int32 numEventStructs = eventStructSpecsRef->ElementType()->SubElementCount();
     EventInfo *eventInfo = vi->GetEventInfo();
@@ -1210,10 +1210,10 @@ VIREO_FUNCTION_SIGNATURE3(_OccurEvent, RefNumVal, UInt32, UInt32)
     return _NextInstruction();
 }
 
-VIREO_FUNCTION_SIGNATURE3(ConfigureEventSpecJSRef, UInt32, UInt32, JavaScriptRefNum)
+VIREO_FUNCTION_SIGNATURE3(ConfigureEventSpecJSRef, Int32, Int32, JavaScriptRefNum)
 {
-    UInt32 eventStructIndex = _Param(0);
-    UInt32 eventSpecIndex = _Param(1);
+    Int32 eventStructIndex = _Param(0);
+    Int32 eventSpecIndex = _Param(1);
     JavaScriptRefNum jsRefNum = _Param(2);
     VirtualInstrument *owningVI = THREAD_CLUMP()->OwningVI();
     ConfigureEventSpecForJSRef(owningVI, eventStructIndex, eventSpecIndex, jsRefNum);
@@ -1294,8 +1294,8 @@ DEFINE_VIREO_BEGIN(Events)
     DEFINE_VIREO_FUNCTION(WaitForEventsAndDispatch, "p(i(VarArgCount) i(Int32 timeOut) i(StaticTypeAndData ref) i(Int32 esIndex) "
                           "i(VarArgRepeat) i(Int32 specIndex)i(StaticTypeAndData)i(BranchTarget))")
 
-    DEFINE_VIREO_FUNCTION(_OccurEvent, "p(i(JavaScriptRefNum controlRef) i(UInt32 eSource) i(UInt32 eType))")
-    DEFINE_VIREO_FUNCTION(ConfigureEventSpecJSRef, "p(i(UInt32 eStructIndex) i(UInt32 eSpecIndex) i(JavaScriptRefNum jsReference))")
+    DEFINE_VIREO_FUNCTION(_OccurEvent, "p(i(ControlRefNum controlRef) i(UInt32 eSource) i(UInt32 eType))")
+    DEFINE_VIREO_FUNCTION(ConfigureEventSpecJSRef, "p(i(Int32 eStructIndex) i(Int32 eSpecIndex) i(JavaScriptRefNum jsReference))")
     DEFINE_VIREO_FUNCTION(RegisterForJSEvent, "p(i(JavaScriptRefNum jsReference) i(UInt32 eType))")
 
     DEFINE_VIREO_FUNCTION_CUSTOM(IsNotANumPathRefnum, IsNotAUserEventRefnum, "p(i(UserEventRefNum) o(Boolean))")

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -1295,6 +1295,7 @@ DEFINE_VIREO_BEGIN(Events)
                           "i(VarArgRepeat) i(Int32 specIndex)i(StaticTypeAndData)i(BranchTarget))")
 
     DEFINE_VIREO_FUNCTION(_OccurEvent, "p(i(ControlRefNum controlRef) i(UInt32 eSource) i(UInt32 eType))")
+    DEFINE_VIREO_FUNCTION(_OccurEvent, "p(i(JavaScriptRefNum controlRef) i(UInt32 eSource) i(UInt32 eType))")
     DEFINE_VIREO_FUNCTION(ConfigureEventSpecJSRef, "p(i(Int32 eStructIndex) i(Int32 eSpecIndex) i(JavaScriptRefNum jsReference))")
     DEFINE_VIREO_FUNCTION(RegisterForJSEvent, "p(i(JavaScriptRefNum jsReference) i(UInt32 eType))")
 

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -555,7 +555,8 @@ void GetVIName(VirtualInstrument *vi, StringRef viName) {
     viName->AppendSubString(&encodedSubstr);
 }
 
-void RegisterForControlEvent(EventInfo *eventInfo, EventSpec eventSpec, StringRef viName, EventQueueID qID, UInt32 controlID, RefNum reference, bool registerControlEvent) {
+void RegisterForControlEvent(EventInfo *eventInfo, EventSpec eventSpec, StringRef viName, EventQueueID qID, UInt32 controlID, RefNum reference,
+                        bool registerControlEvent) {
     EventOracleIndex eventOracleIdx = kNotAnEventOracleIdx;
     EventType eventType = eventSpec.eventType;
     EventSource eSource = eventSpec.eventSource;
@@ -624,7 +625,6 @@ void ConfigureEventSpecForJSRef(VirtualInstrument *vi, UInt32 eventStructIndex, 
                 StringRef viName = viNameVar.Value;
                 GetVIName(vi, viName);
 
-                eventInfo->controlRefNumMap[controlID] = jsReference;
                 eventSpecRef[eventSpecIndex].eventControlRef = jsReference;
                 RegisterForControlEvent(eventInfo, eventSpecRef[eventSpecIndex], viName, qID, controlID, jsReference, false);
             }
@@ -654,17 +654,6 @@ void UnregisterForStaticEvents(VirtualInstrument *vi) {
                 if (controlRef) {
                     EventInfo::ControlIDInfoMap::iterator ciIter = eventInfo->controlIDInfoMap.find(controlRef);
                     EventOracleIndex eventOracleIdx = kNotAnEventOracleIdx;
-                    if (ciIter == eventInfo->controlIDInfoMap.end()) {
-                        // If we couldn't find the control ref in the controlIDInfoMap it means we're
-                        // likely using a JavaScriptRefNum, which we can look up in the controlRefNumMap
-                        EventControlUID controlID = (EventControlUID)controlRef;
-                        controlRef = 0;
-                        EventInfo::ControlRefNumMap::iterator cRefIter = eventInfo->controlRefNumMap.find(controlID);
-                        if (cRefIter != eventInfo->controlRefNumMap.end()) {
-                            controlRef = cRefIter->second;
-                            ciIter = eventInfo->controlIDInfoMap.find(controlRef);
-                        }
-                    }
 
                     if (ciIter != eventInfo->controlIDInfoMap.end()) {
                         eventOracleIdx = ciIter->second.eventOracleIndex;

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -18,6 +18,7 @@
 #include "RefNum.h"
 #include "Events.h"
 #include "ControlRef.h"
+#include "JavaScriptRef.h"
 #include <deque>
 #include <vector>
 #include <list>
@@ -564,29 +565,12 @@ void RegisterForStaticEvents(VirtualInstrument *vi) {
             ControlRefNum controlRef = eventSpecRef[eventSpecIndex].eventControlRef;
             if (controlRef) {
                 StringRef tag = nullptr;
-                STACK_VAR(String, viNameVar);
-                StringRef viName = viNameVar.Value;
                 if (ControlReferenceLookup(controlRef, nullptr, &tag) == kNIError_Success) {
-                    PercentEncodedSubString encodedStr(vi->VIName(), true, false);
-                    SubString encodedSubstr = encodedStr.GetSubString();
-                    viName->AppendSubString(&encodedSubstr);
+                    StringRef viName = GetVIName(vi);
                     char *tagBegin = reinterpret_cast<char*>(tag->Begin()), *tagEnd = reinterpret_cast<char*>(tag->End());
                     EventControlUID controlID = Int32(strtol(tagBegin, &tagEnd, 10));
                     if (controlID) {
-                        EventOracleIndex eventOracleIdx = kNotAnEventOracleIdx;
-                        EventType eventType = eventSpecRef[eventSpecIndex].eventType;
-                        EventSource eSource = eventSpecRef[eventSpecIndex].eventSource;
-
-                        EventOracle::EventInsertStatus status = EventOracle::TheEventOracle().RegisterForEvent(qID, eSource, eventType, controlID, controlRef,
-                                            &eventOracleIdx);
-                        // gPlatform.IO.Printf("Static Register for VI %*s controlID %d, event %d, eventOracleIdx %d\n",
-                        //                     viName->Length(), viName->Begin(), controlID, eventType, eventOracleIdx);
-                        if (eventOracleIdx > kAppEventOracleIdx && status == EventOracle::kNewRegistration) {
-                            eventInfo->controlIDInfoMap[controlRef] = EventControlInfo(eventOracleIdx, controlID);
-#if kVireoOS_emscripten
-                            jsRegisterForControlEvent(viName, controlID, eventType, eventOracleIdx);
-#endif
-                        }
+                        RegisterForControlEvent(eventInfo, eventSpecRef[eventSpecIndex], viName, qID, controlID, controlRef, true);
                     }
                 }
             }
@@ -595,6 +579,55 @@ void RegisterForStaticEvents(VirtualInstrument *vi) {
         eventInfo->eventStructInfo[eventStructIndex].setCount = 0;
     }
     vi->SetEventInfo(eventInfo);
+}
+
+void ConfigureEventSpecForJSRef(VirtualInstrument *vi, UInt32 eventStructIndex, UInt32 eventSpecIndex, JavaScriptRefNum jsReference) {
+    TypedObjectRef eventStructSpecsRef = vi->EventSpecs();
+    Int32 numEventStructs = eventStructSpecsRef->ElementType()->SubElementCount();
+    EventInfo *eventInfo = vi->GetEventInfo();
+    if (eventStructIndex < numEventStructs) {
+        TypeRef eventSpecType = eventStructSpecsRef->ElementType()->GetSubElement(eventStructIndex);
+        AQBlock1 *eventSpecClustPtr = eventStructSpecsRef->RawBegin() + eventSpecType->ElementOffset();
+        EventSpecRef eventSpecRef = (EventSpecRef)eventSpecClustPtr;
+        UInt32 eventSpecCount = UInt32(eventSpecType->SubElementCount());
+        if (eventSpecIndex < eventSpecCount) {
+            EventQueueID qID = eventInfo->eventStructInfo[eventStructIndex].staticQID;
+            EventControlUID controlID = (EventControlUID)eventSpecRef[eventSpecIndex].eventControlRef;
+            if (controlID) {
+                StringRef viName = GetVIName(vi);
+
+                eventInfo->controlRefNumMap[controlID] = jsReference;
+                RegisterForControlEvent(eventInfo, eventSpecRef[eventSpecIndex], viName, qID, controlID, jsReference, false);
+            }
+        }
+    }
+}
+
+void RegisterForControlEvent(EventInfo *eventInfo, EventSpec eventSpec, StringRef viName, EventQueueID qID, UInt32 controlID, RefNum reference, bool registerControlEvent) {
+    EventOracleIndex eventOracleIdx = kNotAnEventOracleIdx;
+    EventType eventType = eventSpec.eventType;
+    EventSource eSource = eventSpec.eventSource;
+    EventOracle::EventInsertStatus status = EventOracle::TheEventOracle().RegisterForEvent(qID, eSource, eventType, controlID, reference,
+                                &eventOracleIdx);
+    // gPlatform.IO.Printf("Static Register for VI %*s controlID %d, event %d, eventOracleIdx %d\n",
+    //                     viName->Length(), viName->Begin(), controlID, eventType, eventOracleIdx);
+    if (eventOracleIdx > kAppEventOracleIdx && status == EventOracle::kNewRegistration) {
+        eventInfo->controlIDInfoMap[reference] = EventControlInfo(eventOracleIdx, controlID);
+#if kVireoOS_emscripten
+        if (registerControlEvent) {
+            jsRegisterForControlEvent(viName, controlID, eventType, eventOracleIdx);
+        }
+#endif
+    }
+}
+
+StringRef GetVIName(VirtualInstrument *vi) {
+    STACK_VAR(String, viNameVar);
+    StringRef viName = viNameVar.Value;
+    PercentEncodedSubString encodedStr(vi->VIName(), true, false);
+    SubString encodedSubstr = encodedStr.GetSubString();
+    viName->AppendSubString(&encodedSubstr);
+    return viName;
 }
 
 void UnregisterForStaticEvents(VirtualInstrument *vi) {
@@ -615,11 +648,24 @@ void UnregisterForStaticEvents(VirtualInstrument *vi) {
             UInt32 eventSpecCount = UInt32(eventSpecType->SubElementCount());
             EventQueueID qID =  eventInfo->eventStructInfo[eventStructIndex].staticQID;
             for (Int32 eventSpecIndex = 0; eventSpecIndex < eventSpecCount; ++eventSpecIndex) {
-                ControlRefNum controlRef = eventSpecRef[eventSpecIndex].eventControlRef;
+                RefNum controlRef = eventSpecRef[eventSpecIndex].eventControlRef;
                 if (controlRef) {
                     EventInfo::ControlIDInfoMap::iterator ciIter = eventInfo->controlIDInfoMap.find(controlRef);
+                    EventOracleIndex eventOracleIdx = kNotAnEventOracleIdx;
+                    if (ciIter == eventInfo->controlIDInfoMap.end()) {
+                        // If we couldn't find the control ref in the controlIDInfoMap it means we're
+                        // likely using a JavaScriptRefNum, which we can look up in the controlRefNumMap
+                        EventControlUID controlID = (EventControlUID)controlRef;
+                        controlRef = 0;
+                        EventInfo::ControlRefNumMap::iterator cRefIter = eventInfo->controlRefNumMap.find(controlID);
+                        if (cRefIter != eventInfo->controlRefNumMap.end()) {
+                            controlRef = cRefIter->second;
+                            ciIter = eventInfo->controlIDInfoMap.find(controlRef);
+                        }
+                    }
+
                     if (ciIter != eventInfo->controlIDInfoMap.end()) {
-                        EventOracleIndex eventOracleIdx = ciIter->second.eventOracleIndex;
+                        eventOracleIdx = ciIter->second.eventOracleIndex;
                         EventType eventType = eventSpecRef[eventSpecIndex].eventType;
                         EventSource eSource = eventSpecRef[eventSpecIndex].eventSource;
 
@@ -1173,6 +1219,39 @@ VIREO_FUNCTION_SIGNATURE3(_OccurEvent, RefNumVal, UInt32, UInt32)
     return _NextInstruction();
 }
 
+VIREO_FUNCTION_SIGNATURE3(ConfigureEventSpecJSRef, UInt32, UInt32, JavaScriptRefNum)
+{
+    UInt32 eventStructIndex = _Param(0);
+    UInt32 eventSpecIndex = _Param(1);
+    JavaScriptRefNum jsRefNum = _Param(2);
+    VirtualInstrument *owningVI = THREAD_CLUMP()->OwningVI();
+    ConfigureEventSpecForJSRef(owningVI, eventSpecIndex, eventSpecIndex, jsRefNum);
+
+    return _NextInstruction();
+}
+
+VIREO_FUNCTION_SIGNATURE2(RegisterForJSEvent, JavaScriptRefNum, UInt32)
+{
+    JavaScriptRefNum jsRefNum = _Param(0);
+    UInt32 eventType = _Param(1);
+    VirtualInstrument *owningVI = THREAD_CLUMP()->OwningVI();
+    StringRef viName = GetVIName(owningVI);
+    EventInfo *eventInfo = owningVI->GetEventInfo();
+    EventOracleIndex eventOracleIdx = kNotAnEventOracleIdx;
+    EventControlUID controlID = 0;
+    if (eventInfo) {
+        EventControlInfo *ecInfo = &eventInfo->controlIDInfoMap[jsRefNum];
+        eventOracleIdx = ecInfo->eventOracleIndex;
+        controlID = ecInfo->controlID;
+
+#if kVireoOS_emscripten
+        jsRegisterForControlEvent(viName, controlID, eventType, eventOracleIdx);
+#endif
+    }
+
+    return _NextInstruction();
+}
+
 VIREO_FUNCTION_SIGNATURE2(IsNotAUserEventRefnum, RefNumVal, Boolean)
 {
     RefNumVal* refnumPtr = _ParamPointer(0);
@@ -1223,6 +1302,8 @@ DEFINE_VIREO_BEGIN(Events)
                           "i(VarArgRepeat) i(Int32 specIndex)i(StaticTypeAndData)i(BranchTarget))")
 
     DEFINE_VIREO_FUNCTION(_OccurEvent, "p(i(ControlRefNum controlRef) i(UInt32 eSource) i(UInt32 eType))")
+    DEFINE_VIREO_FUNCTION(ConfigureEventSpecJSRef, "p(i(UInt32 eStructIndex) i(UInt32 eSpecIndex) i(JavaScriptRefNum jsReference))")
+    DEFINE_VIREO_FUNCTION(RegisterForJSEvent, "p(i(JavaScriptRefNum jsReference) i(UInt32 eType))")
 
     DEFINE_VIREO_FUNCTION_CUSTOM(IsNotANumPathRefnum, IsNotAUserEventRefnum, "p(i(UserEventRefNum) o(Boolean))")
     DEFINE_VIREO_FUNCTION_CUSTOM(IsEQ, IsEQRefnum, "p(i(UserEventRefNum) i(UserEventRefNum) o(Boolean))")

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -586,7 +586,7 @@ void RegisterForStaticEvents(VirtualInstrument *vi) {
         UInt32 eventSpecCount = UInt32(eventSpecType->SubElementCount());
         EventQueueID qID = kNotAQueueID;
         EventOracle::TheEventOracle().GetNewQueueObject(&qID, nullptr);
-        // TODO (segaljared) remove this when we no longer use ControlRefNum
+        // TODO(segaljared): remove this when we no longer use ControlRefNum
         for (Int32 eventSpecIndex = 0; eventSpecIndex < eventSpecCount; ++eventSpecIndex) {
             ControlRefNum controlRef = (ControlRefNum)eventSpecRef[eventSpecIndex].eventControlRef;
             if (controlRef) {
@@ -1295,7 +1295,7 @@ DEFINE_VIREO_BEGIN(Events)
     DEFINE_VIREO_FUNCTION(WaitForEventsAndDispatch, "p(i(VarArgCount) i(Int32 timeOut) i(StaticTypeAndData ref) i(Int32 esIndex) "
                           "i(VarArgRepeat) i(Int32 specIndex)i(StaticTypeAndData)i(BranchTarget))")
 
-    // TODO (segaljared) remove this when we no longer use ControlRefNum
+    // TODO(segaljared): remove this when we no longer use ControlRefNum
     DEFINE_VIREO_FUNCTION(_OccurEvent, "p(i(ControlRefNum controlRef) i(UInt32 eSource) i(UInt32 eType))")
     DEFINE_VIREO_FUNCTION(_OccurEvent, "p(i(JavaScriptRefNum controlRef) i(UInt32 eSource) i(UInt32 eType))")
     DEFINE_VIREO_FUNCTION(ConfigureEventSpecJSRef, "p(i(Int32 eStructIndex) i(Int32 eSpecIndex) i(JavaScriptRefNum jsReference))")

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -586,6 +586,7 @@ void RegisterForStaticEvents(VirtualInstrument *vi) {
         UInt32 eventSpecCount = UInt32(eventSpecType->SubElementCount());
         EventQueueID qID = kNotAQueueID;
         EventOracle::TheEventOracle().GetNewQueueObject(&qID, nullptr);
+        // TODO (segaljared) remove this when we no longer use ControlRefNum
         for (Int32 eventSpecIndex = 0; eventSpecIndex < eventSpecCount; ++eventSpecIndex) {
             ControlRefNum controlRef = (ControlRefNum)eventSpecRef[eventSpecIndex].eventControlRef;
             if (controlRef) {
@@ -1294,6 +1295,7 @@ DEFINE_VIREO_BEGIN(Events)
     DEFINE_VIREO_FUNCTION(WaitForEventsAndDispatch, "p(i(VarArgCount) i(Int32 timeOut) i(StaticTypeAndData ref) i(Int32 esIndex) "
                           "i(VarArgRepeat) i(Int32 specIndex)i(StaticTypeAndData)i(BranchTarget))")
 
+    // TODO (segaljared) remove this when we no longer use ControlRefNum
     DEFINE_VIREO_FUNCTION(_OccurEvent, "p(i(ControlRefNum controlRef) i(UInt32 eSource) i(UInt32 eType))")
     DEFINE_VIREO_FUNCTION(_OccurEvent, "p(i(JavaScriptRefNum controlRef) i(UInt32 eSource) i(UInt32 eType))")
     DEFINE_VIREO_FUNCTION(ConfigureEventSpecJSRef, "p(i(Int32 eStructIndex) i(Int32 eSpecIndex) i(JavaScriptRefNum jsReference))")

--- a/source/include/VirtualInstrument.h
+++ b/source/include/VirtualInstrument.h
@@ -59,11 +59,9 @@ struct EventControlInfo {
 
 struct EventInfo {
     typedef std::map<RefNum, EventControlInfo> ControlIDInfoMap;
-    typedef std::map<EventControlUID, RefNum> ControlRefNumMap;
 
     EventStructInfo *eventStructInfo;
     ControlIDInfoMap controlIDInfoMap;
-    ControlRefNumMap controlRefNumMap;
 
     EventInfo() : eventStructInfo(nullptr) { }
     explicit EventInfo(Int32 numEventStruct) : eventStructInfo(nullptr) { eventStructInfo = new EventStructInfo[numEventStruct]; }

--- a/source/include/VirtualInstrument.h
+++ b/source/include/VirtualInstrument.h
@@ -59,9 +59,11 @@ struct EventControlInfo {
 
 struct EventInfo {
     typedef std::map<RefNum, EventControlInfo> ControlIDInfoMap;
+    typedef std::map<EventControlUID, RefNum> ControlRefNumMap;
 
     EventStructInfo *eventStructInfo;
     ControlIDInfoMap controlIDInfoMap;
+    ControlRefNumMap controlRefNumMap;
 
     EventInfo() : eventStructInfo(nullptr) { }
     explicit EventInfo(Int32 numEventStruct) : eventStructInfo(nullptr) { eventStructInfo = new EventStructInfo[numEventStruct]; }

--- a/test-it/karma/fixtures/events/ValueChangeStaticControlEventJavaScriptRefNum.via
+++ b/test-it/karma/fixtures/events/ValueChangeStaticControlEventJavaScriptRefNum.via
@@ -1,0 +1,56 @@
+define (UpdateBooleanOnValueChangeEvent dv(.VirtualInstrument (
+    Events: c(
+        e(c( // Event Struct 0
+           e(c(  // Event spec 0
+               e(dv(UInt32 1000) eventSource)  // event source enum
+               e(dv(UInt32 2) eventType)  // ValueChanged
+               e(dv(UInt32 18) controlUID)  // for static control refs
+               e(dv(UInt32 0) dynIndex)    // zero - statically registered
+           ))
+           e(dv(.EventSpec (0 1 0 0)))
+        ))
+    )
+    Locals: c(   // Data Space
+        e(.ErrorCluster error)
+        e(c(
+            e(.UInt32 Source)
+            e(.UInt32 Type)
+            e(.UInt32 Time)
+            e(.UInt32 Index)
+            e(.JavaScriptRefNum ControlRef)
+            e(.Boolean OldValue)
+            e(.Boolean NewValue)
+        ) eventData)
+        e(c(
+            e(.UInt32 Source)
+            e(.UInt32 Type)
+            e(.UInt32 Time)
+            e(.UInt32 Index)
+        ) timeoutData)
+        e(.Boolean eventOccurred)
+        e(.Boolean eventTimedOut)
+        e(c(
+            e(.Boolean OldValue)
+            e(.Boolean NewValue)
+        ) valueChangedEventDataBool)
+        e(.JavaScriptRefNum controlRef)
+        e(.Occurrence occurrence)
+        e(.ErrorCluster error)
+    )
+    clump(1
+        JavaScriptInvoke(occurrence true error 'GetJSRef' controlRef)
+        ConfigureEventSpecJSRef(0 0 controlRef)
+        RegisterForJSEvent(controlRef 2)
+        Printf("Waiting on Events\n")
+        WaitForEventsAndDispatch(100 * 0 0 eventData 1 1 timeoutData 2)
+        Branch(0)
+        Perch(1)
+        Copy(true eventOccurred)
+        Branch(0)
+        Perch(2)
+        Printf("Timeout Event\n")
+        Copy(true eventTimedOut)
+        Perch(0)
+    )
+)))
+enqueue(UpdateBooleanOnValueChangeEvent)


### PR DESCRIPTION
Adding support for JavaScriptRefNums to the events code. Right now it doesn't remove support for using ControlRefNums, which means they can both be used depending on which feature is enabled in LV *and* this can be used without the changes VIA generation, since it won't break existing functionality.

Currently, I haven't create tests on the GitHub side for this, but I will be adding them as the review goes on.

I will add an example of what the VIA would like as a comment.