### PR TITLE
Fix bug in Date UTC support accidentally introduced in c835647c

### DIFF
--- a/source/core/Date.cpp
+++ b/source/core/Date.cpp
@@ -292,7 +292,7 @@ namespace Vireo {
         _daylightSavingTime = isDaylightSavingTime();
     }
 
-    Date::Date(Timestamp timestamp, bool isUTC) {
+    Date::Date(Timestamp timestamp, Boolean isUTC) {
 #ifdef VIREO_DATE_TIME_STDLIB
 #if !kVireoOS_windows
         struct tm tm;

--- a/source/include/DataTypes.h
+++ b/source/include/DataTypes.h
@@ -19,11 +19,7 @@ SDG
 
 #include "BuildConfig.h"
 
-#if defined (kVireoOS_macosxU)
-    typedef unsigned char Boolean;
-#else
-    typedef bool Boolean;
-#endif
+typedef bool Boolean;
 
 #define __STDC_LIMIT_MACROS
 #include <stdint.h>

--- a/source/include/Date.h
+++ b/source/include/Date.h
@@ -53,7 +53,7 @@ class Date {
  public:
     Date(Timestamp timestamp, Int32 timeZoneOffset);  // this API is conceptually wrong;
     // (tzo should be computed from UTC date)
-    explicit Date(Timestamp timestamp, bool isUTC = false);
+    explicit Date(Timestamp timestamp, Boolean isUTC = false);
     ~Date();
     static Int32 getLocaletimeZone(Int64 utcTime);
     Int32 Year() const { return _year; }


### PR DESCRIPTION
by Michael's code cleanup.

For unknown reasons, Boolean on Mac was typedef'd to unsigned char
instead of bool, causing the Boolean arg to the Date constructor to
pick the wrong overload after his change of 'isUTC ? true : false' to
be just 'isUTC' in 2nd arg of the Date() constructor..