### PR TITLE
Fixing issue where errors in using or retrieving completion callback could freeze execution

### DIFF
--- a/source/io/module_javaScriptInvoke.js
+++ b/source/io/module_javaScriptInvoke.js
@@ -296,19 +296,18 @@ var assignJavaScriptInvoke;
             labVIEWCallStatus.hasFinished = true;
         };
 
-        var reportExecutionError = function (occurrencePointer, functionName, errorToSet,  returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus) {
+        var reportExecutionError = function (occurrencePointer, functionName, errorToSet, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus) {
             reportExecutionErrorCore(functionName, errorToSet, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus);
             Module.eggShell.setOccurrence(occurrencePointer);
         };
 
-        var reportExecutionErrorAsync = function (occurrencePointer, functionName, errorToSet,  returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus) {
+        var reportExecutionErrorAsync = function (occurrencePointer, functionName, errorToSet, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus) {
             reportExecutionErrorCore(functionName, errorToSet, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus);
             completionCallbackStatus.invocationState = completionCallbackInvocationEnum.REJECTED;
             Module.eggShell.setOccurrenceAsync(occurrencePointer);
         };
 
-        var updateReturnValueCore = function(functionName, returnValueRef, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus)
-        {
+        var updateReturnValueCore = function (functionName, returnValueRef, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus) {
             if (isInternalFunction) {
                 if (returnValue !== undefined) {
                     throw new Error('Unexpected return value, internal functions should update return values through api functions instead of relying on return values');
@@ -332,12 +331,11 @@ var assignJavaScriptInvoke;
             completionCallbackStatus.retrievalState = completionCallbackRetrievalEnum.UNRETRIEVABLE;
             completionCallbackStatus.invocationState = completionCallbackInvocationEnum.FULFILLED;
             labVIEWCallStatus.hasFinished = true;
-        }
+        };
 
         var updateReturnValue = function (occurrencePointer, functionName, returnValueRef, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus) {
             updateReturnValueCore(functionName, returnValueRef, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus);
             Module.eggShell.setOccurrence(occurrencePointer);
-
         };
 
         var updateReturnValueAsync = function (occurrencePointer, functionName, returnValueRef, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus) {
@@ -355,7 +353,7 @@ var assignJavaScriptInvoke;
                 }
                 if (completionCallbackStatus.invocationState === completionCallbackInvocationEnum.REJECTED) {
                     const error = new Error('The call to ' + functionName + ' threw an error, so this callback cannot be invoked.');
-                    reportExecutionErrorAsync(occurrencePointer, functionName,  ERRORS.kNIUnableToInvokeAJavaScriptFunction, error, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus);
+                    reportExecutionErrorAsync(occurrencePointer, functionName, ERRORS.kNIUnableToInvokeAJavaScriptFunction, error, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus);
                     return;
                 }
 
@@ -377,12 +375,12 @@ var assignJavaScriptInvoke;
                 if (completionCallbackStatus.retrievalState === completionCallbackRetrievalEnum.RETRIEVED) {
                     const error = new Error('The completion callback was retrieved more than once for ' + functionName + '.');
                     reportExecutionErrorAsync(occurrencePointer, functionName, ERRORS.kNIUnableToInvokeAJavaScriptFunction, error, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus);
-                    return;
+                    return undefined;
                 }
                 if (completionCallbackStatus.retrievalState === completionCallbackRetrievalEnum.UNRETRIEVABLE) {
                     const error = new Error('The API being accessed for ' + functionName + ' is not valid anymore.');
                     reportExecutionErrorAsync(occurrencePointer, functionName, ERRORS.kNIUnableToInvokeAJavaScriptFunction, error, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus);
-                    return;
+                    return undefined;
                 }
                 completionCallbackStatus.retrievalState = completionCallbackRetrievalEnum.RETRIEVED;
                 return generateCompletionCallback(occurrencePointer, functionName, returnValueRef, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus);

--- a/source/io/module_javaScriptInvoke.js
+++ b/source/io/module_javaScriptInvoke.js
@@ -279,8 +279,8 @@ var assignJavaScriptInvoke;
             return returnValue instanceof Error;
         };
 
-        var reportExecutionErrorCore = function (functionName, errorToSet, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus, shouldThrow) {
-            if (isInternalFunction || (labVIEWCallStatus.hasFinished && shouldThrow)) {
+        var reportExecutionErrorCore = function (functionName, errorToSet, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus) {
+            if (isInternalFunction || labVIEWCallStatus.hasFinished) {
                 // TODO mraj because this can happen asynchronously we may end up not actually
                 // stopping the runtime on throw. It would be helpful to have JS api function
                 // to abort the runtime at this point. https://github.com/ni/VireoSDK/issues/521
@@ -294,12 +294,12 @@ var assignJavaScriptInvoke;
         };
 
         var reportExecutionError = function (occurrencePointer, functionName, errorToSet, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus) {
-            reportExecutionErrorCore(functionName, errorToSet, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus, false);
+            reportExecutionErrorCore(functionName, errorToSet, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus);
             Module.eggShell.setOccurrence(occurrencePointer);
         };
 
         var reportExecutionErrorAsync = function (occurrencePointer, functionName, errorToSet, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus) {
-            reportExecutionErrorCore(functionName, errorToSet, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus, true);
+            reportExecutionErrorCore(functionName, errorToSet, returnValue, errorValueRef, completionCallbackStatus, isInternalFunction, labVIEWCallStatus);
             Module.eggShell.setOccurrenceAsync(occurrencePointer);
         };
 

--- a/test-it/karma/javascriptinvoke/Async.Test.js
+++ b/test-it/karma/javascriptinvoke/Async.Test.js
@@ -300,7 +300,8 @@ describe('A JavaScript function invoke', function () {
                 expect(viPathParser('error.status')).toBeTrue();
                 expect(viPathParser('error.code')).toBe(44300);
                 expect(viPathParser('error.source')).toMatch(/retrieved more than once/);
-                expect(viPathParser('return')).toBe(49);
+                expect(viPathParser('return')).toBe(0);
+                expect(error.message).toMatch(/threw an error, so this callback cannot be invoked/);
             };
         });
         it('using the completion callback', async function () {
@@ -311,22 +312,23 @@ describe('A JavaScript function invoke', function () {
                 // Instead if we are not resolved we should resolve immediately with an error
                 completionCallback(input * input);
             };
-            await test();
+            //await test();
+            test().catch(function(ex) {
+                error = ex;
+            });
         });
         it('using promises', async function () {
             window.SingleFunction = async function (input, jsapi) {
                 // By returning a promise the first implicit call happens
                 await delayForTask();
-                try {
-                    jsapi.getCompletionCallback();
-                } catch (ex) {
-                    error = ex;
-                }
+                jsapi.getCompletionCallback();
                 // TODO mraj this allows completing after an exception is thrown, this should not be allowed.
                 // Instead if we are not resolved we should resolve immediately with an error
                 return input * input;
             };
-            await test();
+            test().catch(function(ex) {
+                error = ex;
+            });
         });
     });
 

--- a/test-it/karma/javascriptinvoke/Async.Test.js
+++ b/test-it/karma/javascriptinvoke/Async.Test.js
@@ -312,8 +312,7 @@ describe('A JavaScript function invoke', function () {
                 // Instead if we are not resolved we should resolve immediately with an error
                 completionCallback(input * input);
             };
-            //await test();
-            test().catch(function(ex) {
+            test().catch(function (ex) {
                 error = ex;
             });
         });
@@ -326,7 +325,7 @@ describe('A JavaScript function invoke', function () {
                 // Instead if we are not resolved we should resolve immediately with an error
                 return input * input;
             };
-            test().catch(function(ex) {
+            test().catch(function (ex) {
                 error = ex;
             });
         });

--- a/test-it/karma/javascriptinvoke/Async.Test.js
+++ b/test-it/karma/javascriptinvoke/Async.Test.js
@@ -297,21 +297,16 @@ describe('A JavaScript function invoke', function () {
                 const {rawPrint, rawPrintError} = await runSlicesAsync();
                 expect(rawPrint).toBeEmptyString();
                 expect(rawPrintError).toBeEmptyString();
-                expect(viPathParser('error.status')).toBeFalse();
-                expect(viPathParser('error.code')).toBe(0);
-                expect(viPathParser('error.source')).toBeEmptyString();
+                expect(viPathParser('error.status')).toBeTrue();
+                expect(viPathParser('error.code')).toBe(44300);
+                expect(viPathParser('error.source')).toMatch(/retrieved more than once/);
                 expect(viPathParser('return')).toBe(49);
-                expect(error.message).toMatch(/retrieved more than once/);
             };
         });
         it('using the completion callback', async function () {
             window.SingleFunction = function (input, jsapi) {
                 var completionCallback = jsapi.getCompletionCallback();
-                try {
-                    jsapi.getCompletionCallback();
-                } catch (ex) {
-                    error = ex;
-                }
+                jsapi.getCompletionCallback();
                 // TODO mraj this allows completing after an exception is thrown, this should not be allowed.
                 // Instead if we are not resolved we should resolve immediately with an error
                 completionCallback(input * input);


### PR DESCRIPTION
Fixing issue where errors in using or retrieving completion callback could freeze execution and not put the error on the error output. For example:

```
window.performTask = function (jsapi) {
    var old = jsapi.getCompletionCallback();

    setTimeout(function () {
         var cb = jsapi.getCompletionCallback();
         cb(5+5);
    });
};
```
In this case, even though the JSLI instruction call won't have completed, the second call to getCompletionCallback will throw an exception, but not set the occurrence pointer, which will result in execution halting.

Instead, these changes make it so that execution will never freeze when an error is encountered like this **and** we will report the error/exception on the error output as long as the instruction hasn't completed yet. If the error/exception happens after the instruction has completed, it will be thrown instead.