### PR TITLE
Remove error logging for unhandled JS errors

### DIFF
--- a/source/core/module_coreHelpers.js
+++ b/source/core/module_coreHelpers.js
@@ -310,7 +310,7 @@ var assignCoreHelpers;
                 // Some browsers do not print the message in the stack so print both
                 if (typeof exception.message === 'string' && exception.message.length !== 0) {
                     additionalInfo = ', Additional information:\nMessage: ' + exception.message;
-                    if (typeof exception.stack === 'string' && exception.message.length !== 0) {
+                    if (typeof exception.stack === 'string' && exception.stack.length !== 0) {
                         additionalInfo += '\nStack: ' + exception.stack;
                     }
                     return messageText + additionalInfo;

--- a/source/core/module_coreHelpers.js
+++ b/source/core/module_coreHelpers.js
@@ -305,8 +305,16 @@ var assignCoreHelpers;
         };
 
         Module.coreHelpers.formatMessageWithException = function (messageText, exception) {
-            if (exception !== undefined && exception !== null && typeof exception.message === 'string' && exception.message.length !== 0) {
-                return messageText + ', Additional information: ' + exception.message;
+            var additionalInfo;
+            if (exception !== undefined && exception !== null) {
+                // Some browsers do not print the message in the stack so print both
+                if (typeof exception.message === 'string' && exception.message.length !== 0) {
+                    additionalInfo = ', Additional information:\nMessage: ' + exception.message;
+                    if (typeof exception.stack === 'string' && exception.message.length !== 0) {
+                        additionalInfo += '\nStack: ' + exception.stack;
+                    }
+                    return messageText + additionalInfo;
+                }
             }
 
             return messageText;

--- a/source/io/module_javaScriptInvoke.js
+++ b/source/io/module_javaScriptInvoke.js
@@ -287,7 +287,6 @@ var assignJavaScriptInvoke;
                 // to abort the runtime at this point. https://github.com/ni/VireoSDK/issues/521
                 throw returnValue;
             }
-            console.error(returnValue);
 
             mergeNewError(errorValueRef, functionName, ERRORS.kNIUnableToInvokeAJavaScriptFunction, returnValue);
             completionCallbackStatus.retrievalState = completionCallbackRetrievalEnum.UNRETRIEVABLE;

--- a/source/io/module_javaScriptInvoke.js
+++ b/source/io/module_javaScriptInvoke.js
@@ -273,6 +273,13 @@ var assignJavaScriptInvoke;
             REJECTED: 'REJECTED'
         };
 
+        var coerceToError = function (returnValue) {
+            if (returnValue instanceof Error === false) {
+                return new Error(returnValue);
+            }
+            return returnValue;
+        };
+
         var hasExecutionError = function (returnValue) {
             return returnValue instanceof Error;
         };
@@ -430,7 +437,7 @@ var assignJavaScriptInvoke;
             try {
                 returnValue = functionToCall.apply(context, parameters);
             } catch (ex) {
-                returnValue = ex;
+                returnValue = coerceToError(ex);
             }
 
             if (hasExecutionError(returnValue)) {
@@ -457,7 +464,7 @@ var assignJavaScriptInvoke;
                 }
 
                 completionCallback = jsapi.getCompletionCallback();
-                returnValue.then(completionCallback).catch(completionCallback);
+                returnValue.then(completionCallback).catch((returnValue) => completionCallback(coerceToError(returnValue)));
                 // Do not setOccurrence when returning here since waiting asynchronously for user Promise to resolve
                 return;
             }

--- a/test-it/karma/fixtures/javascriptinvoke/FunctionThatThrowsNumbers.via
+++ b/test-it/karma/fixtures/javascriptinvoke/FunctionThatThrowsNumbers.via
@@ -1,0 +1,16 @@
+define(MyVI dv(VirtualInstrument (
+    Locals: c(
+        e(c(
+            e(.Boolean status)
+            e(.Int32 code)
+            e(.String source)
+        ) error)
+        e(dv(.String "") return)
+        e(.Occurrence occurrence)
+    )
+    clump (
+        JavaScriptInvoke(occurrence false error 'NI_FunctionThatThrowsNumbers' return)
+    )
+) ) )
+
+enqueue(MyVI)

--- a/test-it/karma/javascriptinvoke/Async.Test.js
+++ b/test-it/karma/javascriptinvoke/Async.Test.js
@@ -167,8 +167,7 @@ describe('A JavaScript function invoke', function () {
                 expect(viPathParser('error.code')).toBe(44300);
                 expect(viPathParser('error.source')).toMatch(/Failed to run sync/);
                 expect(viPathParser('return')).toBe(0);
-                expect(console.error.calls.count()).toBe(1);
-                expect(console.error.calls.argsFor(0)).toMatch(/Failed to run sync/);
+                expect(console.error).not.toHaveBeenCalled();
             };
         });
         it('using the completion callback', async function () {
@@ -199,8 +198,7 @@ describe('A JavaScript function invoke', function () {
                 expect(viPathParser('error.code')).toBe(44300);
                 expect(viPathParser('error.source')).toMatch(/Failed to run microtask/);
                 expect(viPathParser('return')).toBe(0);
-                expect(console.error.calls.count()).toBe(1);
-                expect(console.error.calls.argsFor(0)).toMatch(/Failed to run microtask/);
+                expect(console.error).not.toHaveBeenCalled();
             };
         });
         it('using the completion callback', async function () {
@@ -238,8 +236,7 @@ describe('A JavaScript function invoke', function () {
                 expect(viPathParser('error.code')).toBe(44300);
                 expect(viPathParser('error.source')).toMatch(/Failed to run new task/);
                 expect(viPathParser('return')).toBe(0);
-                expect(console.error.calls.count()).toBe(1);
-                expect(console.error.calls.argsFor(0)).toMatch(/Failed to run new task/);
+                expect(console.error).not.toHaveBeenCalled();
             };
         });
         it('using the completion callback', async function () {
@@ -340,7 +337,7 @@ describe('A JavaScript function invoke', function () {
         });
     });
 
-    describe('errors retrieving completion callback twice without a try/catch are printed to console when', function () {
+    describe('errors retrieving completion callback twice without a try/catch when', function () {
         beforeEach(function () {
             spyOn(console, 'error');
             test = async function () {
@@ -354,7 +351,7 @@ describe('A JavaScript function invoke', function () {
                 const {rawPrint, rawPrintError} = await runSlicesAsync();
                 expect(rawPrint).toBeEmptyString();
                 expect(rawPrintError).toBeEmptyString();
-                expect(console.error).toHaveBeenCalled();
+                expect(console.error).not.toHaveBeenCalled();
                 expect(viPathParser('error.status')).toBeTrue();
                 expect(viPathParser('error.code')).toBe(44300);
                 expect(viPathParser('error.source')).toMatch(/retrieved more than once/);
@@ -648,8 +645,7 @@ describe('A JavaScript function invoke', function () {
                 expect(viPathParser('error.source')).toMatch(/This function is a failure!/);
                 expect(viPathParser('return')).toBe(0);
                 expect(jsapiStale.getCompletionCallback).toThrowError(/not valid anymore/);
-                expect(console.error.calls.count()).toBe(1);
-                expect(console.error.calls.argsFor(0)).toMatch(/This function is a failure!/);
+                expect(console.error).not.toHaveBeenCalled();
             };
         });
         it('using the synchronous functions', async function () {
@@ -689,8 +685,7 @@ describe('A JavaScript function invoke', function () {
                 expect(viPathParser('error.source')).toMatch(/Your function errored before completion callback!/);
                 expect(viPathParser('return')).toBe(0);
                 expect(completionCallbackStale).toThrowError(/callback cannot be invoked/);
-                expect(console.error.calls.count()).toBe(1);
-                expect(console.error.calls.argsFor(0)).toMatch(/Your function errored before completion callback!/);
+                expect(console.error).not.toHaveBeenCalled();
             };
         });
         it('using the completion callback', async function () {

--- a/test-it/karma/javascriptinvoke/Simple.Test.js
+++ b/test-it/karma/javascriptinvoke/Simple.Test.js
@@ -153,12 +153,12 @@ describe('A JavaScript function invoke', function () {
         });
     });
 
-    describe('logs error', function () {
+    describe('does not log error', function () {
         beforeEach(function () {
             spyOn(console, 'error');
         });
 
-        it('errors when function throws an exception', function (done) {
+        it('when function throws an exception', function (done) {
             var runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, jsFunctionThatThrowsViaUrl);
             var viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
 
@@ -168,8 +168,7 @@ describe('A JavaScript function invoke', function () {
                 expect(viPathParser('error.status')).toBeTrue();
                 expect([kNIUnableToInvokeAJavaScriptFunction]).toContain(viPathParser('error.code'));
                 expect(viPathParser('error.source')).toMatch(/JavaScriptInvoke in MyVI/);
-                expect(console.error.calls.count()).toBe(1);
-                expect(console.error.calls.argsFor(0)).toMatch(/This function throws/);
+                expect(console.error).not.toHaveBeenCalled();
                 done();
             });
         });


### PR DESCRIPTION
Previously in https://github.com/ni/VireoSDK/pull/541, we introduced error logging for uncaught JS errors from users. The assumption was that all JS exceptions caught by JavaScriptInvoke were unexpected / unhandled and worthy of logging for additional context for the user.

While implementing the WebSockets api we found it was necessary to report JS errors back to a GVI to handle from the LabVIEW NXG diagram. So we have to signal to NXG that a JavaScriptInvoke call is in an expected error state. While internal functions are capable of reporting that state through the jsapi.setLabVIEWError function, that capability is not available to general JavaScriptInvoke users yet (and we are not confident the setLabVIEWError api is necessarily a good enough api to expose to users yet).

Instead we will disable the console logging JS errors feature as some of the initial concerns are already mitigated by the automatic error handling feature. This PR also improves the quality of JS errors reported to the error wire by including the JS stack trace as well which further mitigates the need to perform the console logging.

Lastly, during implementation it was observed that it is possible for JS users to throw non-error objects and those would be treated as return values instead of as errors. This change includes a fix such that when we are on a known error path (synchronous catch or Promise reject) we coerce the thrown value to an Error object so that it is consistently reported as an error.