### PR TITLE
Fix issues found in native test suite with AddressSanitizer

### DIFF
--- a/make-it/Makefile
+++ b/make-it/Makefile
@@ -96,6 +96,12 @@ else
         CC=clang++
         LDFLAGS+= -dead_strip
         CFLAGS+= -pthread $(CCOPT) $(TARGETARCH) -fno-rtti -fno-exceptions -std=c++11
+
+        ifdef ASAN
+            LDFLAGS += -fsanitize=address
+            CFLAGS += -fsanitize=address
+        endif
+
         PROGRAM_DIR=/Applications/Vireo
     endif
 endif

--- a/source/core/Array.cpp
+++ b/source/core/Array.cpp
@@ -139,7 +139,7 @@ VIREO_FUNCTION_SIGNATUREV(ArrayIndexND, ArrayIndexNDParamBlock)
             empty = true;
     }
     for (; j < rank; ++j) {
-        arraySlabLen[j] = arraySlabLen[j-1];
+        arraySlabLen[j] = j >= 1 ? arraySlabLen[j-1] : 0;
         arrayLen[j] = 1;
     }
     if (subRank > 0) {
@@ -570,8 +570,9 @@ VIREO_FUNCTION_SIGNATUREV(ArrayReplaceSubsetND, ArrayReplaceSubsetParamBlock)
         if (len == 0)
             empty = true;
     }
-    for (; j < rank; ++j)
-        arrayOutSlabLengths[j] = arrayOutSlabLengths[(j-1)];
+    for (; j < rank; ++j) {
+        arrayOutSlabLengths[j] = j >= 1 ? arrayOutSlabLengths[(j-1)] : 0;
+    }
     void* element = arguments[i]._pData;
     IntIndex srcRank =  arguments[i]._paramType->Rank();
     if (srcRank != expectedElemRank) {

--- a/source/core/NumericString.cpp
+++ b/source/core/NumericString.cpp
@@ -1473,7 +1473,7 @@ Boolean TypedScanString(SubString* inputString, IntIndex* endToken, const Format
                 break;
             }
         }
-        in.AliasAssign(in.Begin(), in.Begin()+formatOptions->MinimumFieldWidth+leadingSpace);
+        in.AliasAssign(in.Begin(), in.Begin() + std::min(in.Length(), formatOptions->MinimumFieldWidth + leadingSpace));
     }
     truncateInput.Append(&in);
     char* inpBegin = truncateInput.BeginCStr();

--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -591,7 +591,7 @@ TypeRef TDViaParser::ParseArray()
         _string.ReadToken(&token);
     }
 
-    ArrayType  *array = ArrayType::New(_typeManager, elementType, rank, dimensionLengths);
+    ArrayType  *array = ArrayType::New(_typeManager, elementType, std::min(rank, static_cast<IntIndex>(kArrayMaxRank)), dimensionLengths);
     return array;
 }
 //------------------------------------------------------------


### PR DESCRIPTION
There are three fixes here:
1. In two places in `Array.cpp`, don't attempt to copy from before the start of the array to avoid a buffer underflow.
2. In `TDViaParser::ParseArray`, only copy at most `kArrayMaxRank` items from `dimensionLengths`, as we never put more than `kArrayMaxRank` items into it. This avoids a buffer overflow when we try to `memcpy` from it in `ArrayType::ArrayType`.
3. In `TypedScanString`, cap the length of `in` used for `AliasAssign` at `in.Length()`. This avoids a buffer overflow later when copying it in `FixedCArray<unsigned char, 255>::Append`

In addition to the above fixes, add a flag in Makefile to make enabling AddressSanitizer simple.