### PR TITLE
[Refactoring] Return non-const in operator overload

### DIFF
--- a/source/core/Timestamp.cpp
+++ b/source/core/Timestamp.cpp
@@ -148,21 +148,21 @@ namespace Vireo
         return wholeSeconds + fractionalSeconds;
     }
     //------------------------------------------------------------
-    Timestamp const Timestamp::operator+(const Int64& value) {
+    Timestamp Timestamp::operator+(const Int64& value) {
         Timestamp answer;
         answer._integer = _integer + value;
         answer._fraction = _fraction;
         return answer;
     }
     //------------------------------------------------------------
-    Timestamp const Timestamp::operator-(const Int64& value) {
+    Timestamp Timestamp::operator-(const Int64& value) {
         Timestamp answer;
         answer._integer = _integer - value;
         answer._fraction = _fraction;
         return answer;
     }
     //------------------------------------------------------------
-    Timestamp const Timestamp::operator+(const Timestamp& value) {
+    Timestamp Timestamp::operator+(const Timestamp& value) {
         Timestamp answer;
         answer._integer = _integer + value._integer;
         answer._fraction = _fraction + value._fraction;
@@ -172,7 +172,7 @@ namespace Vireo
         return answer;
     }
     //------------------------------------------------------------
-    Timestamp const Timestamp::operator-(const Timestamp& value) {
+    Timestamp Timestamp::operator-(const Timestamp& value) {
         Timestamp answer;
         answer._integer = _integer - value._integer;
         answer._fraction = _fraction - value._fraction;

--- a/source/include/Timestamp.h
+++ b/source/include/Timestamp.h
@@ -38,14 +38,14 @@ class Timestamp {
     UInt64 Fraction() const { return _fraction; }
 
     //! Add two timestamps, one operand should be relative.
-    Timestamp const operator+(const Timestamp & value);
+    Timestamp operator+(const Timestamp & value);
 
     //! Add integer number of seconds to a timestamp.
-    Timestamp const operator+(const Int64 & value);
-    Timestamp const operator-(const Int64 & value);
+    Timestamp operator+(const Int64 & value);
+    Timestamp operator-(const Int64 & value);
 
     //! Subtract two timestamps, result is a relative value.
-    Timestamp const operator-(const Timestamp & value);
+    Timestamp operator-(const Timestamp & value);
     Boolean operator==(const Timestamp & value) const {
         return ((_integer == value._integer) && (_fraction == value._fraction));
     }

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -351,7 +351,7 @@ class TypeManager
 IntMax ReadIntFromMemory(TypeRef type, void* pData);
 NIError WriteIntToMemory(TypeRef type, void* pData, IntMax value);
 Double ReadDoubleFromMemory(TypeRef type, const void* pData, NIError* errResult = nullptr);
-NIError WriteDoubleToMemory(TypeRef type, void* pData, const Double value);
+NIError WriteDoubleToMemory(TypeRef type, void* pData, Double value);
 IntMax ConvertNumericRange(EncodingEnum encoding, Int32 size, IntMax value);
 //------------------------------------------------------------
 //! Banker's rounding for Doubles.


### PR DESCRIPTION
See first answer of https://stackoverflow.com/questions/8716330/purpose-of-returning-by-const-value. Also resharper was giving a warning for this.