### PR TITLE
JavaScript invoke internal function clean-up

### DIFF
--- a/source/io/module_javaScriptInvoke.js
+++ b/source/io/module_javaScriptInvoke.js
@@ -187,18 +187,14 @@ var assignJavaScriptInvoke;
                     try {
                         fn(valueRef, data);
                     } catch (ex) {
-                        if (data.isInternalFunction) {
-                            throw ex;
-                        }
+                        // Internal check not needed because poker is not used for internal calls
                         mergeNewError(data.errorValueRef, data.functionName, ERRORS.kNIUnableToSetReturnValueInJavaScriptInvoke, ex);
                     }
                 };
             };
 
             var reportTypeMismatch = function (data) {
-                if (data.isInternalFunction) {
-                    throw new Error('Type mismatch trying to set return value');
-                }
+                // Internal check not needed because poker is not used for internal calls
                 mergeNewError(data.errorValueRef, data.functionName, ERRORS.kNITypeMismatchForReturnTypeInJavaScriptInvoke);
             };
 
@@ -334,8 +330,7 @@ var assignJavaScriptInvoke;
                 data = {
                     returnValue: returnValue,
                     errorValueRef: errorValueRef,
-                    functionName: functionName,
-                    isInternalFunction: isInternalFunction
+                    functionName: functionName
                 };
                 Module.eggShell.reflectOnValueRef(jsInvokePoker, returnValueRef, data);
             }

--- a/source/io/module_javaScriptInvoke.js
+++ b/source/io/module_javaScriptInvoke.js
@@ -13,10 +13,7 @@ var assignJavaScriptInvoke;
             MESSAGE: 'An exception occurred within the external JavaScript function called by a JavaScript Library Interface node. Verify your JavaScript code is valid.'
         },
 
-        kNIUnsupportedParameterTypeInJavaScriptInvoke: {
-            CODE: 44301,
-            MESSAGE: 'JavaScript function contains a parameter of an unsupported data type. Convert unsupported JavaScript types to types supported by the JavaScript Library Interface.'
-        },
+        kNIUnsupportedParameterTypeInJavaScriptInvoke: undefined, // Code 44301 no longer used. Unsupported LabVIEW parameter types now result in runtime exception.
 
         kNIUnableToFindFunctionForJavaScriptInvoke: {
             CODE: 44302,
@@ -28,10 +25,7 @@ var assignJavaScriptInvoke;
             MESSAGE: 'Unable to set return value for JavaScript Library Interface node parameter.'
         },
 
-        kNIUnsupportedLabVIEWReturnTypeInJavaScriptInvoke: {
-            CODE: 44305,
-            MESSAGE: 'Unsupported return type for JavaScript Library Interface node parameter.'
-        },
+        kNIUnsupportedLabVIEWReturnTypeInJavaScriptInvoke: undefined, // Code 44305 no longer used. Unsupported LabVIEW return types now result in runtime exception.
 
         kNITypeMismatchForReturnTypeInJavaScriptInvoke: {
             CODE: 44306,
@@ -319,9 +313,11 @@ var assignJavaScriptInvoke;
         };
 
         var updateReturnValue = function (functionName, returnValueRef, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction) {
-            // TODO mraj should we allow undefined values to be ignored? need to check if this is a change in behavior.. should we allow null through?
-            if (isInternalFunction && returnValue !== undefined) {
-                throw new Error('Unexpected return value, internal functions should update return values through api functions instead of relying on return values');
+            if (isInternalFunction) {
+                if (returnValue !== undefined) {
+                    throw new Error('Unexpected return value, internal functions should update return values through api functions instead of relying on return values');
+                }
+                return;
             }
 
             // The returnValueRef is undefined if we're passing '*' for return parameter in VIA code
@@ -408,9 +404,10 @@ var assignJavaScriptInvoke;
             returnPointer,
             parametersPointer,
             parametersCount,
-            isInternalFunction,
+            isInternalFunctionIn,
             errorTypeRef,
             errorDataRef) {
+            var isInternalFunction = isInternalFunctionIn !== 0;
             var errorValueRef = Module.eggShell.createValueRef(errorTypeRef, errorDataRef);
             var functionNameValueRef = Module.eggShell.createValueRef(functionNameTypeRef, functionNameDataRef);
             var functionName = Module.eggShell.readString(functionNameValueRef);

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -229,7 +229,7 @@ describe('The Vireo Control Event', function () {
         });
     });
 
-    it('occurrence updates boolean terminal value when using JavaScriptRefNum', function (done) {
+    xit('occurrence updates boolean terminal value when using JavaScriptRefNum', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, updateBooleanOnValueChangeEventJavaScriptRefNum);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'UpdateBooleanOnValueChangeEvent');
 

--- a/test-it/karma/events/ControlEvents.Test.js
+++ b/test-it/karma/events/ControlEvents.Test.js
@@ -14,6 +14,7 @@ describe('The Vireo Control Event', function () {
     var updateMultipleEventStructuresOnValueChange = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeStaticControlEventWithMultipleRegistrations.via');
     var updateBooleanOnValueChangeEventJavaScriptRefNum = fixtures.convertToAbsoluteFromFixturesDir('events/ValueChangeStaticControlEventJavaScriptRefNum.via');
 
+    var javaScriptRefNumObject = {};
     var getEventDataValueRef = function (viName, controlName) {
         return vireo.eggShell.findValueRef(viName, 'valueChangedEventData' + controlName);
     };
@@ -62,8 +63,8 @@ describe('The Vireo Control Event', function () {
             // no-op
         });
         vireo.javaScriptInvoke.registerInternalFunctions({
-            GetJSRef: function () {
-                return 5;
+            GetJSRef: function (returnValueRef) {
+                vireo.eggShell.writeJavaScriptRefNum(returnValueRef, javaScriptRefNumObject);
             }
         });
     });
@@ -229,7 +230,7 @@ describe('The Vireo Control Event', function () {
         });
     });
 
-    xit('occurrence updates boolean terminal value when using JavaScriptRefNum', function (done) {
+    it('occurrence updates boolean terminal value when using JavaScriptRefNum', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, updateBooleanOnValueChangeEventJavaScriptRefNum);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'UpdateBooleanOnValueChangeEvent');
 

--- a/test-it/karma/fixtures/javascriptinvoke/AsyncFunctions.via
+++ b/test-it/karma/fixtures/javascriptinvoke/AsyncFunctions.via
@@ -137,3 +137,33 @@ define(RetrieveCompletionCallbackAfterContextIsStaleFromError dv(VirtualInstrume
         JavaScriptInvoke(occurrence1 false error 'NI_RetrieveCompletionCallbackAfterContextIsStaleFromError' return input)
     )
 ) ) )
+
+define(NI_StartAsync_ReturnValueSync_Errors dv(VirtualInstrument (
+    Locals: c(
+        e(c(
+            e(.Boolean status)
+            e(.Int32 code)
+            e(.String source)
+        ) error)
+        e(dv(.UInt8 0) return)
+        e(.Occurrence occurrence1)
+    )
+    clump (
+        JavaScriptInvoke(occurrence1 false error 'NI_StartAsync_ReturnValueSync_Errors' return)
+    )
+) ) )
+
+define(NI_ResolveAsyncWithError dv(VirtualInstrument (
+    Locals: c(
+        e(c(
+            e(.Boolean status)
+            e(.Int32 code)
+            e(.String source)
+        ) error)
+        e(dv(.UInt8 0) return)
+        e(.Occurrence occurrence1)
+    )
+    clump (
+        JavaScriptInvoke(occurrence1 false error 'NI_ResolveAsyncWithError' return)
+    )
+) ) )

--- a/test-it/karma/fixtures/javascriptinvoke/InternalFunctions.via
+++ b/test-it/karma/fixtures/javascriptinvoke/InternalFunctions.via
@@ -24,6 +24,8 @@ define(MyVI dv(VirtualInstrument (
         e(.Occurrence occurrence4)
     )
     clump (
+        // TODO the test InternalFunction.Tests.js needs to be updated and this via needs to be updated to not run all of these functions every time
+        // Currently if an internal function is not found, no error is reported, and the test rrelies on that 
         JavaScriptInvoke(occurrence1 true error1 'NI_InternalFunction' returnValue1 value1)
         JavaScriptInvoke(occurrence2 true error2 'NI_InternalFunctionSetsError' returnValue2 value2)
         JavaScriptInvoke(occurrence3 true * 'NI_InternalFunctionNoErrorCluster' returnValue3 value3)

--- a/test-it/karma/fixtures/javascriptinvoke/InternalFunctions.via
+++ b/test-it/karma/fixtures/javascriptinvoke/InternalFunctions.via
@@ -4,13 +4,13 @@ define(NI_InternalFunction dv(VirtualInstrument (
             e(.Boolean status)
             e(.Int32 code)
             e(.String source)
-        ) error1)
-        e(dv(.Int32 1) value1)
-        e(dv(.Int32 0) returnValue1)
-        e(.Occurrence occurrence1)
+        ) error)
+        e(dv(.Int32 1) value)
+        e(dv(.Int32 0) returnValue)
+        e(.Occurrence occurrence)
     )
     clump (
-        JavaScriptInvoke(occurrence1 true error1 'NI_InternalFunction' returnValue1 value1)
+        JavaScriptInvoke(occurrence true error 'NI_InternalFunction' returnValue value)
     )
 ) ) )
 
@@ -20,34 +20,50 @@ define(NI_InternalFunctionSetsError dv(VirtualInstrument (
             e(.Boolean status)
             e(.Int32 code)
             e(.String source)
-        ) error2)
-        e(dv(.Int32 11) value2)
-        e(dv(.Int32 0) returnValue2)
-        e(.Occurrence occurrence2)
+        ) error)
+        e(dv(.Int32 11) value)
+        e(dv(.Int32 0) returnValue)
+        e(.Occurrence occurrence)
     )
     clump (
-        JavaScriptInvoke(occurrence2 true error2 'NI_InternalFunctionSetsError' returnValue2 value2)
+        JavaScriptInvoke(occurrence true error 'NI_InternalFunctionSetsError' returnValue value)
     )
 ) ) )
 
 define(NI_InternalFunctionNoErrorCluster dv(VirtualInstrument (
     Locals: c(
-        e(dv(.Int32 111) value3)
-        e(dv(.Int32 0) returnValue3)
-        e(.Occurrence occurrence3)
+        e(dv(.Int32 111) value)
+        e(dv(.Int32 0) returnValue)
+        e(.Occurrence occurrence)
     )
     clump (
-        JavaScriptInvoke(occurrence3 true * 'NI_InternalFunctionNoErrorCluster' returnValue3 value3)
+        JavaScriptInvoke(occurrence true * 'NI_InternalFunctionNoErrorCluster' returnValue value)
     )
 ) ) )
 
 define(NI_InternalFunctionNoErrorClusterSetsError dv(VirtualInstrument (
     Locals: c(
-        e(dv(.Int32 1111) value4)
-        e(dv(.Int32 0) returnValue4)
-        e(.Occurrence occurrence4)
+        e(dv(.Int32 1111) value)
+        e(dv(.Int32 0) returnValue)
+        e(.Occurrence occurrence)
     )
     clump (
-        JavaScriptInvoke(occurrence4 true * 'NI_InternalFunctionNoErrorClusterSetsError' returnValue4 value4)
+        JavaScriptInvoke(occurrence true * 'NI_InternalFunctionNoErrorClusterSetsError' returnValue value)
+    )
+) ) )
+
+define(NI_InternalFunction_DoesNotExist dv(VirtualInstrument (
+    Locals: c(
+        e(c(
+            e(.Boolean status)
+            e(.Int32 code)
+            e(.String source)
+        ) error)
+        e(dv(.Int32 1) value)
+        e(dv(.Int32 0) returnValue)
+        e(.Occurrence occurrence)
+    )
+    clump (
+        JavaScriptInvoke(occurrence true error 'NI_InternalFunction_DoesNotExist' returnValue value)
     )
 ) ) )

--- a/test-it/karma/fixtures/javascriptinvoke/InternalFunctions.via
+++ b/test-it/karma/fixtures/javascriptinvoke/InternalFunctions.via
@@ -1,36 +1,53 @@
-define(MyVI dv(VirtualInstrument (
+define(NI_InternalFunction dv(VirtualInstrument (
     Locals: c(
         e(c(
             e(.Boolean status)
             e(.Int32 code)
             e(.String source)
         ) error1)
+        e(dv(.Int32 1) value1)
+        e(dv(.Int32 0) returnValue1)
+        e(.Occurrence occurrence1)
+    )
+    clump (
+        JavaScriptInvoke(occurrence1 true error1 'NI_InternalFunction' returnValue1 value1)
+    )
+) ) )
+
+define(NI_InternalFunctionSetsError dv(VirtualInstrument (
+    Locals: c(
         e(c(
             e(.Boolean status)
             e(.Int32 code)
             e(.String source)
         ) error2)
-        e(dv(.Int32 1) value1)
         e(dv(.Int32 11) value2)
-        e(dv(.Int32 111) value3)
-        e(dv(.Int32 1111) value4)
-        e(dv(.Int32 0) returnValue1)
         e(dv(.Int32 0) returnValue2)
-        e(dv(.Int32 0) returnValue3)
-        e(dv(.Int32 0) returnValue4)
-        e(.Occurrence occurrence1)
         e(.Occurrence occurrence2)
-        e(.Occurrence occurrence3)
-        e(.Occurrence occurrence4)
     )
     clump (
-        // TODO the test InternalFunction.Tests.js needs to be updated and this via needs to be updated to not run all of these functions every time
-        // Currently if an internal function is not found, no error is reported, and the test rrelies on that 
-        JavaScriptInvoke(occurrence1 true error1 'NI_InternalFunction' returnValue1 value1)
         JavaScriptInvoke(occurrence2 true error2 'NI_InternalFunctionSetsError' returnValue2 value2)
-        JavaScriptInvoke(occurrence3 true * 'NI_InternalFunctionNoErrorCluster' returnValue3 value3)
-        JavaScriptInvoke(occurrence4 true * 'NI_InternalFunctionNoErrorClusterSetsError' returnValue4 value4)
     )
 ) ) )
 
-enqueue(MyVI)
+define(NI_InternalFunctionNoErrorCluster dv(VirtualInstrument (
+    Locals: c(
+        e(dv(.Int32 111) value3)
+        e(dv(.Int32 0) returnValue3)
+        e(.Occurrence occurrence3)
+    )
+    clump (
+        JavaScriptInvoke(occurrence3 true * 'NI_InternalFunctionNoErrorCluster' returnValue3 value3)
+    )
+) ) )
+
+define(NI_InternalFunctionNoErrorClusterSetsError dv(VirtualInstrument (
+    Locals: c(
+        e(dv(.Int32 1111) value4)
+        e(dv(.Int32 0) returnValue4)
+        e(.Occurrence occurrence4)
+    )
+    clump (
+        JavaScriptInvoke(occurrence4 true * 'NI_InternalFunctionNoErrorClusterSetsError' returnValue4 value4)
+    )
+) ) )

--- a/test-it/karma/fixtures/javascriptinvoke/ObjectType.via
+++ b/test-it/karma/fixtures/javascriptinvoke/ObjectType.via
@@ -30,40 +30,40 @@ define(MyVI dv(VirtualInstrument (
         e(dv(.Boolean false) isNotANumPathRefnum3)
         e(dv(.Boolean false) isSharedRef)
         e(dv(.Boolean false) isSharedPrimRef)
+        e(dv(.Boolean true) internal)
         e(.Occurrence occurrence)
     )
     clump (
         // Get js object refs
-        JavaScriptInvoke(occurrence false error1 'NI_GetObjectFunction' ref1 name1)
-        JavaScriptInvoke(occurrence false error2 'NI_GetObjectFunction' ref2 name2)
+        JavaScriptInvoke(occurrence internal error1 'NI_GetObjectFunction' ref1 name1)
+        JavaScriptInvoke(occurrence internal error2 'NI_GetObjectFunction' ref2 name2)
         IsEQ(ref1 ref2 isEqual)
         IsNE(ref1 ref2 isNotEqual)
         IsNotANumPathRefnum(ref1 isNotANumPathRefnum1)
         IsNotANumPathRefnum(ref2 isNotANumPathRefnum2)
 
         // Use the js object refs
-        JavaScriptInvoke(occurrence false error3 'NI_UseObjectFunction' length1 ref1)
-        JavaScriptInvoke(occurrence false error4 'NI_UseObjectFunction' length2 ref2)
+        JavaScriptInvoke(occurrence internal error3 'NI_UseObjectFunction' length1 ref1)
+        JavaScriptInvoke(occurrence internal error4 'NI_UseObjectFunction' length2 ref2)
         
         // Get the same js ref
-        JavaScriptInvoke(occurrence false error5 'NI_GetObjectFunction' ref3 name1) 
+        JavaScriptInvoke(occurrence internal error5 'NI_GetObjectFunction' ref3 name1) 
         IsEQ(ref1 ref3 isSharedRef)
 
         // Primitive types don't get same js ref
-        JavaScriptInvoke(occurrence false error6 'NI_GetPrimitiveFunction' ref4 name1)
-        JavaScriptInvoke(occurrence false error7 'NI_GetPrimitiveFunction' ref5 name1)
+        JavaScriptInvoke(occurrence internal error6 'NI_GetPrimitiveFunction' ref4 name1)
+        JavaScriptInvoke(occurrence internal error7 'NI_GetPrimitiveFunction' ref5 name1)
         IsEQ(ref4 ref5 isSharedPrimRef)
 
         // Use un-inialized ref
         IsNotANumPathRefnum(ref6 isNotANumPathRefnum3)
-        JavaScriptInvoke(occurrence false error8 'NI_UseObjectFunction' length3 ref6)
+        JavaScriptInvoke(occurrence internal error8 'NI_UseObjectFunction' length3 ref6)
 
         // Setting pre-initalized ref to the same js object is ok, this case can happen for JSLI with in/out ref terminal
-        JavaScriptInvoke(occurrence false error9 'NI_GetObjectFunction' ref1 name1)
+        JavaScriptInvoke(occurrence internal error9 'NI_GetObjectFunction' ref1 name1)
 
         // Setting pre-initalized ref to a different object is not ok
-        JavaScriptInvoke(occurrence false error10 'NI_GetObjectFunction' ref1 name2)
-        JavaScriptInvoke(occurrence false error11 'NI_GetObjectFunction' ref1 name3)
+        JavaScriptInvoke(occurrence internal error10 'NI_GetObjectFunction' ref1 name2)
     )
 ) ) )
 

--- a/test-it/karma/javascriptinvoke/Async.Test.js
+++ b/test-it/karma/javascriptinvoke/Async.Test.js
@@ -8,106 +8,125 @@ describe('A JavaScript function invoke', function () {
     var vireo;
 
     var jsAsyncFunctionsUrl = fixtures.convertToAbsoluteFromFixturesDir('javascriptinvoke/AsyncFunctions.via');
-    var running = 0;
+
+    var javaScriptInvokeFixtures;
     var CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution;
     var CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromError;
     var NI_CallCompletionCallbackAfterFunctionErrors_Callback;
+    var running;
 
-    var javaScriptInvokeFixtures = Object.freeze({
-        NI_AsyncSquareFunction: function (inputInteger, jsAPI) {
-            var completionCallback = jsAPI.getCompletionCallback();
-            setTimeout(function () {
-                completionCallback(inputInteger * inputInteger);
-            }, 0);
-        },
-        NI_CallCompletionCallbackSynchronously: function (inputInteger, jsAPI) {
-            var completionCallback = jsAPI.getCompletionCallback();
-            completionCallback(inputInteger * inputInteger);
-        },
-        NI_PromiseBasedAsyncSquareFunction: function (inputInteger, jsAPI) {
-            var createTimerPromise = function (input) {
-                var myPromise = new Promise(function (resolve) {
-                    setTimeout(function () {
-                        resolve(input * input);
-                    }, 0);
-                });
-                return myPromise;
-            };
-            var completionCallback = jsAPI.getCompletionCallback();
-            createTimerPromise(inputInteger).then(completionCallback);
-        },
-        NI_RetrieveCompletionCallbackMoreThanOnceBeforeCallback: function (inputInteger, jsAPI) {
-            var completionCallback = jsAPI.getCompletionCallback();
-            expect(jsAPI.getCompletionCallback).toThrowError(/retrieved more than once/);
-            completionCallback(inputInteger + inputInteger);
-        },
-        NI_RetrieveCompletionCallbackMoreThanOnceAfterCallback: function (inputInteger, jsAPI) {
-            var completionCallback = jsAPI.getCompletionCallback();
-            completionCallback(inputInteger * inputInteger);
-            expect(jsAPI.getCompletionCallback).toThrowError(/The API being accessed for NI_RetrieveCompletionCallbackMoreThanOnceAfterCallback is not valid anymore./);
-        },
-        NI_CallCompletionCallbackMoreThanOnce: function (inputInteger, jsAPI) {
-            var completionCallback = jsAPI.getCompletionCallback();
-            var testCompletion = function () {
-                completionCallback(inputInteger * inputInteger);
-            };
-            expect(testCompletion).not.toThrowError();
-            expect(testCompletion).toThrowError(/invoked more than once for NI_CallCompletionCallbackMoreThanOnce/);
-        },
-        NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval: function (inputInteger, jsAPI) {
-            var completionCallback = jsAPI.getCompletionCallback();
-            var testCompletion = function () {
-                completionCallback(inputInteger * inputInteger);
-            };
-            expect(testCompletion).not.toThrowError();
-            expect(testCompletion).toThrowError(/invoked more than once for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval/);
-            expect(jsAPI.getCompletionCallback).toThrowError(/The API being accessed for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval is not valid anymore./);
-            expect(testCompletion).toThrowError(/invoked more than once for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval/);
-        },
-        NI_CompletionCallbackReturnsUndefined: function (inputInteger, jsAPI) {
-            var completionCallback = jsAPI.getCompletionCallback();
-            var testCompletion = function () {
-                completionCallback(undefined);
-            };
-            expect(testCompletion).not.toThrowError();
-        },
-        NI_CallCompletionCallbackAcrossClumps_DoubleFunction: function (inputInteger, jsAPI) {
-            var completionCallback = jsAPI.getCompletionCallback();
-            running = 1;
-            var firstClumpCompletionCallback = function () {
-                if (running === 2) {
-                    completionCallback(inputInteger + inputInteger);
-                    running = 1;
-                } else {
-                    setTimeout(firstClumpCompletionCallback);
-                }
-            };
-            firstClumpCompletionCallback();
-        },
-        NI_CallCompletionCallbackAcrossClumps_SquareFunction: function (inputInteger, jsAPI) {
-            var completionCallback = jsAPI.getCompletionCallback();
-            var secondClumpCompletionCallback = function () {
-                if (running === 1) {
+    beforeAll(function () {
+        javaScriptInvokeFixtures = Object.freeze({
+            NI_AsyncSquareFunction: function (inputInteger, jsAPI) {
+                var completionCallback = jsAPI.getCompletionCallback();
+                setTimeout(function () {
                     completionCallback(inputInteger * inputInteger);
-                    running = 2;
-                } else {
-                    setTimeout(secondClumpCompletionCallback);
-                }
-            };
-            secondClumpCompletionCallback();
-        },
-        NI_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution: function (inputInteger, jsAPI) {
-            CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution = jsAPI;
-            return inputInteger * inputInteger;
-        },
-        NI_RetrieveCompletionCallbackAfterContextIsStaleFromError: function (inputInteger, jsAPI) {
-            CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromError = jsAPI;
-            throw new Error('This function is a failure!');
-        },
-        NI_CallCompletionCallbackAfterFunctionErrors: function (inputInteger, jsAPI) {
-            NI_CallCompletionCallbackAfterFunctionErrors_Callback = jsAPI.getCompletionCallback();
-            throw new Error('Your function call just failed!');
-        }
+                }, 0);
+            },
+            NI_CallCompletionCallbackSynchronously: function (inputInteger, jsAPI) {
+                var completionCallback = jsAPI.getCompletionCallback();
+                completionCallback(inputInteger * inputInteger);
+            },
+            NI_PromiseBasedAsyncSquareFunction: function (inputInteger, jsAPI) {
+                var createTimerPromise = function (input) {
+                    var myPromise = new Promise(function (resolve) {
+                        setTimeout(function () {
+                            resolve(input * input);
+                        }, 0);
+                    });
+                    return myPromise;
+                };
+                var completionCallback = jsAPI.getCompletionCallback();
+                createTimerPromise(inputInteger).then(completionCallback);
+            },
+            NI_RetrieveCompletionCallbackMoreThanOnceBeforeCallback: function (inputInteger, jsAPI) {
+                var completionCallback = jsAPI.getCompletionCallback();
+                expect(jsAPI.getCompletionCallback).toThrowError(/retrieved more than once/);
+                completionCallback(inputInteger + inputInteger);
+            },
+            NI_RetrieveCompletionCallbackMoreThanOnceAfterCallback: function (inputInteger, jsAPI) {
+                var completionCallback = jsAPI.getCompletionCallback();
+                completionCallback(inputInteger * inputInteger);
+                expect(jsAPI.getCompletionCallback).toThrowError(/The API being accessed for NI_RetrieveCompletionCallbackMoreThanOnceAfterCallback is not valid anymore./);
+            },
+            NI_CallCompletionCallbackMoreThanOnce: function (inputInteger, jsAPI) {
+                var completionCallback = jsAPI.getCompletionCallback();
+                var testCompletion = function () {
+                    completionCallback(inputInteger * inputInteger);
+                };
+                expect(testCompletion).not.toThrowError();
+                expect(testCompletion).toThrowError(/invoked more than once for NI_CallCompletionCallbackMoreThanOnce/);
+            },
+            NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval: function (inputInteger, jsAPI) {
+                var completionCallback = jsAPI.getCompletionCallback();
+                var testCompletion = function () {
+                    completionCallback(inputInteger * inputInteger);
+                };
+                expect(testCompletion).not.toThrowError();
+                expect(testCompletion).toThrowError(/invoked more than once for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval/);
+                expect(jsAPI.getCompletionCallback).toThrowError(/The API being accessed for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval is not valid anymore./);
+                expect(testCompletion).toThrowError(/invoked more than once for NI_CallCompletionCallbackMoreThanOnceAfterSecondCallbackRetrieval/);
+            },
+            NI_CompletionCallbackReturnsUndefined: function (inputInteger, jsAPI) {
+                var completionCallback = jsAPI.getCompletionCallback();
+                var testCompletion = function () {
+                    completionCallback(undefined);
+                };
+                expect(testCompletion).not.toThrowError();
+            },
+            NI_CallCompletionCallbackAcrossClumps_DoubleFunction: function (inputInteger, jsAPI) {
+                var completionCallback = jsAPI.getCompletionCallback();
+                running = 1;
+                var firstClumpCompletionCallback = function () {
+                    if (running === 2) {
+                        completionCallback(inputInteger + inputInteger);
+                        running = 1;
+                    } else {
+                        setTimeout(firstClumpCompletionCallback);
+                    }
+                };
+                firstClumpCompletionCallback();
+            },
+            NI_CallCompletionCallbackAcrossClumps_SquareFunction: function (inputInteger, jsAPI) {
+                var completionCallback = jsAPI.getCompletionCallback();
+                var secondClumpCompletionCallback = function () {
+                    if (running === 1) {
+                        completionCallback(inputInteger * inputInteger);
+                        running = 2;
+                    } else {
+                        setTimeout(secondClumpCompletionCallback);
+                    }
+                };
+                secondClumpCompletionCallback();
+            },
+            NI_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution: function (inputInteger, jsAPI) {
+                CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution = jsAPI;
+                return inputInteger * inputInteger;
+            },
+            NI_RetrieveCompletionCallbackAfterContextIsStaleFromError: function (inputInteger, jsAPI) {
+                CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromError = jsAPI;
+                throw new Error('This function is a failure!');
+            },
+            NI_CallCompletionCallbackAfterFunctionErrors: function (inputInteger, jsAPI) {
+                NI_CallCompletionCallbackAfterFunctionErrors_Callback = jsAPI.getCompletionCallback();
+                throw new Error('Your function call just failed!');
+            },
+            NI_StartAsync_ReturnValueSync_Errors: function (jsAPI) {
+                jsAPI.getCompletionCallback();
+                return 'unexpected return value';
+            },
+            NI_ResolveAsyncWithError: function (jsAPI) {
+                var cb = jsAPI.getCompletionCallback();
+                setTimeout(function () {
+                    cb(new Error('An async error occurred'));
+                }, 0);
+            }
+        });
+
+        CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution = undefined;
+        CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromError = undefined;
+        NI_CallCompletionCallbackAfterFunctionErrors_Callback = undefined;
+        running = 0;
     });
 
     beforeAll(function (done) {
@@ -229,6 +248,36 @@ describe('A JavaScript function invoke', function () {
         runSlicesAsync(function () {
             expect(NI_CallCompletionCallbackAfterFunctionErrors_Callback)
                 .toThrowError(/NI_CallCompletionCallbackAfterFunctionErrors threw an error, so this callback cannot be invoked/);
+            done();
+        });
+    });
+
+    it('with call to completion callback, followed by returning a value, causes an error', function (done) {
+        var viName = 'NI_StartAsync_ReturnValueSync_Errors';
+        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsAsyncFunctionsUrl);
+        var viPathParser = vireoRunner.createVIPathParser(vireo, viName);
+        vireoRunner.enqueueVI(vireo, viName);
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrint).toBeEmptyString();
+            expect(rawPrintError).toBeEmptyString();
+            expect(viPathParser('error.status')).toBeTrue();
+            expect(viPathParser('error.code')).toBe(44303);
+            expect(viPathParser('error.source')).toMatch(/Unable to set return value/);
+            done();
+        });
+    });
+
+    it('resolves to an error asynchronously', function (done) {
+        var viName = 'NI_ResolveAsyncWithError';
+        var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsAsyncFunctionsUrl);
+        var viPathParser = vireoRunner.createVIPathParser(vireo, viName);
+        vireoRunner.enqueueVI(vireo, viName);
+        runSlicesAsync(function (rawPrint, rawPrintError) {
+            expect(rawPrint).toBeEmptyString();
+            expect(rawPrintError).toBeEmptyString();
+            expect(viPathParser('error.status')).toBeTrue();
+            expect(viPathParser('error.code')).toBe(44300);
+            expect(viPathParser('error.source')).toMatch(/An exception occurred within the external JavaScript function/);
             done();
         });
     });

--- a/test-it/karma/javascriptinvoke/Async.Test.js
+++ b/test-it/karma/javascriptinvoke/Async.Test.js
@@ -132,9 +132,10 @@ describe('A JavaScript function invoke', function () {
     });
 
     it('with async callback successfully works', function (done) {
+        var viName = 'ValidCases';
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsAsyncFunctionsUrl);
-        var viPathParser = vireoRunner.createVIPathParser(vireo, 'ValidCases');
-        vireo.eggShell.loadVia('enqueue(ValidCases)');
+        var viPathParser = vireoRunner.createVIPathParser(vireo, viName);
+        vireoRunner.enqueueVI(vireo, viName);
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
             expect(rawPrintError).toBeEmptyString();
@@ -149,9 +150,10 @@ describe('A JavaScript function invoke', function () {
     });
 
     it('with multiple completion callback retrievals throws error', function (done) {
+        var viName = 'RetrieveCompletionCallbackMoreThanOnce';
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsAsyncFunctionsUrl);
-        var viPathParser = vireoRunner.createVIPathParser(vireo, 'RetrieveCompletionCallbackMoreThanOnce');
-        vireo.eggShell.loadVia('enqueue(RetrieveCompletionCallbackMoreThanOnce)');
+        var viPathParser = vireoRunner.createVIPathParser(vireo, viName);
+        vireoRunner.enqueueVI(vireo, viName);
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
             expect(rawPrintError).toBeEmptyString();
@@ -165,9 +167,10 @@ describe('A JavaScript function invoke', function () {
     });
 
     it('with multiple calls to completion callback throws error', function (done) {
+        var viName = 'CallCompletionCallbackMoreThanOnce';
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsAsyncFunctionsUrl);
-        var viPathParser = vireoRunner.createVIPathParser(vireo, 'CallCompletionCallbackMoreThanOnce');
-        vireo.eggShell.loadVia('enqueue(CallCompletionCallbackMoreThanOnce)');
+        var viPathParser = vireoRunner.createVIPathParser(vireo, viName);
+        vireoRunner.enqueueVI(vireo, viName);
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
             expect(rawPrintError).toBeEmptyString();
@@ -179,9 +182,10 @@ describe('A JavaScript function invoke', function () {
     });
 
     it('with completion callbacks called out of order', function (done) {
+        var viName = 'CallCompletionCallbackAcrossClumps';
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsAsyncFunctionsUrl);
-        var viPathParser = vireoRunner.createVIPathParser(vireo, 'CallCompletionCallbackAcrossClumps');
-        vireo.eggShell.loadVia('enqueue(CallCompletionCallbackAcrossClumps)');
+        var viPathParser = vireoRunner.createVIPathParser(vireo, viName);
+        vireoRunner.enqueueVI(vireo, viName);
         runSlicesAsync(function (rawPrint, rawPrintError) {
             expect(rawPrint).toBeEmptyString();
             expect(rawPrintError).toBeEmptyString();
@@ -195,9 +199,10 @@ describe('A JavaScript function invoke', function () {
     });
 
     it('with completion callback retrieval when context is stale after to synchronous execution throws error', function (done) {
+        var viName = 'RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution';
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsAsyncFunctionsUrl);
-        var viPathParser = vireoRunner.createVIPathParser(vireo, 'RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution');
-        vireo.eggShell.loadVia('enqueue(RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution)');
+        var viPathParser = vireoRunner.createVIPathParser(vireo, viName);
+        vireoRunner.enqueueVI(vireo, viName);
         runSlicesAsync(function () {
             expect(CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution.getCompletionCallback)
                 .toThrowError(/The API being accessed for NI_RetrieveCompletionCallbackAfterContextIsStaleFromSynchronousExecution is not valid anymore/);
@@ -207,8 +212,9 @@ describe('A JavaScript function invoke', function () {
     });
 
     it('with completion callback retrieval when context is stale after function errors throws error', function (done) {
+        var viName = 'RetrieveCompletionCallbackAfterContextIsStaleFromError';
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsAsyncFunctionsUrl);
-        vireo.eggShell.loadVia('enqueue(RetrieveCompletionCallbackAfterContextIsStaleFromError)');
+        vireoRunner.enqueueVI(vireo, viName);
         runSlicesAsync(function () {
             expect(CachedContextFor_RetrieveCompletionCallbackAfterContextIsStaleFromError.getCompletionCallback)
                 .toThrowError(/The API being accessed for NI_RetrieveCompletionCallbackAfterContextIsStaleFromError is not valid anymore/);
@@ -217,8 +223,9 @@ describe('A JavaScript function invoke', function () {
     });
 
     it('with call to completion callback when context is stale after the function errors', function (done) {
+        var viName = 'CallCompletionCallbackAfterFunctionErrors';
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsAsyncFunctionsUrl);
-        vireo.eggShell.loadVia('enqueue(CallCompletionCallbackAfterFunctionErrors)');
+        vireoRunner.enqueueVI(vireo, viName);
         runSlicesAsync(function () {
             expect(NI_CallCompletionCallbackAfterFunctionErrors_Callback)
                 .toThrowError(/NI_CallCompletionCallbackAfterFunctionErrors threw an error, so this callback cannot be invoked/);

--- a/test-it/karma/javascriptinvoke/InternalFunction.Test.js
+++ b/test-it/karma/javascriptinvoke/InternalFunction.Test.js
@@ -19,7 +19,7 @@ describe('A JavaScript function invoke', function () {
         vireo = await vireoHelpers.createInstance();
     });
 
-    it('internal function works', function (done) {
+    xit('internal function works', function (done) {
         var runSlices = vireoRunner.rebootAndLoadVia(vireo, jsInternalFunctionsUrl);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
 
@@ -47,7 +47,7 @@ describe('A JavaScript function invoke', function () {
         });
     });
 
-    it('internal function successfully sets error and return value is unset', function (done) {
+    xit('internal function successfully sets error and return value is unset', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsInternalFunctionsUrl);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
 
@@ -72,7 +72,7 @@ describe('A JavaScript function invoke', function () {
         });
     });
 
-    it('internal function is invoked even when no error cluster is wired', function (done) {
+    xit('internal function is invoked even when no error cluster is wired', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsInternalFunctionsUrl);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
 
@@ -92,7 +92,7 @@ describe('A JavaScript function invoke', function () {
         });
     });
 
-    it('internal function is invoked even when no error cluster is wired and it sets error', function (done) {
+    xit('internal function is invoked even when no error cluster is wired and it sets error', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsInternalFunctionsUrl);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
 

--- a/test-it/karma/javascriptinvoke/InternalFunction.Test.js
+++ b/test-it/karma/javascriptinvoke/InternalFunction.Test.js
@@ -19,9 +19,11 @@ describe('A JavaScript function invoke', function () {
         vireo = await vireoHelpers.createInstance();
     });
 
-    xit('internal function works', function (done) {
+    it('internal function works', function (done) {
+        var viName = 'NI_InternalFunction';
         var runSlices = vireoRunner.rebootAndLoadVia(vireo, jsInternalFunctionsUrl);
-        var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
+        var viPathParser = vireoRunner.createVIPathParser(vireo, viName);
+        vireoRunner.enqueueVI(vireo, viName);
 
         var called = false;
 
@@ -47,9 +49,11 @@ describe('A JavaScript function invoke', function () {
         });
     });
 
-    xit('internal function successfully sets error and return value is unset', function (done) {
+    it('internal function successfully sets error and return value is unset', function (done) {
+        var viName = 'NI_InternalFunctionSetsError';
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsInternalFunctionsUrl);
-        var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
+        var viPathParser = vireoRunner.createVIPathParser(vireo, viName);
+        vireoRunner.enqueueVI(vireo, viName);
 
         vireo.javaScriptInvoke.registerInternalFunctions({
             NI_InternalFunctionSetsError: function (returnValueRef, inputIntegerValueRef, jsAPI) {
@@ -72,9 +76,11 @@ describe('A JavaScript function invoke', function () {
         });
     });
 
-    xit('internal function is invoked even when no error cluster is wired', function (done) {
+    it('internal function is invoked even when no error cluster is wired', function (done) {
+        var viName = 'NI_InternalFunctionNoErrorCluster';
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsInternalFunctionsUrl);
-        var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
+        var viPathParser = vireoRunner.createVIPathParser(vireo, viName);
+        vireoRunner.enqueueVI(vireo, viName);
 
         vireo.javaScriptInvoke.registerInternalFunctions({
             NI_InternalFunctionNoErrorCluster: function (returnValueRef, inputIntegerValueRef) {
@@ -92,9 +98,11 @@ describe('A JavaScript function invoke', function () {
         });
     });
 
-    xit('internal function is invoked even when no error cluster is wired and it sets error', function (done) {
+    it('internal function is invoked even when no error cluster is wired and it sets error', function (done) {
+        var viName = 'NI_InternalFunctionNoErrorClusterSetsError';
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsInternalFunctionsUrl);
-        var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
+        var viPathParser = vireoRunner.createVIPathParser(vireo, viName);
+        vireoRunner.enqueueVI(vireo, viName);
 
         vireo.javaScriptInvoke.registerInternalFunctions({
             NI_InternalFunctionNoErrorClusterSetsError: function (returnValueRef, inputIntegerValueRef, jsAPI) {

--- a/test-it/karma/javascriptinvoke/Simple.Test.js
+++ b/test-it/karma/javascriptinvoke/Simple.Test.js
@@ -168,7 +168,7 @@ describe('A JavaScript function invoke', function () {
         });
     });
 
-    it('errors when parameter type is not supported', function (done) {
+    xit('errors when parameter type is not supported', function (done) {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsFunctionWithUnsupportedParameterTypeViaUrl);
         var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
 

--- a/test-it/karma/javascriptinvoke/Simple.Test.js
+++ b/test-it/karma/javascriptinvoke/Simple.Test.js
@@ -6,7 +6,6 @@ describe('A JavaScript function invoke', function () {
     var fixtures = window.testHelpers.fixtures;
 
     var kNIUnableToInvokeAJavaScriptFunction = 44300;
-    var kNIUnsupportedParameterTypeInJavaScriptInvoke = 44301;
     var kNIUnableToFindFunctionForJavaScriptInvoke = 44302;
 
     var vireo;
@@ -168,18 +167,19 @@ describe('A JavaScript function invoke', function () {
         });
     });
 
-    xit('errors when parameter type is not supported', function (done) {
+    it('errors when parameter type is not supported', async function () {
         var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsFunctionWithUnsupportedParameterTypeViaUrl);
-        var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
 
-        runSlicesAsync(function (rawPrint, rawPrintError) {
-            expect(rawPrint).toBeEmptyString();
-            expect(rawPrintError).toBeEmptyString();
-            expect(viPathParser('error.status')).toBeTrue();
-            expect([kNIUnsupportedParameterTypeInJavaScriptInvoke]).toContain(viPathParser('error.code'));
-            expect(viPathParser('error.source')).toMatch(/JavaScriptInvoke in MyVI/);
-            done();
-        });
+        var exception;
+        try {
+            await runSlicesAsync();
+        } catch (ex) {
+            exception = ex;
+        }
+        expect(exception.rawPrint).toBeEmptyString();
+        expect(exception.rawPrintError).toBeEmptyString();
+        expect(exception instanceof Error).toBeTrue();
+        expect(exception.message).toMatch(/Visitor must have a method named/);
     });
 
     describe('with a specific context', function () {

--- a/test-it/karma/utilities/TestHelpers.VireoRunner.js
+++ b/test-it/karma/utilities/TestHelpers.VireoRunner.js
@@ -88,6 +88,10 @@
         };
     };
 
+    var enqueueVI = function (vireo, viName) {
+        vireo.eggShell.loadVia('enqueue(' + viName + ')');
+    };
+
     var vireoMatchers = {
         toMatchVtrText: function () {
             return {
@@ -139,6 +143,7 @@
     window.testHelpers.vireoRunner = {
         rebootAndLoadVia: rebootAndLoadVia,
         createVIPathParser: createVIPathParser,
-        createVIPathWriter: createVIPathWriter
+        createVIPathWriter: createVIPathWriter,
+        enqueueVI: enqueueVI
     };
 }());


### PR DESCRIPTION
The goals of this PR are three things:

1. Make sure internal functions do not rely on returning values. They should instead be using api functions to set the returnValueRef. If values are returned for internal functions we error instead.
2. Enable tests that check if the vireo runtime has an error during execution
3. Remove JSObjectRefnum from the public parameterValueVisitor (formerly peeker) and returnValueVisitor (formerly poker)

In the process I made the following changes:
1. Cleaned up the sync vs async code path so they call three helper functions for processing error and returnValues. This makes it much clearer what are the actual differences in the code paths
2. Make terminology used consistent throughout
3. Increase coverage of locations where internal errors should be reported as exceptions instead of LabVIEW errors. The heuristic is that each location with mergeNewError calls should be preceded with an internal check and throw or justify why one is not needed.