### PR TITLE
Adding null check for JavaScriptRefNum in events configuration instructions

### DIFF
--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -1218,7 +1218,7 @@ VIREO_FUNCTION_SIGNATURE3(ConfigureEventSpecJSRef, Int32, Int32, JavaScriptRefNu
     Int32 eventSpecIndex = _Param(1);
     JavaScriptRefNum jsRefNum = _Param(2);
     if (jsRefNum == 0) {
-        THREAD_EXEC()->LogEvent(EventLog::kHardDataError, "JavaScriptRefNum must not be null");
+        THREAD_EXEC()->LogEvent(EventLog::kSoftDataError, "JavaScriptRefNum must not be null");
         return THREAD_EXEC()->Stop();
     }
     VirtualInstrument *owningVI = THREAD_CLUMP()->OwningVI();
@@ -1231,7 +1231,7 @@ VIREO_FUNCTION_SIGNATURE2(RegisterForJSEvent, JavaScriptRefNum, UInt32)
 {
     JavaScriptRefNum jsRefNum = _Param(0);
     if (jsRefNum == 0) {
-        THREAD_EXEC()->LogEvent(EventLog::kHardDataError, "JavaScriptRefNum must not be null");
+        THREAD_EXEC()->LogEvent(EventLog::kSoftDataError, "JavaScriptRefNum must not be null");
         return THREAD_EXEC()->Stop();
     }
     UInt32 eventType = _Param(1);

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -1217,6 +1217,10 @@ VIREO_FUNCTION_SIGNATURE3(ConfigureEventSpecJSRef, Int32, Int32, JavaScriptRefNu
     Int32 eventStructIndex = _Param(0);
     Int32 eventSpecIndex = _Param(1);
     JavaScriptRefNum jsRefNum = _Param(2);
+    if (jsRefNum == 0) {
+        THREAD_EXEC()->LogEvent(EventLog::kHardDataError, "JavaScriptRefNum must not be null");
+        return THREAD_EXEC()->Stop();
+    }
     VirtualInstrument *owningVI = THREAD_CLUMP()->OwningVI();
     ConfigureEventSpecForJSRef(owningVI, eventStructIndex, eventSpecIndex, jsRefNum);
 
@@ -1226,6 +1230,10 @@ VIREO_FUNCTION_SIGNATURE3(ConfigureEventSpecJSRef, Int32, Int32, JavaScriptRefNu
 VIREO_FUNCTION_SIGNATURE2(RegisterForJSEvent, JavaScriptRefNum, UInt32)
 {
     JavaScriptRefNum jsRefNum = _Param(0);
+    if (jsRefNum == 0) {
+        THREAD_EXEC()->LogEvent(EventLog::kHardDataError, "JavaScriptRefNum must not be null");
+        return THREAD_EXEC()->Stop();
+    }
     UInt32 eventType = _Param(1);
     VirtualInstrument *owningVI = THREAD_CLUMP()->OwningVI();
     STACK_VAR(String, viNameVar);

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -44,6 +44,7 @@ describe('The Vireo Control Event', function () {
         vireo.eggShell.reflectOnValueRef(typeVisitor, valueRef, data);
     };
 
+    // Can be removed once we finish this task: https://ni.visualstudio.com/DevCentral/_workitems/edit/41574
     var waitForReadyDataItem = function (viPathParser) {
         return new Promise(function (resolve) {
             (function checkReady () {

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -251,7 +251,8 @@ describe('The Vireo Control Event', function () {
         });
     });
 
-    /*it('errors when JavaScriptRefNum is left null', function (done) {
+    /*
+    it('errors when JavaScriptRefNum is left null', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, updateBooleanOnValueChangeEventNullJavaScriptRefNum);
 
         setTimeout(function () {
@@ -268,5 +269,6 @@ describe('The Vireo Control Event', function () {
             expect(rawPrint).toBe('(Error "JavaScriptRefNum must not be null.")\n');
             done();
         });
-    });*/
+    });
+    */
 });

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -250,4 +250,23 @@ describe('The Vireo Control Event', function () {
             done();
         });
     });
+
+    /*it('errors when JavaScriptRefNum is left null', function (done) {
+        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, updateBooleanOnValueChangeEventNullJavaScriptRefNum);
+
+        setTimeout(function () {
+            const valueRef = getEventDataValueRef('UpdateBooleanOnValueChangeEvent', 'Bool');
+            const data = {
+                OldValue: false,
+                NewValue: true
+            };
+            vireo.eventHelpers.occurEvent(1, 18, 2, writeData, valueRef, data);
+        }, 20);
+
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrintError).toBeEmptyString();
+            expect(rawPrint).toBe('(Error "JavaScriptRefNum must not be null.")\n');
+            done();
+        });
+    });*/
 });

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -251,18 +251,8 @@ describe('The Vireo Control Event', function () {
         });
     });
 
-    /*
     it('errors when JavaScriptRefNum is left null', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, updateBooleanOnValueChangeEventNullJavaScriptRefNum);
-
-        setTimeout(function () {
-            const valueRef = getEventDataValueRef('UpdateBooleanOnValueChangeEvent', 'Bool');
-            const data = {
-                OldValue: false,
-                NewValue: true
-            };
-            vireo.eventHelpers.occurEvent(1, 18, 2, writeData, valueRef, data);
-        }, 20);
 
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrintError).toBeEmptyString();
@@ -270,5 +260,4 @@ describe('The Vireo Control Event', function () {
             done();
         });
     });
-    */
 });

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -250,23 +250,4 @@ describe('The Vireo Control Event', function () {
             done();
         });
     });
-
-    it('errors when JavaScriptRefNum is left null', function (done) {
-        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, updateBooleanOnValueChangeEventNullJavaScriptRefNum);
-
-        setTimeout(function () {
-            const valueRef = getEventDataValueRef('UpdateBooleanOnValueChangeEvent', 'Bool');
-            const data = {
-                OldValue: false,
-                NewValue: true
-            };
-            vireo.eventHelpers.occurEvent(1, 18, 2, writeData, valueRef, data);
-        }, 20);
-
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrintError).toBeEmptyString();
-            expect(rawPrint).toBe('(HardError "JavaScriptRefNum must not be null.")\n');
-            done();
-        });
-    });
 });

--- a/test-it/karma/fixtures/events/ValueChangeNumericStaticControlEvent.via
+++ b/test-it/karma/fixtures/events/ValueChangeNumericStaticControlEvent.via
@@ -27,6 +27,7 @@ define (UpdateNumericOnValueChangeEvent dv(.VirtualInstrument (
             e(.UInt32 Time)
             e(.UInt32 Index)
         ) timeoutData)
+        e(.Boolean ready)
         e(.Boolean eventOccurred)
         e(.Int32 oldValueInEvent)
         e(.Int32 newValueInEvent)
@@ -37,6 +38,7 @@ define (UpdateNumericOnValueChangeEvent dv(.VirtualInstrument (
         ) valueChangedEventDataNumeric)
     )
     clump(1
+        Copy(true ready)
         Printf("Waiting on Events\n")
         WaitForEventsAndDispatch(100 * 0 0 eventData 1 1 timeoutData 2)
         Branch(0)

--- a/test-it/karma/fixtures/events/ValueChangeStaticControlEvent.via
+++ b/test-it/karma/fixtures/events/ValueChangeStaticControlEvent.via
@@ -27,6 +27,7 @@ define (UpdateBooleanOnValueChangeEvent dv(.VirtualInstrument (
             e(.UInt32 Time)
             e(.UInt32 Index)
         ) timeoutData)
+        e(.Boolean ready)
         e(.Boolean eventOccurred)
         e(.Boolean eventTimedOut)
         e(c(
@@ -35,6 +36,7 @@ define (UpdateBooleanOnValueChangeEvent dv(.VirtualInstrument (
         ) valueChangedEventDataBool)
     )
     clump(1
+        Copy(true ready)
         Printf("Waiting on Events\n")
         WaitForEventsAndDispatch(100 * 0 0 eventData 1 1 timeoutData 2)
         Branch(0)

--- a/test-it/karma/fixtures/events/ValueChangeStaticControlEventJavaScriptRefNum.via
+++ b/test-it/karma/fixtures/events/ValueChangeStaticControlEventJavaScriptRefNum.via
@@ -27,6 +27,7 @@ define (UpdateBooleanOnValueChangeEvent dv(.VirtualInstrument (
             e(.UInt32 Time)
             e(.UInt32 Index)
         ) timeoutData)
+        e(.Boolean ready)
         e(.Boolean eventOccurred)
         e(.Boolean eventTimedOut)
         e(c(
@@ -41,6 +42,7 @@ define (UpdateBooleanOnValueChangeEvent dv(.VirtualInstrument (
         JavaScriptInvoke(occurrence true error 'GetJSRef' controlRef)
         ConfigureEventSpecJSRef(0 0 controlRef)
         RegisterForJSEvent(controlRef 2)
+        Copy(true ready)
         Printf("Waiting on Events\n")
         WaitForEventsAndDispatch(100 * 0 0 eventData 1 1 timeoutData 2)
         Branch(0)

--- a/test-it/karma/fixtures/events/ValueChangeStaticControlEventNullJavaScriptRefNum.via
+++ b/test-it/karma/fixtures/events/ValueChangeStaticControlEventNullJavaScriptRefNum.via
@@ -38,7 +38,6 @@ define (UpdateBooleanOnValueChangeEvent dv(.VirtualInstrument (
         e(.ErrorCluster error)
     )
     clump(1
-        JavaScriptInvoke(occurrence true error 'GetJSRef' controlRef)
         ConfigureEventSpecJSRef(0 0 controlRef)
         RegisterForJSEvent(controlRef 2)
         Printf("Waiting on Events\n")

--- a/test-it/karma/fixtures/events/ValueChangeStaticControlEventWithMultipleRegistrations.via
+++ b/test-it/karma/fixtures/events/ValueChangeStaticControlEventWithMultipleRegistrations.via
@@ -119,8 +119,10 @@ define (MultipleEventStructuresListeningToSameControl dv(.VirtualInstrument (
             e(.Boolean OldValue)
             e(.Boolean NewValue)
         ) valueChangedEventDataBool)
+        e(.Boolean ready)
     )
     clump(1
+        Copy(true ready)
         Printf("Starting\n")
         Trigger(1)
         Trigger(2)


### PR DESCRIPTION
Adding null check for JavaScriptRefNum in events configuration instructions. I've also updated the JavaScriptRefNum karma test so that it works correctly.

I have not been able to get a test working for the null check specifically, because other tests start failing when the error occurs in Vireo. It's currently commented out in the test file.