### PR TITLE
[Refactoring] make functions non-virtual

### DIFF
--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -907,7 +907,7 @@ class ArrayType : public WrappedType
     virtual TypeRef GetSubElement(Int32 index)          { return index == 0 ? _wrapped : nullptr; }
     virtual TypeRef GetSubElementAddressFromPath(SubString* path, void *start, void **end, Boolean allowDynamic);
     virtual SubString Name()                            { return SubString("Array"); }
-    virtual IntDim* DimensionLengths()                  { return &_dimensionLengths[0]; }
+    IntDim* DimensionLengths()					        { return &_dimensionLengths[0]; }
 
     virtual void*   Begin(PointerAccessEnum mode);
     virtual NIError InitData(void* pData, TypeRef pattern = nullptr);
@@ -929,7 +929,7 @@ class DefaultValueType : public WrappedType
     DefaultValueType* FinalizeDVT();
  public:
     virtual void    Accept(TypeVisitor *tv)             { tv->VisitDefaultValue(this); }
-    virtual void*   Begin(PointerAccessEnum mode);
+    void*           Begin(PointerAccessEnum mode);
     virtual NIError InitData(void* pData, TypeRef pattern = nullptr);
 };
 //------------------------------------------------------------

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -907,7 +907,7 @@ class ArrayType : public WrappedType
     virtual TypeRef GetSubElement(Int32 index)          { return index == 0 ? _wrapped : nullptr; }
     virtual TypeRef GetSubElementAddressFromPath(SubString* path, void *start, void **end, Boolean allowDynamic);
     virtual SubString Name()                            { return SubString("Array"); }
-    IntDim* DimensionLengths()					        { return &_dimensionLengths[0]; }
+    IntDim* DimensionLengths()                          { return &_dimensionLengths[0]; }
 
     virtual void*   Begin(PointerAccessEnum mode);
     virtual NIError InitData(void* pData, TypeRef pattern = nullptr);


### PR DESCRIPTION
There were no derived implementations of these functions, and one of their uses was in a constructor at which point the implementation would have been statically resolved anyway.