### PR TITLE
[Refactoring] remove redundant base class specifiers

### DIFF
--- a/source/core/NumericString.cpp
+++ b/source/core/NumericString.cpp
@@ -1861,7 +1861,7 @@ VIREO_FUNCTION_SIGNATURE4(StringFormatValue, StringRef, StringRef, StaticType, v
 }
 
 //------------------------------------------------------------
-struct StringFormatParamBlock : public VarArgInstruction
+struct StringFormatParamBlock : VarArgInstruction
 {
     _ParamDef(StringRef, StringOut);
     _ParamDef(StringRef, StringFormat);
@@ -1959,7 +1959,7 @@ static void MakeFormatString(StringRef format, ErrorCluster *error, Int32 argCou
 }
 
 //------------------------------------------------------------
-struct StringScanParamBlock : public VarArgInstruction
+struct StringScanParamBlock : VarArgInstruction
 {
     _ParamDef(StringRef, StringInput);
     _ParamDef(StringRef, StringRemaining);

--- a/source/core/String.cpp
+++ b/source/core/String.cpp
@@ -142,7 +142,7 @@ void String::AppendEscapeEncoded(const Utf8Char* source, IntIndex len)
     }
 }
 //------------------------------------------------------------
-struct ReplaceSubstringStruct : public InstructionCore
+struct ReplaceSubstringStruct : InstructionCore
 {
     _ParamDef(StringRef, StringIn);
     _ParamDef(StringRef, ReplacementString);
@@ -200,7 +200,7 @@ VIREO_FUNCTION_SIGNATURET(ReplaceSubstring, ReplaceSubstringStruct)
     return _NextInstruction();
 }
 
-struct SearchAndReplaceStringStruct : public InstructionCore
+struct SearchAndReplaceStringStruct : InstructionCore
 {
     _ParamDef(StringRef, StringOut);
     _ParamDef(StringRef, StringIn);
@@ -286,7 +286,7 @@ VIREO_FUNCTION_SIGNATURET(SearchAndReplaceString, SearchAndReplaceStringStruct)
     return _NextInstruction();
 }
 
-struct SearchSplitStringStruct : public InstructionCore
+struct SearchSplitStringStruct : InstructionCore
 {
     _ParamDef(StringRef, StringIn);
     _ParamDef(StringRef, SearchString);
@@ -656,7 +656,7 @@ VIREO_FUNCTION_SIGNATURE3(StringTrim, StringRef, Int32, StringRef)
 }
 
 //------------------------------------------------------------
-struct StringConcatenateParamBlock : public VarArgInstruction
+struct StringConcatenateParamBlock : VarArgInstruction
 {
     _ParamDef(StringRef, StringOut);
     _ParamImmediateDef(TypedArrayCoreRef*, Element[1]);

--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -2395,7 +2395,7 @@ VIREO_FUNCTION_SIGNATURE4(ToStringEx, StaticType, void, StringRef, StringRef)
     return _NextInstruction();
 }
 //------------------------------------------------------------
-struct FlattenToJSONParamBlock : public VarArgInstruction
+struct FlattenToJSONParamBlock : VarArgInstruction
 {
     _ParamImmediateDef(StaticTypeAndData, arg1[1]);
     _ParamDef(Boolean, lvExtensions);
@@ -2441,7 +2441,7 @@ VIREO_FUNCTION_SIGNATUREV(FlattenToJSON, FlattenToJSONParamBlock)
  *      :default null elements
  *      :strict validation. whether allow json object contains items not defined in the cluster
  * */
-struct UnflattenFromJSONParamBlock : public VarArgInstruction
+struct UnflattenFromJSONParamBlock : VarArgInstruction
 {
     _ParamDef(StringRef, jsonString);
     _ParamImmediateDef(StaticTypeAndData, arg1[1]);

--- a/source/core/TypeAndDataManager.cpp
+++ b/source/core/TypeAndDataManager.cpp
@@ -3014,7 +3014,7 @@ VIREO_FUNCTION_SIGNATURE4(TypeMakeVectorType, TypeManagerRef, TypeRef, TypeRef, 
     return _NextInstruction();
 }
 //------------------------------------------------------------
-struct TypeMakeClusterTypeParamBlock : public VarArgInstruction
+struct TypeMakeClusterTypeParamBlock : VarArgInstruction
 {
     _ParamDef(TypeManagerRef, tm);
     _ParamDef(TypeRef, computedType);

--- a/source/include/Instruction.h
+++ b/source/include/Instruction.h
@@ -53,14 +53,14 @@ struct InstructionCore
 
 //------------------------------------------------------------
 // A struct used for accessing any number or arguments in a non type strict way.
-struct GenericInstruction : public InstructionCore
+struct GenericInstruction : InstructionCore
 {
     void* _args[1];  // may be zero or more elements
 };
 
 //------------------------------------------------------------
 // Struct for var arg functions
-struct VarArgInstruction : public InstructionCore
+struct VarArgInstruction : InstructionCore
 {
     size_t _count;   // may be zero or more arguments in addition to the count
 };
@@ -75,56 +75,56 @@ struct VarArgInstruction : public InstructionCore
     return ( (InstructionCore*) ((size_t*)((VarArgInstruction*)this + 1) + (int)this->_count) ); }
 
 template <class type0>
-struct Instruction1 : public InstructionCore
+struct Instruction1 : InstructionCore
 {
     type0* _p0;
     NEXT_INSTRUCTION_METHOD()
 };
 
 template <class type0, class type1>
-struct Instruction2 : public Instruction1<type0>
+struct Instruction2 : Instruction1<type0>
 {
     type1* _p1;
     NEXT_INSTRUCTION_METHOD()
 };
 
 template <class type0, class type1, class type2>
-struct Instruction3 : public Instruction2<type0, type1>
+struct Instruction3 : Instruction2<type0, type1>
 {
     type2* _p2;
     NEXT_INSTRUCTION_METHOD()
 };
 
 template <class type0, class type1, class type2, class type3>
-struct Instruction4 : public Instruction3<type0, type1, type2>
+struct Instruction4 : Instruction3<type0, type1, type2>
 {
     type3* _p3;
     NEXT_INSTRUCTION_METHOD()
 };
 
 template <class type0, class type1, class type2, class type3, class type4>
-struct Instruction5 : public Instruction4<type0, type1, type2, type3>
+struct Instruction5 : Instruction4<type0, type1, type2, type3>
 {
     type4* _p4;
     NEXT_INSTRUCTION_METHOD()
 };
 
 template <class type0, class type1, class type2, class type3, class type4, class type5>
-struct Instruction6 : public Instruction5<type0, type1, type2, type3, type4>
+struct Instruction6 : Instruction5<type0, type1, type2, type3, type4>
 {
     type5* _p5;
     NEXT_INSTRUCTION_METHOD()
 };
 
 template <class type0, class type1, class type2, class type3, class type4, class type5, class type6>
-struct Instruction7 : public Instruction6<type0, type1, type2, type3, type4, type5>
+struct Instruction7 : Instruction6<type0, type1, type2, type3, type4, type5>
 {
     type6* _p6;
     NEXT_INSTRUCTION_METHOD()
 };
 
 template <class type0, class type1, class type2, class type3, class type4, class type5, class type6, class type7>
-struct Instruction8 : public Instruction7<type0, type1, type2, type3, type4, type5, type6>
+struct Instruction8 : Instruction7<type0, type1, type2, type3, type4, type5, type6>
 {
     type7* _p7;
     NEXT_INSTRUCTION_METHOD()
@@ -132,7 +132,7 @@ struct Instruction8 : public Instruction7<type0, type1, type2, type3, type4, typ
 
 template <class type0, class type1, class type2, class type3, class type4, class type5, class type6,
     class type7, class type8>
-struct Instruction9 : public Instruction8<type0, type1, type2, type3, type4, type5, type6, type7>
+struct Instruction9 : Instruction8<type0, type1, type2, type3, type4, type5, type6, type7>
 {
     type8* _p8;
     NEXT_INSTRUCTION_METHOD()
@@ -140,7 +140,7 @@ struct Instruction9 : public Instruction8<type0, type1, type2, type3, type4, typ
 
 template <class type0, class type1, class type2, class type3, class type4, class type5, class type6,
     class type7, class type8, class type9>
-struct Instruction10 : public Instruction9<type0, type1, type2, type3, type4, type5, type6, type7, type8>
+struct Instruction10 : Instruction9<type0, type1, type2, type3, type4, type5, type6, type7, type8>
 {
     type9* _p9;
     NEXT_INSTRUCTION_METHOD()

--- a/source/io/FileIO.cpp
+++ b/source/io/FileIO.cpp
@@ -48,7 +48,7 @@ typedef Int32 FileHandle;
 
 #ifdef VIREO_FILESYSTEM
 
-struct FileOpenInstruction : public InstructionCore
+struct FileOpenInstruction : InstructionCore
 {
     _ParamDef(StringRef, path);
 
@@ -347,7 +347,7 @@ VIREO_FUNCTION_SIGNATURE2(ListDirectory, StringRef, TypedArray1D<StringRef>*)
 
 #if defined(VIREO_VIA_FORMATTER)
 //------------------------------------------------------------
-struct PrintfParamBlock : public VarArgInstruction
+struct PrintfParamBlock : VarArgInstruction
 {
     _ParamDef(StringRef, format);
     _ParamImmediateDef(StaticTypeAndData, argument1[1]);

--- a/source/io/JavaScriptInvoke.cpp
+++ b/source/io/JavaScriptInvoke.cpp
@@ -44,7 +44,7 @@ VIREO_EXPORT void* JavaScriptInvoke_GetParameterTypeRef(StaticTypeAndData *param
 
 //------------------------------------------------------------
 // arguments: occurrence, isInternalFunction, errorCluster, functionName, returnValue, then variable number of inputs that can be nullptr or any type
-struct JavaScriptInvokeParamBlock : public VarArgInstruction
+struct JavaScriptInvokeParamBlock : VarArgInstruction
 {
     _ParamDef(OccurrenceRef, occurrence);
     _ParamDef(Boolean, isInternalFunction);

--- a/source/io/PropertyNode.cpp
+++ b/source/io/PropertyNode.cpp
@@ -40,7 +40,7 @@ extern void AddCallChainToSourceIfErrorPresent(ErrorCluster *errorCluster, Const
 extern void GenerateNotSupportedOnPlatformError(ErrorCluster *errorCluster, ConstCStr methodName);
 
 //------------------------------------------------------------
-struct PropertyNodeWriteParamBlock : public VarArgInstruction
+struct PropertyNodeWriteParamBlock : VarArgInstruction
 {
     _ParamDef(RefNumVal, refNum);
     _ParamDef(StringRef, propertyName);


### PR DESCRIPTION
The default inheritance type is public.