### PR TITLE
Fixing async JSLI issue by printing to console.error

### DIFF
--- a/source/io/module_javaScriptInvoke.js
+++ b/source/io/module_javaScriptInvoke.js
@@ -289,7 +289,7 @@ var assignJavaScriptInvoke;
                 // to abort the runtime at this point. https://github.com/ni/VireoSDK/issues/521
                 throw returnValue;
             }
-            console.error(returnValue.message);
+            console.error(returnValue);
 
             mergeNewError(errorValueRef, functionName, ERRORS.kNIUnableToInvokeAJavaScriptFunction, returnValue);
             completionCallbackStatus.retrievalState = completionCallbackRetrievalEnum.UNRETRIEVABLE;

--- a/source/io/module_javaScriptInvoke.js
+++ b/source/io/module_javaScriptInvoke.js
@@ -289,6 +289,7 @@ var assignJavaScriptInvoke;
                 // to abort the runtime at this point. https://github.com/ni/VireoSDK/issues/521
                 throw returnValue;
             }
+            console.error(returnValue.message);
 
             mergeNewError(errorValueRef, functionName, ERRORS.kNIUnableToInvokeAJavaScriptFunction, returnValue);
             completionCallbackStatus.retrievalState = completionCallbackRetrievalEnum.UNRETRIEVABLE;

--- a/test-it/karma/javascriptinvoke/Async.Test.js
+++ b/test-it/karma/javascriptinvoke/Async.Test.js
@@ -312,8 +312,6 @@ describe('A JavaScript function invoke', function () {
                 } catch (ex) {
                     error = ex;
                 }
-                // TODO mraj this allows completing after an exception is thrown, this should not be allowed.
-                // Instead if we are not resolved we should resolve immediately with an error
                 completionCallback(input * input);
             };
             await test();
@@ -327,8 +325,6 @@ describe('A JavaScript function invoke', function () {
                 } catch (ex) {
                     error = ex;
                 }
-                // TODO mraj this allows completing after an exception is thrown, this should not be allowed.
-                // Instead if we are not resolved we should resolve immediately with an error
                 return input * input;
             };
             await test();
@@ -360,8 +356,6 @@ describe('A JavaScript function invoke', function () {
             window.SingleFunction = function (input, jsapi) {
                 var completionCallback = jsapi.getCompletionCallback();
                 jsapi.getCompletionCallback();
-                // TODO mraj this allows completing after an exception is thrown, this should not be allowed.
-                // Instead if we are not resolved we should resolve immediately with an error
                 completionCallback(input * input);
             };
             await test();
@@ -371,8 +365,6 @@ describe('A JavaScript function invoke', function () {
                 // By returning a promise the first implicit call happens
                 await delayForTask();
                 jsapi.getCompletionCallback();
-                // TODO mraj this allows completing after an exception is thrown, this should not be allowed.
-                // Instead if we are not resolved we should resolve immediately with an error
                 return input * input;
             };
             await test();


### PR DESCRIPTION
If a user calls a JSLI function like this:

```
window.performTask = function (jsapi) {
    var old = jsapi.getCompletionCallback();
    var cb = jsapi.getCompletionCallback();
    cb(5+5);
};
```

an Error will be thrown. This will be caught and put on the error wire, but could go unnoticed by the user. Furthermore, even if the user inspected the error wire (or it was printed to console), they would be missing the callstack that you would get by using console.error.

These changes fix that by adding console.error to the reportExecutionError function in the JSLI api.