### PR TITLE
Initialize default values

### DIFF
--- a/source/include/Platform.h
+++ b/source/include/Platform.h
@@ -34,7 +34,7 @@ typedef String *StringRef;
 //! Process level functions for memory allocation.
 class PlatformMemory {
  private:
-    size_t _totalAllocated;
+    size_t _totalAllocated = 0;
  public:
     void* Malloc(size_t countAQ);
     void* Realloc(void* pBuffer, size_t countAQ);

--- a/source/include/RefNum.h
+++ b/source/include/RefNum.h
@@ -41,15 +41,15 @@ typedef intptr_t *RefNumDataPtr;
 class RefNumStorageBase
 {
  protected:
-    UInt32    _nextMagicNum;  // Magic Number to be used for creating next requested cookie
-    UInt32    _dataSize;      // Size of user-provided cookie info
-    UInt32    _cookieSize;    // Size of entire cookie including info
-    Int32    _firstFree;      // Index of first free cookie record
-    Int32   _numUsed;         // Total number of used cookies
+    UInt32    _nextMagicNum = 0;  // Magic Number to be used for creating next requested cookie
+    UInt32    _dataSize = 0;      // Size of user-provided cookie info
+    UInt32    _cookieSize = 0;    // Size of entire cookie including info
+    Int32    _firstFree = 0;      // Index of first free cookie record
+    Int32   _numUsed = 0;         // Total number of used cookies
 #ifdef  VIREO_MULTI_THREAD
     Mutex _mutex;    // Must have Acquired this mutex before read/writing to fields
 #endif
-    bool _isRefCounted;
+    bool _isRefCounted = false;
     struct RefNumHeaderAndData {
         RefNumCommonHeader _refHeader;
         intptr_t _refData;

--- a/source/include/Synchronization.h
+++ b/source/include/Synchronization.h
@@ -91,15 +91,15 @@ class Timer : public ObservableCore
 class QueueCore : public ObservableCore
 {
  private:
-    TypedArrayCoreRef _elements;
+    TypedArrayCoreRef _elements = nullptr;
 
     //! Index where the next element will be stored (may be one past end if full)
-    IntIndex   _insert;
+    IntIndex   _insert = 0;
 
     //! How many elements are in the queue
-    IntIndex   _count;
+    IntIndex   _count = 0;
 
-    IntIndex   _maxSize;
+    IntIndex   _maxSize = 0;
 
     IntIndex RemoveIndex();
  public:


### PR DESCRIPTION
We weren't explicitly declaring what the default values of these members were.