### PR TITLE
[Refactoring] Change declaration params to match implemented

### DIFF
--- a/source/core/TypeAndDataManager.cpp
+++ b/source/core/TypeAndDataManager.cpp
@@ -2403,19 +2403,19 @@ Boolean TypedArrayCore::ResizeDimensions(Int32 rank, IntIndex *dimensionLengths,
     return bOK;
 }
 //------------------------------------------------------------
-Boolean TypedArrayCore::ResizeCapacity(IntIndex countAQ, IntIndex currentCapactiy, IntIndex newCapacity, Boolean reserveExists)
+Boolean TypedArrayCore::ResizeCapacity(IntIndex countAQ, IntIndex currentCapacity, IntIndex newCapacity, Boolean reserveExists)
 {
     // Resize the underlying block of bytes as needed.
 
     Boolean bOK = true;
-    if (newCapacity < currentCapactiy) {
+    if (newCapacity < currentCapacity) {
         // Shrinking
         VIREO_ASSERT(_pRawBufferBegin!= nullptr);
         bOK = AQRealloc(countAQ, countAQ);
-    } else if (newCapacity > currentCapactiy) {
+    } else if (newCapacity > currentCapacity) {
         // Growing
         Int32 eltSize = _eltTypeRef->TopAQSize();
-        bOK = AQRealloc(countAQ, (eltSize * currentCapactiy));
+        bOK = AQRealloc(countAQ, (eltSize * currentCapacity));
     }
     _capacity = reserveExists ? -newCapacity :  newCapacity;
     return bOK;

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -31,7 +31,7 @@ typedef enum {
 //------------------------------------------------------------
 //! TypeManager functions
 VIREO_EXPORT Int32 Vireo_MaxExecWakeUpTime();
-VIREO_EXPORT void* EggShell_Create(TypeManagerRef tm);
+VIREO_EXPORT void* EggShell_Create(TypeManagerRef parent);
 VIREO_EXPORT NIError EggShell_REPL(TypeManagerRef tm, const Utf8Char* commands, Int32 length);
 VIREO_EXPORT Int32 EggShell_ExecuteSlices(TypeManagerRef tm, Int32 numSlices, Int32 millisecondsToRun);
 VIREO_EXPORT TypeRef EggShell_GetTypeList(TypeManagerRef tm);
@@ -43,13 +43,13 @@ VIREO_EXPORT Int32 EggShell_PokeMemory(TypeManagerRef tm, const char* viName, co
 VIREO_EXPORT EggShellResult EggShell_AllocateData(TypeManagerRef tm, const TypeRef typeRef, void** dataRefLocation);
 VIREO_EXPORT EggShellResult EggShell_DeallocateData(TypeManagerRef tm, const TypeRef typeRef, void* dataRef);
 VIREO_EXPORT EggShellResult EggShell_FindValue(TypeManagerRef tm, const char* viName, const char* eltName, TypeRef* typeRefLocation, void** dataRefLocation);
-VIREO_EXPORT EggShellResult EggShell_FindSubValue(TypeManagerRef tm, const TypeRef type, void *start, const char* eltName,
+VIREO_EXPORT EggShellResult EggShell_FindSubValue(TypeManagerRef tm, const TypeRef typeRef, void * pData, const char* eltName,
         TypeRef* typeRefLocation, void** dataRefLocation);
-VIREO_EXPORT EggShellResult EggShell_WriteDouble(TypeManagerRef tm, const TypeRef actualType, void* pData, Double value);
-VIREO_EXPORT EggShellResult EggShell_ReadDouble(TypeManagerRef tm, const TypeRef actualType, const void* pData, Double* result);
+VIREO_EXPORT EggShellResult EggShell_WriteDouble(TypeManagerRef tm, const TypeRef typeRef, void* pData, Double value);
+VIREO_EXPORT EggShellResult EggShell_ReadDouble(TypeManagerRef tm, const TypeRef typeRef, const void* pData, Double* result);
 VIREO_EXPORT EggShellResult EggShell_WriteValueString(TypeManagerRef tm, TypeRef typeRef, void* pData, const char* format, const char* value);
 VIREO_EXPORT EggShellResult EggShell_ReadValueString(TypeManagerRef tm, TypeRef typeRef, void* pData, const char* format, UInt8** valueString);
-VIREO_EXPORT EggShellResult EggShell_ResizeArray(TypeManagerRef tm, const TypeRef actualType, const void* pData,
+VIREO_EXPORT EggShellResult EggShell_ResizeArray(TypeManagerRef tm, const TypeRef typeRef, const void* pData,
                                                  Int32 rank, Int32 dimensionLengths[]);
 VIREO_EXPORT void* Data_GetStringBegin(StringRef stringObject);
 VIREO_EXPORT Int32 Data_GetStringLength(StringRef stringObject);
@@ -66,8 +66,8 @@ VIREO_EXPORT Boolean TypeRef_IsValid(TypeRef typeRef);
 VIREO_EXPORT Boolean TypeRef_HasCustomDefault(TypeRef typeRef);
 VIREO_EXPORT EncodingEnum TypeRef_BitEncoding(TypeRef typeRef);
 VIREO_EXPORT Int32 TypeRef_Alignment(TypeRef typeRef);
-VIREO_EXPORT StringRef TypeRef_Name(TypeManagerRef typeManager, TypeRef typeRef);
-VIREO_EXPORT StringRef TypeRef_ElementName(TypeManagerRef typeManager, TypeRef typeRef);
+VIREO_EXPORT StringRef TypeRef_Name(TypeManagerRef tm, TypeRef typeRef);
+VIREO_EXPORT StringRef TypeRef_ElementName(TypeManagerRef tm, TypeRef typeRef);
 VIREO_EXPORT Int32 TypeRef_ElementOffset(TypeRef typeRef);
 VIREO_EXPORT Int32 TypeRef_Rank(TypeRef typeRef);
 VIREO_EXPORT PointerTypeEnum TypeRef_PointerType(TypeRef typeRef);

--- a/source/include/DataReflectionVisitor.h
+++ b/source/include/DataReflectionVisitor.h
@@ -27,8 +27,8 @@ namespace Vireo
 class DataReflectionVisitor : public TypeVisitor
 {
  public:
-    DataReflectionVisitor(TypeRef tNeedle, DataPointer pHaystack, StringRef path);
-    void Accept(TypeRef tHaystack, DataPointer pHaystack);
+    DataReflectionVisitor(TypeRef tHaystack, DataPointer pNeedle, StringRef path);
+    void Accept(TypeRef tHayStack, DataPointer pHayStack);
     void Accept(TypeManagerRef tm);
     Boolean Found()         { return _found; }
     Boolean FoundInVI()     { return _foundInVI; }

--- a/source/include/Date.h
+++ b/source/include/Date.h
@@ -48,7 +48,7 @@ class Date {
     void getDate(Timestamp timestamp, Int64* secondsOfYearPtr, Int32* yearPtr,
         Int32* monthPtr = nullptr, Int32* dayPtr = nullptr, Int32* hourPtr = nullptr,
         Int32* minutePtr = nullptr, Int32* secondPtr = nullptr, Double* fractionPtr = nullptr,
-        Int32* weekPtr = nullptr, Int32* weekOfFirstDay = nullptr, char** timeZoneString = nullptr);
+        Int32* weekDayPtr = nullptr, Int32* weekOfFirstDay = nullptr, char** timeZoneString = nullptr);
 
  public:
     Date(Timestamp timestamp, Int32 timeZoneOffset);  // this API is conceptually wrong;

--- a/source/include/EventLog.h
+++ b/source/include/EventLog.h
@@ -44,7 +44,7 @@ class EventLog {
         kHardDataError = 3,
     };
 
-    explicit EventLog(StringRef stringRef);
+    explicit EventLog(StringRef str);
     Int32 TotalErrorCount()                 { return _softErrorCount + _hardErrorCount; }
     Int32 HardErrorCount()                  { return  _hardErrorCount; }
     Int32 WarningCount()                    { return _warningCount; }

--- a/source/include/ExecutionContext.h
+++ b/source/include/ExecutionContext.h
@@ -112,7 +112,7 @@ class ExecutionContext
 
     // Run the concurrent execution system for a short period of time
     ECONTEXT    Int32 /*ExecSlicesResult*/ ExecuteSlices(Int32 numSlices, Int32 millisecondsToRun);
-    ECONTEXT    InstructionCore* SuspendRunningQueueElt(InstructionCore* whereToWakeUp);
+    ECONTEXT    InstructionCore* SuspendRunningQueueElt(InstructionCore* nextInClump);
     ECONTEXT    InstructionCore* Stop();
     ECONTEXT    void            ClearBreakout() { _breakoutCount = 0; }
     ECONTEXT    void            EnqueueRunQueue(VIClump* elt);

--- a/source/include/Platform.h
+++ b/source/include/Platform.h
@@ -77,8 +77,8 @@ class PlatformTimer {
     PlatformTickType MicrosecondsToTickCount(Int64 microseconds);
     Int64 TickCountToMilliseconds(PlatformTickType);
     Int64 TickCountToMicroseconds(PlatformTickType);
-    PlatformTickType MillisecondsFromNowToTickCount(Int64 milliseconds);
-    PlatformTickType MicrosecondsFromNowToTickCount(Int64 microseconds);
+    PlatformTickType MillisecondsFromNowToTickCount(Int64 millisecondCount);
+    PlatformTickType MicrosecondsFromNowToTickCount(Int64 microsecondCount);
 #if !kVireoOS_emscripten
     void SleepMilliseconds(Int64 milliseconds);  // Cannot sleep in emscripten code without using interpreter, must sleep in caller on JS side
 #endif

--- a/source/include/RefNum.h
+++ b/source/include/RefNum.h
@@ -63,8 +63,8 @@ class RefNumStorageBase
     NIError    GetRefNumData(const RefNum &refnum, RefNumDataPtr info);
 
     bool    AcquireRefNumRights(const RefNum &refnum, RefNumDataPtr info);
-    RefNumHeaderAndData* ValidateRefNumIndex(RefNum cookie);
-    RefNumHeaderAndData* CreateRefNumIndex(RefNum cookie);
+    RefNumHeaderAndData* ValidateRefNumIndex(RefNum refnum);
+    RefNumHeaderAndData* CreateRefNumIndex(RefNum refnum);
     virtual RefNumHeaderAndData* ValidateRefNumIndexT(RefNum cookie) = 0;
     virtual RefNumHeaderAndData* CreateRefNumIndexT(RefNum cookie, bool *isNew) = 0;
 

--- a/source/include/StringUtilities.h
+++ b/source/include/StringUtilities.h
@@ -218,7 +218,7 @@ class SubString : public SubVector<Utf8Char>
         return ((UInt8)c <= 127) && (AsciiCharTraits[(UInt8)c] & kACT_Letter);
     }
     static Int32   CharLength(const Utf8Char* begin);
-    static Int32   DigitValue(Utf32Char codepoint, Int32 base);
+    static Int32   DigitValue(Utf32Char codePoint, Int32 base);
 
  public:
     SubString()                          { }
@@ -256,12 +256,12 @@ class SubString : public SubVector<Utf8Char>
 
     //! Compare the SubString with a reference string.
     Boolean Compare(const SubString* str)  const { return Compare(str->Begin(), str->Length()); }
-    Boolean Compare(const Utf8Char* begin, IntIndex length) const;
-    Boolean Compare(const Utf8Char* begin, IntIndex length, Boolean ignoreCase) const;
-    Boolean CompareCStr(ConstCStr begin) const;
+    Boolean Compare(const Utf8Char* begin2, IntIndex length2) const;
+    Boolean Compare(const Utf8Char* begin2, IntIndex length2, Boolean ignoreCase) const;
+    Boolean CompareCStr(ConstCStr begin2) const;
     Boolean CompareCStrIgnoreCase(ConstCStr begin) const { return Compare((const Utf8Char*)begin, (IntIndex)strlen((ConstCStr)begin), true); }
-    Boolean ComparePrefix(const Utf8Char* begin, Int32 length) const;
-    Boolean ComparePrefixIgnoreCase(const Utf8Char* begin, Int32 length) const;
+    Boolean ComparePrefix(const Utf8Char* begin2, Int32 length2) const;
+    Boolean ComparePrefixIgnoreCase(const Utf8Char* begin2, Int32 length2) const;
     Boolean ComparePrefix(char asciiChar) const { return (_begin != _end) && (*_begin == asciiChar); }
     Boolean ComparePrefixCStr(ConstCStr begin) const {
         return ComparePrefix((const Utf8Char*)begin, (IntIndex)strlen((ConstCStr)begin));
@@ -271,17 +271,17 @@ class SubString : public SubVector<Utf8Char>
     }
 
     //! Compare with the encoded string
-    Boolean CompareViaEncodedString(SubString* str);
+    Boolean CompareViaEncodedString(SubString* encodedString);
 
     //! Functions to work with backslash '\' escapes in strings
     Int32 ReadEscapeToken(SubString* token);
     Boolean ReadRawChar(Utf8Char* token);
     Boolean PeekRawChar(Utf8Char* token, IntIndex pos = 0);
     Int32 LengthAfterProcessingEscapes();
-    void ProcessEscapes(Utf8Char* begin, Utf8Char* end);
+    void ProcessEscapes(Utf8Char* dest, Utf8Char* end);
 
     //! Process the escape characters in the substring ('\t','\n', etc.) to ('\\t', '\\n', etc.)
-    IntIndex UnEscape(Utf8Char* begin, IntIndex length);
+    IntIndex UnEscape(Utf8Char* dest, IntIndex length);
 
     //! Read the next UTF-8 sequence and decode it into a regular UTF-32 code point.
     Boolean ReadUtf32(Utf32Char* value);
@@ -293,22 +293,22 @@ class SubString : public SubVector<Utf8Char>
     Boolean ReadLine(SubString* line);
 
     //! Read the next sequence of digits and parse them as an integer.
-    Boolean ReadInt(IntMax* value, Boolean *overflow = nullptr);
+    Boolean ReadInt(IntMax* pValue, Boolean *overflow = nullptr);
 
     //! Read the next sequence of digits and parse them as an IntDim. Like Int but adds '*' and '$n'
-    Boolean ReadIntDim(IntIndex* value);
+    Boolean ReadIntDim(IntIndex* pValue);
 
     //! Read the next sequence of digits and parse them as a Double.
-    Boolean ParseDouble(Double* value, Boolean suppressInfNaN = false, Int32 *errCodePtr = nullptr);
+    Boolean ParseDouble(Double* pValue, Boolean suppressInfNaN = false, Int32 *errCodePtr = nullptr);
 
     //! Read a simple token name, value, punctuation, etc.
     TokenTraits ReadToken(SubString* token, Boolean suppressInfNaN = false);
 
     //! Read 2 digit hex value
-    Boolean ReadHex2(Int32* value);
+    Boolean ReadHex2(Int32* pValue);
 
     //! Read a 64-bit integer in given base
-    Boolean ReadIntWithBase(Int64 *value, Int32 base);
+    Boolean ReadIntWithBase(Int64 * pValue, Int32 base);
 
     //! Read a simple name (like a field name in a JSON object)
     Boolean ReadNameToken(SubString* token);

--- a/source/include/Synchronization.h
+++ b/source/include/Synchronization.h
@@ -104,12 +104,12 @@ class QueueCore : public ObservableCore
     IntIndex RemoveIndex();
  public:
     Boolean Compress();
-    Boolean TryMakeRoom(IntIndex length, IntIndex insert);
+    Boolean TryMakeRoom(IntIndex additionalCount, IntIndex insert);
     Boolean Enqueue(void* pData);
     Boolean PushFront(void* pData);
     Boolean Dequeue(void* pData, bool skipObserver = false);
     Boolean Peek(void* pData, IntIndex skipCount = 0);
-    Boolean HasRoom(IntIndex count);
+    Boolean HasRoom(IntIndex additionalCount);
     IntIndex Count() const { return _count; }
     TypeRef EltType() const { return _elements->ElementType(); }
     IntDim MaxSize() const {

--- a/source/include/TDCodecVia.h
+++ b/source/include/TDCodecVia.h
@@ -123,15 +123,15 @@ class TDViaParser
     TypeRef ParseEnqueue();
     Boolean PreParseElements(Int32 rank, ArrayDimensionVector dimensionLengths);
     TokenTraits ReadArrayItem(SubString* input, SubString* token, Boolean topLevel, Boolean suppressInfNaN);
-    Int32   ParseArrayData(TypedArrayCoreRef array, void* pData, Int32 level);
+    Int32   ParseArrayData(TypedArrayCoreRef pArray, void* pFirstEltInSlice, Int32 level);
     void    ParseVirtualInstrument(TypeRef viType, void* pData);
-    void    ParseClump(VIClump* clump, InstructionAllocator* cia);
+    void    ParseClump(VIClump* viClump, InstructionAllocator* cia);
     void    PreParseClump(VIClump* viClump);
     SubString* TheString() {return &_string;}
     VirtualInstrument *CurrentVIScope() { return _virtualInstrumentScope; }
 
  public:
-    static NIError StaticRepl(TypeManagerRef typeManager, SubString *replStream);
+    static NIError StaticRepl(TypeManagerRef tm, SubString *replStream);
     static void FinalizeVILoad(VirtualInstrument* vi, EventLog* pLog);
     static void FinalizeModuleLoad(TypeManagerRef tm, EventLog* pLog);
 
@@ -187,11 +187,11 @@ class TDViaFormatter
     void    SetExponentialNotation(Boolean on) { _options._exponentialNotation = on; }
     // Data formatters
     void    FormatData(TypeRef type, void* pData);
-    void    FormatArrayData(TypeRef arrayType, TypedArrayCoreRef pData, Int32 rank);
+    void    FormatArrayData(TypeRef arrayType, TypedArrayCoreRef pArray, Int32 rank);
     void    FormatArrayDataRecurse(TypeRef elementType, Int32 rank, AQBlock1* pBegin,
                 IntIndex *pDimLengths, IntIndex *pSlabLengths);
 
-    void    FormatClusterData(TypeRef clusterType, void* pData);
+    void    FormatClusterData(TypeRef type, void* pData);
     void    FormatPointerData(TypeRef pointerType, void* pData);
     void    FormatEncoding(EncodingEnum value);
     void    FormatElementUsageType(UsageTypeEnum value);

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -1157,7 +1157,7 @@ class TypedArrayCore
 
  private:
     //! Resize the underlying block of memory. It DOES NOT update any dimension information. Returns true if success.
-    Boolean ResizeCapacity(IntIndex countAQ, IntIndex currentCapactiy, IntIndex newCapacity, Boolean reserveExists);
+    Boolean ResizeCapacity(IntIndex countAQ, IntIndex currentCapacity, IntIndex newCapacity, Boolean reserveExists);
 
  public:
     NIError Replace1D(IntIndex position, IntIndex count, const void* pSource, Boolean truncate);

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -226,7 +226,7 @@ class TypeManager
 {
  public:
     //! Create a Execution and Typemanager pair.
-    static TypeManagerRef New(TypeManagerRef tm);
+    static TypeManagerRef New(TypeManagerRef parentTADM);
     void Delete();
 
  private:
@@ -260,7 +260,7 @@ class TypeManager
     // but some times it is larger (e.g. 16 or 32) the CDC 7600 was 60
     // also defines alignment rules. Each element in a cluster is addressable
  private:
-    explicit TypeManager(TypeManagerRef typeManager);
+    explicit TypeManager(TypeManagerRef parentTm);
     NamedTypeRef NewNamedType(const SubString* typeName, TypeRef type, NamedTypeRef existingOverload);
  public:
     ExecutionContextRef TheExecutionContext() { return _executionContext; }
@@ -272,10 +272,10 @@ class TypeManager
     void    UntrackLastType(TypeCommon* type);
     void    GetTypes(TypedArray1D<TypeRef>*);
     TypeRef TypeList() { return _typeList; }
-    void    PrintMemoryStat(ConstCStr, Boolean last);
+    void    PrintMemoryStat(ConstCStr, Boolean bLast);
 
     TypeManagerRef BaseTypeManager() { return _baseTypeManager; }
-    TypeRef Define(const SubString* name, TypeRef type);
+    TypeRef Define(const SubString* typeName, TypeRef type);
 
     TypeRef FindType(ConstCStr name);
     TypeRef FindType(const SubString* name, Boolean decode = false);
@@ -301,7 +301,7 @@ class TypeManager
     TypeRef GetObjectElementAddressFromPath(SubString* objectName, SubString* path, void** ppData,
                                             Boolean allowDynamic);
 #if defined (VIREO_INSTRUCTION_REFLECTION)
-    TypeRef DefineCustomPointerTypeWithValue(ConstCStr name, void* pointer, TypeRef type,
+    TypeRef DefineCustomPointerTypeWithValue(ConstCStr name, void* pointer, TypeRef typeRef,
                                              PointerTypeEnum pointerType, ConstCStr cName);
     TypeRef FindCustomPointerTypeFromValue(void*, SubString *cName);
     TypeRef PointerToSymbolPath(TypeRef t, DataPointer p, StringRef path, Boolean* foundInVI = nullptr);
@@ -310,7 +310,7 @@ class TypeManager
 #else
     TypeRef DefineCustomPointerTypeWithValue(ConstCStr name, void* pointer, TypeRef type, PointerTypeEnum pointerType);
 #endif
-    TypeRef DefineCustomDataProcs(ConstCStr name, IDataProcs* pDataProcs, TypeRef type);
+    TypeRef DefineCustomDataProcs(ConstCStr name, IDataProcs* pDataProcs, TypeRef typeRef);
 
  public:
     // Low level allocation functions
@@ -334,7 +334,7 @@ class TypeManager
 
  public:
     // Read or write values accessible to this TM as described by a symbolic path
-    NIError ReadValue(SubString* objectName, SubString* path, Double *value);
+    NIError ReadValue(SubString* objectName, SubString* path, Double * pValue);
     NIError WriteValue(SubString* objectName, SubString* path, Double value);
     NIError ReadValue(SubString* objectName, SubString* path, StringRef);
     NIError WriteValue(SubString* objectName, SubString* path, SubString*);
@@ -352,7 +352,7 @@ IntMax ReadIntFromMemory(TypeRef type, void* pData);
 NIError WriteIntToMemory(TypeRef type, void* pData, IntMax value);
 Double ReadDoubleFromMemory(TypeRef type, const void* pData, NIError* errResult = nullptr);
 NIError WriteDoubleToMemory(TypeRef type, void* pData, const Double value);
-IntMax ConvertNumericRange(EncodingEnum encoding, Int32 size, IntMax input);
+IntMax ConvertNumericRange(EncodingEnum encoding, Int32 size, IntMax value);
 //------------------------------------------------------------
 //! Banker's rounding for Doubles.
 inline Double RoundToEven(Double value)
@@ -575,7 +575,7 @@ class TypeCommon
     //! Get an element of an Aggregate using it index.
     virtual TypeRef GetSubElement(Int32 index)          { return nullptr; }
     //! Parse through a path, digging through Aggregate element names. Calculates the cumulative offset.
-    virtual TypeRef GetSubElementAddressFromPath(SubString* name, void *start, void **end, Boolean allowDynamic);
+    virtual TypeRef GetSubElementAddressFromPath(SubString* path, void *start, void **end, Boolean allowDynamic);
 
     //! Set the SubString to the name if the type is not anonymous.
     virtual SubString Name()                            { return SubString(nullptr, nullptr); }
@@ -602,19 +602,19 @@ class TypeCommon
     virtual IntIndex GetEnumItemCount()              { return 0; }
 
     //! Initialize a linear block to the default value for the type.
-    NIError InitData(void* pData, IntIndex count);
+    NIError InitData(void* pTarget, IntIndex count);
     //! Deep copy a linear block of values from one locatio to another.
-    NIError CopyData(const void* pData, void* pDataCopy, IntIndex count);
+    NIError CopyData(const void* pSource, void* pDest, IntIndex count);
     //! Deallocate and nullptr out a linear block of value of the type.
-    NIError ClearData(void* pData, IntIndex count);
+    NIError ClearData(void* pTarget, IntIndex count);
     //! Make multiple copies of a single instance to a linear block.
-    NIError MultiCopyData(const void* pSingleData, void* pDataCopy, IntIndex count);
+    NIError MultiCopyData(const void* pSource, void* pDest, IntIndex count);
 
     Boolean CompareType(TypeRef otherType);
     Boolean IsA(const SubString* otherTypeName);
     Boolean IsA(ConstCStr typeNameCstr)                 { SubString typeName(typeNameCstr); return IsA(&typeName); }
     Boolean IsA(TypeRef otherType);
-    Boolean IsA(TypeRef otherType, Boolean compatibleArrays);
+    Boolean IsA(TypeRef otherType, Boolean compatibleStructure);
     Boolean IsNumeric();
     Boolean IsInteger();
     Boolean IsSignedInteger();
@@ -689,11 +689,11 @@ class NamedType : public WrappedType
  private:
     NamedTypeRef            _nextOverload;  // May point to one in current or root type manager.
     InlineArray<Utf8Char>   _name;
-    NamedType(TypeManagerRef typeManager, const SubString* name, TypeRef type, NamedTypeRef nextOverload);
+    NamedType(TypeManagerRef typeManager, const SubString* name, TypeRef wrappedType, NamedTypeRef nextOverload);
  public:
     static size_t   StructSize(const SubString* name)
         { return sizeof(NamedType) + InlineArray<Utf8Char>::ExtraStructSize(name->Length()); }
-    static NamedType* New(TypeManagerRef typeManager, const SubString* name, TypeRef type, NamedTypeRef nextOverload);
+    static NamedType* New(TypeManagerRef typeManager, const SubString* name, TypeRef wrappedType, NamedTypeRef nextOverload);
 
     NamedTypeRef    NextOverload()                  { return _nextOverload; }
     virtual void    Accept(TypeVisitor *tv)         { tv->VisitNamed(this); }
@@ -729,9 +729,9 @@ class BitBlockType : public TypeCommon
 {
  private:
     IntIndex   _blockLength;
-    BitBlockType(TypeManagerRef typeManager, IntIndex size, EncodingEnum encoding);
+    BitBlockType(TypeManagerRef typeManager, IntIndex length, EncodingEnum encoding);
  public:
-    static BitBlockType* New(TypeManagerRef typeManager, Int32 size, EncodingEnum encoding);
+    static BitBlockType* New(TypeManagerRef typeManager, Int32 length, EncodingEnum encoding);
     virtual void    Accept(TypeVisitor *tv)     { tv->VisitBitBlock(this); }
     virtual IntIndex BitLength()               { return _blockLength; }
 };
@@ -926,9 +926,9 @@ class DefaultValueType : public WrappedType
     static size_t   StructSize(TypeRef type)            { return sizeof(DefaultValueType) + type->TopAQSize(); }
  public:
     //! Create a default value for a pointer and set the value in one operation.
-    static DefaultValueType* New(TypeManagerRef typeManager, TypeRef type, Boolean mutableValue, void* pointerValue);
+    static DefaultValueType* New(TypeManagerRef typeManager, TypeRef valuesType, Boolean mutableValue, void* pointerValue);
     //!
-    static DefaultValueType* New(TypeManagerRef typeManager, TypeRef type, Boolean mutableValue);
+    static DefaultValueType* New(TypeManagerRef typeManager, TypeRef valuesType, Boolean mutableValue);
     DefaultValueType* FinalizeDVT();
  public:
     virtual void    Accept(TypeVisitor *tv)             { tv->VisitDefaultValue(this); }
@@ -989,7 +989,7 @@ class EnumType : public WrappedType
     virtual TypeRef GetSubElement(Int32 index)          { return index == 0 ? _wrapped : nullptr; }
     void AddEnumItem(SubString *name);
     virtual Int32   SubElementCount()                   { return 1; }
-    virtual StringRef GetEnumItemName(IntIndex index);
+    virtual StringRef GetEnumItemName(IntIndex i);
     virtual IntIndex GetEnumItemCount();
     virtual ~EnumType();
 
@@ -1034,10 +1034,10 @@ class IDataProcs {
 class CustomDataProcType : public WrappedType
 {
  protected:
-    CustomDataProcType(TypeManagerRef typeManager, TypeRef type, IDataProcs *pAlloc);
+    CustomDataProcType(TypeManagerRef typeManager, TypeRef type, IDataProcs * pDataProcs);
     IDataProcs*    _pDataProcs;
  public:
-    static CustomDataProcType* New(TypeManagerRef typeManager, TypeRef type, IDataProcs *pIAlloc);
+    static CustomDataProcType* New(TypeManagerRef typeManager, TypeRef type, IDataProcs * pDataProcs);
     virtual void    Accept(TypeVisitor *tv)
         { tv->VisitCustomDataProc(this); }
     virtual NIError InitData(void* pData, TypeRef pattern = nullptr)
@@ -1093,7 +1093,7 @@ class TypedArrayCore
         return begin;
     }
     AQBlock1* BeginAtND(Int32, IntIndex*);
-    AQBlock1* BeginAtNDIndirect(Int32 rank, IntIndex* pDimIndexes[]);
+    AQBlock1* BeginAtNDIndirect(Int32 rank, IntIndex* ppDimIndexes[]);
 
  public:
     void* RawObj()                  { VIREO_ASSERT(Rank() == 0); return RawBegin(); }  // some extra asserts fo  ZDAs
@@ -1141,7 +1141,7 @@ class TypedArrayCore
     IntIndex AQBlockLength(IntIndex count)  { return ElementType()->TopAQSize() * count; }
 
     //! Resize for multi dim arrays
-    Boolean ResizeDimensions(Int32 rank, IntIndex *dimensionLengths, Boolean preserveOld, Boolean noInit = false);
+    Boolean ResizeDimensions(Int32 rank, IntIndex *dimensionLengths, Boolean preserveElements, Boolean noInit = false);
 
     //! Make this array match the shape of the reference type.
     Boolean ResizeToMatchOrEmpty(TypedArrayCoreRef pReference);
@@ -1157,7 +1157,7 @@ class TypedArrayCore
 
  private:
     //! Resize the underlying block of memory. It DOES NOT update any dimension information. Returns true if success.
-    Boolean ResizeCapacity(IntIndex aqLength, IntIndex currentLength, IntIndex length, Boolean reserveExists);
+    Boolean ResizeCapacity(IntIndex countAQ, IntIndex currentCapactiy, IntIndex newCapacity, Boolean reserveExists);
 
  public:
     NIError Replace1D(IntIndex position, IntIndex count, const void* pSource, Boolean truncate);

--- a/source/include/TypeDefiner.h
+++ b/source/include/TypeDefiner.h
@@ -48,16 +48,16 @@ class TypeDefiner
 
     //@{
     /** Methods used by C++ modules to register Vireo type definitions. */
-    TypeDefiner(TypeDefinerCallback pCallback, ConstCStr pNameSpace, Int32 version);
-    static TypeRef Define(TypeManagerRef tm, ConstCStr name, ConstCStr typeCStr);
-    static TypeRef Define(TypeManagerRef tm, SubString* name, SubString* wrappedTypeString);
+    TypeDefiner(TypeDefinerCallback callback, ConstCStr pModuleName, Int32 version);
+    static TypeRef Define(TypeManagerRef tm, ConstCStr name, ConstCStr typeString);
+    static TypeRef Define(TypeManagerRef tm, SubString* typeName, SubString* typeString);
     static TypeRef ParseAndBuildType(TypeManagerRef tm, SubString* typeString);
     static Boolean HasRequiredModule(TypeDefiner* _this, ConstCStr name);
     static void InsertPastRequirement(TypeDefiner** ppNext, TypeDefiner* module, ConstCStr requirementName);
 
 #if defined(VIREO_INSTRUCTION_REFLECTION)
     static void DefineCustomPointerTypeWithValue(TypeManagerRef tm, ConstCStr name, void* pointer,
-                                                 ConstCStr typeString, PointerTypeEnum pointerType,
+                                                 ConstCStr typeCStr, PointerTypeEnum pointerType,
                                                  ConstCStr cname);
 #else
     static void DefineCustomPointerTypeWithValue(TypeManagerRef tm, ConstCStr name, void* pointer,
@@ -65,7 +65,7 @@ class TypeDefiner
 #endif
     static void DefineCustomValue(TypeManagerRef tm, ConstCStr name, Int32 value, ConstCStr typeString);
     static void DefineCustomDataProcs(TypeManagerRef tm, ConstCStr name, IDataProcs* pDataProcs,
-                                      ConstCStr typeString);
+                                      ConstCStr typeCStr);
  private:
     static TypeDefiner* _gpTypeDefinerList;
     //@}

--- a/source/include/UnitTest.h
+++ b/source/include/UnitTest.h
@@ -43,5 +43,5 @@ class VireoUnitTest {
     virtual bool Execute() = 0;
     void RegisterTest(VireoUnitTest *test);
 
-    static bool RunTests(bool *passed);
+    static bool RunTests(bool * pass);
 };

--- a/source/include/VirtualInstrument.h
+++ b/source/include/VirtualInstrument.h
@@ -91,10 +91,10 @@ class VirtualInstrument
                                            // It has a Begin and End pointer
  public:
     NIError Init(TypeManagerRef tm, Int32 clumpCount, TypeRef paramsType, TypeRef localsType, TypeRef eventSpecsType,
-                 Int32 lineNumberBase, SubString* source);
+                 Int32 lineNumberBase, SubString* clumpSource);
     void PressGo();
     void GoIsDone();
-    TypeRef GetVIElementAddressFromPath(SubString* elementPath, void* pStart, void** pData, Boolean allowDynamic);
+    TypeRef GetVIElementAddressFromPath(SubString* eltPath, void* pStart, void** ppData, Boolean allowDynamic);
 
  public:
     ~VirtualInstrument();
@@ -198,8 +198,8 @@ class VIClump : public FunctionClump
         return caller->_owningVI;
     }
     Observer*          GetObservationStates(Int32) { return _observationCount ? _observationStates : nullptr; }
-    Observer*          ReserveObservationStatesWithTimeout(Int32, PlatformTickType count);
-    InstructionCore*    WaitUntilTickCount(PlatformTickType count, InstructionCore* next);
+    Observer*          ReserveObservationStatesWithTimeout(Int32, PlatformTickType tickCount);
+    InstructionCore*    WaitUntilTickCount(PlatformTickType tickCount, InstructionCore* nextInstruction);
     void               ClearObservationStates();
     InstructionCore*    WaitOnObservableObject(InstructionCore* nextInstruction);
     TypeManagerRef      TheTypeManager()       { return OwningVI()->TheTypeManager(); }
@@ -313,7 +313,7 @@ class ClumpParseState
     InstructionCore*    AllocInstructionCore(Int32 argumentCount);
     InstructionCore*    CreateInstruction(TypeRef instructionType, Int32 argCount, void* args[]);
  public:
-    void                RecordNextHere(InstructionCore** startLocation);
+    void                RecordNextHere(InstructionCore** where);
 
  private:    // State related to two-pass parsing
     Int32           _totalInstructionCount;
@@ -355,7 +355,7 @@ class ClumpParseState
     explicit ClumpParseState(ClumpParseState* cps);
     ClumpParseState(VIClump* clump, InstructionAllocator* cia, EventLog* pLog);
     void            Construct(VIClump* clump, InstructionAllocator* cia, Int32 lineNumber, EventLog* pLog);
-    void            StartSnippet(InstructionCore** startLocation);
+    void            StartSnippet(InstructionCore** pWhereToPatch);
     TypeRef         FormalParameterType()       { return _formalParameterType; }
     TypeRef         ActualArgumentType()        { return _actualArgumentType; }
     Boolean         LastArgumentError()         { return _argumentState < kArgumentResolved_FirstGood; }


### PR DESCRIPTION
Some of the function declarations had different parameter names. I modified the headers, mostly with the assumption that the implementation was "correct".