### PR TITLE
Cherry-pick fix for converting control id to integer

### DIFF
--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -570,8 +570,10 @@ void RegisterForStaticEvents(VirtualInstrument *vi) {
                     PercentEncodedSubString encodedStr(vi->VIName(), true, false);
                     SubString encodedSubstr = encodedStr.GetSubString();
                     viName->AppendSubString(&encodedSubstr);
-                    char *tagBegin = reinterpret_cast<char*>(tag->Begin()), *tagEnd = reinterpret_cast<char*>(tag->End());
-                    EventControlUID controlID = Int32(strtol(tagBegin, &tagEnd, 10));
+                    SubString tagSubString = tag->MakeSubStringAlias();
+                    TempStackCString tagCString;
+                    tagCString.Append(&tagSubString);
+                    EventControlUID controlID = Int32(strtol(tagCString.BeginCStr(), nullptr, 10));
                     if (controlID) {
                         EventOracleIndex eventOracleIdx = kNotAnEventOracleIdx;
                         EventType eventType = eventSpecRef[eventSpecIndex].eventType;

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -570,9 +570,7 @@ void RegisterForStaticEvents(VirtualInstrument *vi) {
                     PercentEncodedSubString encodedStr(vi->VIName(), true, false);
                     SubString encodedSubstr = encodedStr.GetSubString();
                     viName->AppendSubString(&encodedSubstr);
-                    SubString tagSubString = tag->MakeSubStringAlias();
-                    TempStackCString tagCString;
-                    tagCString.Append(&tagSubString);
+                    TempStackCString tagCString(tag->Begin(), tag->Length());
                     EventControlUID controlID = Int32(strtol(tagCString.BeginCStr(), nullptr, 10));
                     if (controlID) {
                         EventOracleIndex eventOracleIdx = kNotAnEventOracleIdx;


### PR DESCRIPTION
Cherry-pick the fix into a cobra branch. We do not have a reliable way to reproduce the failure this corrects so no new test was added. Existing tests failed intermittently before this change.