### PR TITLE
Place default log function in loader

### DIFF
--- a/source/core/vireo.loader.shared.js
+++ b/source/core/vireo.loader.shared.js
@@ -50,12 +50,22 @@ const createModuleBase = function (config) {
         }
     }
 
+    Module.vireoPrint = function (text) {
+        console.log(text);
+    };
+
+    Module.vireoPrintErr = function (text) {
+        console.error(text);
+    };
+
+    // Module.print and Module.printErr references are saved internally by Emscripten JS code
+    // So we forward to our own functions so that the target can be replaced as needed
     Module.print = function (text) {
-        Module.eggShell.doPrint(text);
+        Module.vireoPrint(text);
     };
 
     Module.printErr = function (text) {
-        Module.eggShell.doPrintErr(text);
+        Module.vireoPrintErr(text);
     };
 
     Module.vireoWasmReady = new Promise(function (resolve, reject) {

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -73,20 +73,12 @@ var assignEggShell;
         Module.eggShell.v_userShell = Module.eggShell.create(Module.eggShell.v_root);
 
         // Exported functions
-        Module.eggShell.doPrint = function (text) {
-            console.log(text);
-        };
-
-        Module.eggShell.doPrintErr = function (text) {
-            console.error(text);
-        };
-
         publicAPI.eggShell.setPrintFunction = function (fn) {
             if (typeof fn !== 'function') {
                 throw new Error('Print must be a callable function');
             }
 
-            Module.eggShell.doPrint = fn;
+            Module.vireoPrint = fn;
         };
 
         publicAPI.eggShell.setPrintErrorFunction = function (fn) {
@@ -94,7 +86,7 @@ var assignEggShell;
                 throw new Error('PrintError must be a callable function');
             }
 
-            Module.eggShell.doPrintErr = fn;
+            Module.vireoPrintErr = fn;
         };
 
         Module.eggShell.executeSlicesWakeUpCallback = function () {


### PR DESCRIPTION
This allows createVireoCore to print errors before wasm is ready, ie if loading wasm fails and needs to log errors.

This is important for server that serve with the wrong Content-Type. Those servers would cause first stage of wasm loading to fail. Before this change reporting the error would also fail because eggShell was not ready to print errors. This resulted in Vireo completely failing to load on those servers using incorrect Content-Types instead of using fallback load behaviors.