### PR TITLE
[Refactoring] redundant boolean literal fix

### DIFF
--- a/source/core/NumericString.cpp
+++ b/source/core/NumericString.cpp
@@ -1944,7 +1944,7 @@ static void MakeFormatString(StringRef format, ErrorCluster *error, Int32 argCou
             error->status = true;
             break;
         }
-        if (error && error->status == false && format->Length() > 255) {
+        if (error && !error->status && format->Length() > 255) {
             error->code = -1;  // TODO(sanmut): ErrorCluster fix error codes
             error->status = true;
             break;

--- a/source/core/StringUtilities.cpp
+++ b/source/core/StringUtilities.cpp
@@ -198,11 +198,7 @@ Boolean SubString::ReadGraphemeCluster(SubString* token)
         } else {
             // don't break the CR X LF 0x0D 0x0A
             if (*_begin == 0x0D) {
-                if (*next == 0x0A) {
-                    characterEnd = false;
-                } else {
-                    characterEnd = true;
-                }
+	            characterEnd = *next != 0x0A;
             } else if (*_begin == 0x0A) {
                 characterEnd = true;
             } else if (CharLength(next) == 1) {
@@ -212,11 +208,7 @@ Boolean SubString::ReadGraphemeCluster(SubString* token)
                 Int32 secondByte = *next + 1;
                 Int32 code = firstByte * 0x100 + secondByte;
                 // it only support cluster some extending LATIN character
-                if (code >= 0xCC80 && code <= 0xCDAF) {
-                    characterEnd = false;
-                } else {
-                    characterEnd = true;
-                }
+	            characterEnd = !(code >= 0xCC80 && code <= 0xCDAF);
             }
         }
         _begin = next;
@@ -779,10 +771,8 @@ Boolean SubString::CompareViaEncodedString(SubString* encodedString)
             return false;
         }
     }
-    if (length < this->Length()) {
-        return false;
-    }
-    return true;
+
+	return length >= this->Length();
 }
 //------------------------------------------------------------
 //! Read an integer or one of the special symbolic numbers formats

--- a/source/core/StringUtilities.cpp
+++ b/source/core/StringUtilities.cpp
@@ -198,7 +198,7 @@ Boolean SubString::ReadGraphemeCluster(SubString* token)
         } else {
             // don't break the CR X LF 0x0D 0x0A
             if (*_begin == 0x0D) {
-	            characterEnd = *next != 0x0A;
+                characterEnd = *next != 0x0A;
             } else if (*_begin == 0x0A) {
                 characterEnd = true;
             } else if (CharLength(next) == 1) {
@@ -208,7 +208,7 @@ Boolean SubString::ReadGraphemeCluster(SubString* token)
                 Int32 secondByte = *next + 1;
                 Int32 code = firstByte * 0x100 + secondByte;
                 // it only support cluster some extending LATIN character
-	            characterEnd = !(code >= 0xCC80 && code <= 0xCDAF);
+                characterEnd = !(code >= 0xCC80 && code <= 0xCDAF);
             }
         }
         _begin = next;
@@ -772,7 +772,7 @@ Boolean SubString::CompareViaEncodedString(SubString* encodedString)
         }
     }
 
-	return length >= this->Length();
+    return length >= this->Length();
 }
 //------------------------------------------------------------
 //! Read an integer or one of the special symbolic numbers formats

--- a/source/core/TimeFunctions.cpp
+++ b/source/core/TimeFunctions.cpp
@@ -190,7 +190,7 @@ namespace Vireo {
         Boolean toUTC = _ParamPointer(1) ? _Param(1) : false;
         LVDateTimeRec *dt = _ParamPointer(2);
 
-        Date date(timestamp, toUTC ? true : false);
+        Date date(timestamp, toUTC);
         dt->year = date.Year();
         dt->month = date.Month();
         dt->day_of_month = date.Day();

--- a/source/core/TypeAndDataManager.cpp
+++ b/source/core/TypeAndDataManager.cpp
@@ -855,10 +855,7 @@ Boolean TypeCommon::IsA(const SubString *otherTypeName)
         t = t->BaseType();
     }
 
-    if (otherTypeName->CompareCStr(tsWildCard)) {
-        return true;
-    }
-    return false;
+	return otherTypeName->CompareCStr(tsWildCard);
 }
 //------------------------------------------------------------
 Boolean TypeCommon::IsNumeric()

--- a/source/core/TypeAndDataManager.cpp
+++ b/source/core/TypeAndDataManager.cpp
@@ -855,7 +855,7 @@ Boolean TypeCommon::IsA(const SubString *otherTypeName)
         t = t->BaseType();
     }
 
-	return otherTypeName->CompareCStr(tsWildCard);
+    return otherTypeName->CompareCStr(tsWildCard);
 }
 //------------------------------------------------------------
 Boolean TypeCommon::IsNumeric()


### PR DESCRIPTION
This is the readability-simplify-boolean-expr clang-tidy check.