### PR TITLE
Enable disabled event test

### DIFF
--- a/test-it/karma/vtrsuite/VtrTestSuite.Test.js
+++ b/test-it/karma/vtrsuite/VtrTestSuite.Test.js
@@ -1,4 +1,4 @@
-fdescribe('The Vireo VTR test suite', function () {
+describe('The Vireo VTR test suite', function () {
     'use strict';
 
     // Reference aliases
@@ -13,12 +13,12 @@ fdescribe('The Vireo VTR test suite', function () {
         vireo = await vireoHelpers.createInstance();
 
         // // VTR tests can't fire JS events, so register no-op registration functions
-        // vireo.eventHelpers.setRegisterForControlEventsFunction(function () {
-        //     // no-op
-        // });
-        // vireo.eventHelpers.setUnRegisterForControlEventsFunction(function () {
-        //     // no-op
-        // });
+        vireo.eventHelpers.setRegisterForControlEventsFunction(function () {
+            // no-op
+        });
+        vireo.eventHelpers.setUnRegisterForControlEventsFunction(function () {
+            // no-op
+        });
     });
     var viaTestNames = testListLoader.getTestNamesForEnvironment('browser');
 
@@ -44,11 +44,19 @@ fdescribe('The Vireo VTR test suite', function () {
             var testDescription = 'and run ' + testName;
             var test = function (done) {
                 var vtrText = fixtures.loadAbsoluteUrl(vtrFile);
-                var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, viaFile);
-
-                runSlicesAsync(function (results, errorText) {
-                    expect(errorText).toBeEmptyString();
-                    expect(results).toMatchVtrText(vtrText);
+                var runSlicesAsync;
+                try {
+                    runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, viaFile);
+                } catch (ex) {
+                    expect(ex.message).toMatch(/CantDecode/);
+                    expect(ex.rawPrintError).toBeEmptyString();
+                    expect(ex.rawPrint).toMatchVtrText(vtrText);
+                    done();
+                    return;
+                }
+                runSlicesAsync(function (rawPrint, rawPrintError) {
+                    expect(rawPrintError).toBeEmptyString();
+                    expect(rawPrint).toMatchVtrText(vtrText);
                     done();
                 });
             };

--- a/test-it/karma/vtrsuite/VtrTestSuite.Test.js
+++ b/test-it/karma/vtrsuite/VtrTestSuite.Test.js
@@ -1,4 +1,4 @@
-describe('The Vireo VTR test suite', function () {
+fdescribe('The Vireo VTR test suite', function () {
     'use strict';
 
     // Reference aliases
@@ -11,6 +11,14 @@ describe('The Vireo VTR test suite', function () {
     var vireo;
     beforeAll(async function () {
         vireo = await vireoHelpers.createInstance();
+
+        // // VTR tests can't fire JS events, so register no-op registration functions
+        // vireo.eventHelpers.setRegisterForControlEventsFunction(function () {
+        //     // no-op
+        // });
+        // vireo.eventHelpers.setUnRegisterForControlEventsFunction(function () {
+        //     // no-op
+        // });
     });
     var viaTestNames = testListLoader.getTestNamesForEnvironment('browser');
 

--- a/test-it/karma/vtrsuite/VtrTestSuite.Test.js
+++ b/test-it/karma/vtrsuite/VtrTestSuite.Test.js
@@ -12,7 +12,7 @@ describe('The Vireo VTR test suite', function () {
     beforeAll(async function () {
         vireo = await vireoHelpers.createInstance();
 
-        // // VTR tests can't fire JS events, so register no-op registration functions
+        // VTR tests can't fire JS events, so register no-op registration functions
         vireo.eventHelpers.setRegisterForControlEventsFunction(function () {
             // no-op
         });
@@ -42,7 +42,7 @@ describe('The Vireo VTR test suite', function () {
 
         describe('can preload ' + testName, function () {
             var testDescription = 'and run ' + testName;
-            var test = function (done) {
+            var test = async function () {
                 var vtrText = fixtures.loadAbsoluteUrl(vtrFile);
                 var runSlicesAsync;
                 try {
@@ -51,14 +51,11 @@ describe('The Vireo VTR test suite', function () {
                     expect(ex.message).toMatch(/CantDecode/);
                     expect(ex.rawPrintError).toBeEmptyString();
                     expect(ex.rawPrint).toMatchVtrText(vtrText);
-                    done();
                     return;
                 }
-                runSlicesAsync(function (rawPrint, rawPrintError) {
-                    expect(rawPrintError).toBeEmptyString();
-                    expect(rawPrint).toMatchVtrText(vtrText);
-                    done();
-                });
+                var {rawPrint, rawPrintError} = await runSlicesAsync();
+                expect(rawPrintError).toBeEmptyString();
+                expect(rawPrint).toMatchVtrText(vtrText);
             };
 
             beforeEach(function (done) {
@@ -69,11 +66,17 @@ describe('The Vireo VTR test suite', function () {
             });
 
             if (focusTests[testName] === true) {
-                fit(testDescription, test); // eslint-disable-line no-restricted-globals
+                fit(testDescription, async function () { // eslint-disable-line no-restricted-globals
+                    await test();
+                });
             } else if (disabledTests[testName] === true) {
-                xit(testDescription, test);
+                xit(testDescription, async function () {
+                    await test();
+                });
             } else {
-                it(testDescription, test);
+                it(testDescription, async function () {
+                    await test();
+                });
             }
         });
     });

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -12,8 +12,7 @@
                 "Round.via",
                 "Scale2X.via",
                 "Scale2XWithIntegers.via",
-                "StringFormatComplex.via",
-                "ValueChangeStaticControlEvent1.via"
+                "StringFormatComplex.via"
             ]
         },
         "js": {
@@ -25,8 +24,7 @@
                 "Round.via",
                 "Scale2X.via",
                 "Scale2XWithIntegers.via",
-                "StringFormatComplex.via",
-                "ValueChangeStaticControlEvent1.via"
+                "StringFormatComplex.via"
             ]
         },
         "browser": {
@@ -75,7 +73,8 @@
                 "UserEventsRegClustBug1.via",
                 "UserEventsReregister.via",
                 "UserEventsThroughput.via",
-                "UserEventsPoly.via"
+                "UserEventsPoly.via",
+                "ValueChangeStaticControlEvent1.via"
             ]
         },
         "manual": {


### PR DESCRIPTION
Modifies the VTR test runner to provide no-op functions used during event registration in the ControlReference-based event registration api. This allows ValueChangeStaticControlEvent1.via to run in karma in browsers

Fixes https://github.com/ni/VireoSDK/issues/524