### PR TITLE
Update the module field of the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
   },
   "homepage": "https://github.com/NI/VireoSDK#readme",
   "main": "dist/wasm32-unknown-emscripten/release/vireo.js",
-  "module": "source/core/vireo.loader.release.js",
+  "module": "source/core/vireo.loader.wasm32-unknown-emscripten.release.js",
   "dependencies": {}
 }

--- a/test-it/ManualLoaderTests/loadermodule.js
+++ b/test-it/ManualLoaderTests/loadermodule.js
@@ -1,4 +1,4 @@
-import vireoHelpers from '../../source/core/vireo.loader.release.js';
+import vireoHelpers from '../../source/core/vireo.loader.wasm32-unknown-emscripten.release.js';
 
 
 (async function () {


### PR DESCRIPTION
Didn't run the ManualLoaderTests after updating the loader files and missed the case of running es6 modules directly using package.json config and in the manual test