### PR TITLE
Refactor Events files

### DIFF
--- a/source/core/EventLog.cpp
+++ b/source/core/EventLog.cpp
@@ -10,15 +10,15 @@ SDG
 /*! \file
  */
 
-#include <stdio.h>
+#include <cstdio>
 #include "TypeAndDataManager.h"
 #include "EventLog.h"
 
 namespace Vireo {
 
 //------------------------------------------------------------
-StringRef EventLog::DevNull = (StringRef) nullptr;
-StringRef EventLog::StdOut = (StringRef) 1;
+StringRef EventLog::DevNull = static_cast<StringRef>(nullptr);
+StringRef EventLog::StdOut = reinterpret_cast<StringRef>(1);
 
 //------------------------------------------------------------
 EventLog::EventLog(StringRef str)
@@ -86,7 +86,7 @@ void EventLog::LogEventCore(EventSeverity severity, Int32 lineNumber, ConstCStr 
     if (_errorLog == StdOut) {
         gPlatform.IO.Print(buffer);
     } else if (_errorLog) {
-        _errorLog->Append(length, (const Utf8Char*)buffer);
+        _errorLog->Append(length, reinterpret_cast<const Utf8Char*>(buffer));
     }
 }
 

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -222,17 +222,17 @@ void EventOracle::OccurEvent(EventOracleIndex eventOracleIdx, const EventData &e
     if (UInt32(eventOracleIdx) < _eventReg.size()) {
         EventRegList &eRegList = _eventReg[eventOracleIdx]._eRegList;
         auto eRegIter = eRegList.begin();
-        const EventRegList::iterator eRegIterEnd = eRegList.end();
+        auto eRegIterEnd = eRegList.end();
         while (eRegIter != eRegIterEnd && (eRegIter->_eventSource != eData.common.eventSource
                                            || eRegIter->_eventType != eData.common.eventType))
             ++eRegIter;
 
         if (eRegIter != eRegIterEnd) {
             auto rqIter = eRegIter->_qIDList.begin();
-            const auto rqIterEnd = eRegIter->_qIDList.end();
-            const RefNum ref = eData.common.eventRef.GetRefNum();
+            auto rqIterEnd = eRegIter->_qIDList.end();
+            RefNum ref = eData.common.eventRef.GetRefNum();
             while (rqIter != rqIterEnd) {
-                const RefNum rRef = rqIter->_ref;
+                RefNum rRef = rqIter->_ref;
                 if (rRef == ref)
                     _qObject[rqIter->_qID].OccurEvent(eData);
                 ++rqIter;
@@ -258,12 +258,12 @@ EventOracle::EventInsertStatus EventOracle::EventListInsert(EventOracleIndex eve
     EventInsertStatus added = kNoChange;
     EventRegList &eRegList = _eventReg[eventOracleIndex]._eRegList;
     auto eRegIter = eRegList.begin();
-    const EventRegList::iterator eRegIterEnd = eRegList.end();
+    auto eRegIterEnd = eRegList.end();
     while (eRegIter != eRegIterEnd && (eRegIter->_eventSource != eSource || eRegIter->_eventType != eType))
         ++eRegIter;
     if (eRegIter != eRegIterEnd) {  // found registration matching event source/type
         auto rqIter = eRegIter->_qIDList.begin();
-        const auto rqIterEnd = eRegIter->_qIDList.end();
+        auto rqIterEnd = eRegIter->_qIDList.end();
         while (rqIter != rqIterEnd && (rqIter->_qID != eventRegQueueID._qID || rqIter->_ref != eventRegQueueID._ref))
             ++rqIter;
         if (rqIter == rqIterEnd) {  // ref/qID not found, add it
@@ -286,12 +286,12 @@ bool EventOracle::EventListRemove(EventOracleIndex eventOracleIndex, EventRegQue
         return removed;
     EventRegList &eRegList = _eventReg[eventOracleIndex]._eRegList;
     auto eRegIter = eRegList.begin();
-    const auto eRegIterEnd = eRegList.end();
+    auto eRegIterEnd = eRegList.end();
     while (eRegIter != eRegIterEnd && (eRegIter->_eventSource != eSource || eRegIter->_eventType != eType))
         ++eRegIter;
     if (eRegIter != eRegIterEnd) {  // found registration matching event source/type
         auto rqIter = eRegIter->_qIDList.begin();
-        const auto rqIterEnd = eRegIter->_qIDList.end();
+        auto rqIterEnd = eRegIter->_qIDList.end();
         while (rqIter != rqIterEnd && (rqIter->_qID != eventRegQueueID._qID || rqIter->_ref != eventRegQueueID._ref))
             ++rqIter;
         if (rqIter != rqIterEnd) {  // ref/qID found, remove it
@@ -365,7 +365,7 @@ bool EventOracle::UnregisterForEvent(EventQueueID qID, EventSource eSource, Even
 // event reg. refnum input.
 bool EventOracle::GetNewQueueObject(EventQueueID *qID, OccurrenceCore *occurrence) {
     auto qoIter = _qObject.begin()+1;  // skip the first QueueID; reserved as kNotAQueueID
-    const auto qoIterEnd = _qObject.end();
+    auto qoIterEnd = _qObject.end();
     while (qoIter != qoIterEnd && qoIter->GetStatus() != EventQueueObject::kQIDFree)
         ++qoIter;
     if (qoIter != qoIterEnd) {
@@ -476,7 +476,7 @@ class DynamicEventRegInfo {
     }
 
     ~DynamicEventRegInfo() {
-         for (auto& entry : _entry)
+         for (const auto& entry : _entry)
          {
              // Free any allocated polymorphic event reg. data
              if ((entry.regFlags & kEventRegFlagsPolyData)) {
@@ -569,9 +569,9 @@ void GetVIName(VirtualInstrument *vi, StringRef viName) {
 void RegisterForControlEvent(EventInfo *eventInfo, EventSpec eventSpec, StringRef viName, EventQueueID qID, UInt32 controlID, RefNum reference,
                         bool registerControlEvent) {
     EventOracleIndex eventOracleIdx = kNotAnEventOracleIdx;
-    const EventType eventType = eventSpec.eventType;
-    const EventSource eSource = eventSpec.eventSource;
-    const EventOracle::EventInsertStatus status = EventOracle::TheEventOracle().RegisterForEvent(qID, eSource, eventType, controlID, reference,
+    EventType eventType = eventSpec.eventType;
+    EventSource eSource = eventSpec.eventSource;
+    EventOracle::EventInsertStatus status = EventOracle::TheEventOracle().RegisterForEvent(qID, eSource, eventType, controlID, reference,
                                 &eventOracleIdx);
     // gPlatform.IO.Printf("Static Register for VI %*s controlID %d, event %d, eventOracleIdx %d\n",
     //                     viName->Length(), viName->Begin(), controlID, eventType, eventOracleIdx);
@@ -588,18 +588,18 @@ void RegisterForControlEvent(EventInfo *eventInfo, EventSpec eventSpec, StringRe
 void RegisterForStaticEvents(VirtualInstrument *vi) {
     TypedObjectRef eventStructSpecsRef = vi->EventSpecs();
     const Int32 numEventStructs = eventStructSpecsRef->ElementType()->SubElementCount();
-    const auto eventInfo = new EventInfo(numEventStructs);
+    auto eventInfo = new EventInfo(numEventStructs);
 
     for (Int32 eventStructIndex = 0; eventStructIndex < numEventStructs; ++eventStructIndex) {
         TypeRef eventSpecType = eventStructSpecsRef->ElementType()->GetSubElement(eventStructIndex);
         AQBlock1 *eventSpecClustPtr = eventStructSpecsRef->RawBegin() + eventSpecType->ElementOffset();
-        const auto eventSpecRef = reinterpret_cast<EventSpecRef>(eventSpecClustPtr);
+        auto eventSpecRef = reinterpret_cast<EventSpecRef>(eventSpecClustPtr);
         const Int32 eventSpecCount = eventSpecType->SubElementCount();
         EventQueueID qID = kNotAQueueID;
         EventOracle::TheEventOracle().GetNewQueueObject(&qID, nullptr);
         // TODO(segaljared): remove this when we no longer use ControlRefNum
         for (Int32 eventSpecIndex = 0; eventSpecIndex < eventSpecCount; ++eventSpecIndex) {
-            const auto controlRef = static_cast<ControlRefNum>(eventSpecRef[eventSpecIndex].eventControlRef);
+            auto controlRef = static_cast<ControlRefNum>(eventSpecRef[eventSpecIndex].eventControlRef);
             if (controlRef) {
                 StringRef tag = nullptr;
                 if (ControlReferenceLookup(controlRef, nullptr, &tag) == kNIError_Success) {
@@ -607,7 +607,7 @@ void RegisterForStaticEvents(VirtualInstrument *vi) {
                     StringRef viName = viNameVar.Value;
                     GetVIName(vi, viName);
                     TempStackCString tagCString(tag->Begin(), tag->Length());
-                    const EventControlUID controlID = Int32(strtol(tagCString.BeginCStr(), nullptr, 10));
+                    EventControlUID controlID = Int32(strtol(tagCString.BeginCStr(), nullptr, 10));
                     if (controlID) {
                         RegisterForControlEvent(eventInfo, eventSpecRef[eventSpecIndex], viName, qID, controlID, controlRef, true);
                     }
@@ -627,11 +627,11 @@ void ConfigureEventSpecForJSRef(VirtualInstrument *vi, Int32 eventStructIndex, I
     if (eventStructIndex < numEventStructs) {
         TypeRef eventSpecType = eventStructSpecsRef->ElementType()->GetSubElement(eventStructIndex);
         AQBlock1 *eventSpecClustPtr = eventStructSpecsRef->RawBegin() + eventSpecType->ElementOffset();
-        const auto eventSpecRef = reinterpret_cast<EventSpecRef>(eventSpecClustPtr);
+        auto eventSpecRef = reinterpret_cast<EventSpecRef>(eventSpecClustPtr);
         const Int32 eventSpecCount = eventSpecType->SubElementCount();
         if (eventSpecIndex < eventSpecCount) {
-            const EventQueueID qID = eventInfo->eventStructInfo[eventStructIndex].staticQID;
-            const auto controlID = static_cast<EventControlUID>(eventSpecRef[eventSpecIndex].eventControlRef);
+            EventQueueID qID = eventInfo->eventStructInfo[eventStructIndex].staticQID;
+            auto controlID = static_cast<EventControlUID>(eventSpecRef[eventSpecIndex].eventControlRef);
             if (controlID) {
                 STACK_VAR(String, viNameVar);
                 StringRef viName = viNameVar.Value;
@@ -658,17 +658,17 @@ void UnregisterForStaticEvents(VirtualInstrument *vi) {
         for (Int32 eventStructIndex = 0; eventStructIndex < numEventStructs; ++eventStructIndex) {
             TypeRef eventSpecType = eventStructSpecsRef->ElementType()->GetSubElement(eventStructIndex);
             AQBlock1 *eventSpecClustPtr = eventStructSpecsRef->RawBegin() + eventSpecType->ElementOffset();
-            const auto eventSpecRef = reinterpret_cast<EventSpecRef>(eventSpecClustPtr);
+            auto eventSpecRef = reinterpret_cast<EventSpecRef>(eventSpecClustPtr);
             const Int32 eventSpecCount = eventSpecType->SubElementCount();
-            const EventQueueID qID =  eventInfo->eventStructInfo[eventStructIndex].staticQID;
+            EventQueueID qID =  eventInfo->eventStructInfo[eventStructIndex].staticQID;
             for (Int32 eventSpecIndex = 0; eventSpecIndex < eventSpecCount; ++eventSpecIndex) {
                 RefNum controlRef = eventSpecRef[eventSpecIndex].eventControlRef;
                 if (controlRef) {
                     auto ciIter = eventInfo->controlIDInfoMap.find(controlRef);
                     if (ciIter != eventInfo->controlIDInfoMap.end()) {
-                        const EventOracleIndex eventOracleIdx = ciIter->second.eventOracleIndex;
-                        const EventType eventType = eventSpecRef[eventSpecIndex].eventType;
-                        const EventSource eSource = eventSpecRef[eventSpecIndex].eventSource;
+                        EventOracleIndex eventOracleIdx = ciIter->second.eventOracleIndex;
+                        EventType eventType = eventSpecRef[eventSpecIndex].eventType;
+                        EventSource eSource = eventSpecRef[eventSpecIndex].eventSource;
 
                         EventOracle::TheEventOracle().UnregisterForEvent(qID, eSource, eventType, eventOracleIdx, controlRef);
                         // gPlatform.IO.Printf("Static Unregister for VI %*s controlID %d, event %d, eventOracleIdx %d\n",
@@ -689,7 +689,7 @@ void UnregisterForStaticEvents(VirtualInstrument *vi) {
 
 // Cleanup Proc for disposing user event refnums when top-level VI finishes
 static void CleanUpUserEventRefNum(intptr_t arg) {
-    const RefNum refnum = RefNum(arg);
+    RefNum refnum = RefNum(arg);
     void *userEventRef = nullptr;
     UserEventRefNumManager::RefNumStorage().DisposeRefNum(refnum, &userEventRef);
 }
@@ -711,7 +711,7 @@ VIREO_FUNCTION_SIGNATURE2(UserEventRef_Create, RefNumVal, ErrorCluster)
         errCode = kEventArgErr;
     } else {
         // Unlike Queue_Obtain, we don't need to calll InitData on ref here. No actual data allocated for event until the event is fired.
-        const RefNum refnum = UserEventRefNumManager::RefNumStorage().NewRefNum(&userEventRef);
+        RefNum refnum = UserEventRefNumManager::RefNumStorage().NewRefNum(&userEventRef);
         refnumPtr->SetRefNum(refnum);
 
         VirtualInstrument* vi = THREAD_CLUMP()->TopVI();
@@ -782,10 +782,10 @@ static bool UnregisterForEventsAux(RefNum refnum) {
     DynamicEventRegInfo *regInfo = nullptr;
     if (EventRegistrationRefNumManager::RefNumStorage().DisposeRefNum(refnum, &regInfo) != kNIError_Success || !regInfo)
         return false;
-    const EventQueueID qID = regInfo->_qID;
+    EventQueueID qID = regInfo->_qID;
     EventOracle::TheEventOracle().DeleteEventQueue(qID);
     auto regInfoEntryIter = regInfo->_entry.begin();
-    const std::vector<DynamicEventRegEntry>::iterator regInfoEntryIterEnd = regInfo->_entry.end();
+    auto regInfoEntryIterEnd = regInfo->_entry.end();
     while (regInfoEntryIter != regInfoEntryIterEnd) {
         EventOracle::TheEventOracle().UnregisterForEvent(qID, regInfoEntryIter->eventSource, regInfoEntryIter->eventType,
                                                          kAppEventOracleIdx, regInfoEntryIter->refnumEntry.GetRefNum());
@@ -797,7 +797,7 @@ static bool UnregisterForEventsAux(RefNum refnum) {
 
 // Cleanup Proc for disposing event reg. refnums when top-level VI finishes
 static void CleanUpEventRegRefNum(intptr_t arg) {
-    const RefNum refnum = RefNum(arg);
+    RefNum refnum = RefNum(arg);
     UnregisterForEventsAux(refnum);
 }
 
@@ -845,7 +845,7 @@ LVError RegisterForEventsCore(EventQueueID qID, DynamicEventRegInfo *regInfo, In
         }
     } else if (refType->IsCluster()) {
         // Cluster of ... (recursive, can be scalar ref, array of scalar ref, or another cluster).
-        const auto refClustPtr = static_cast<AQBlock1*>(pData);
+        auto refClustPtr = static_cast<AQBlock1*>(pData);
         auto oldEltPtr = static_cast<AQBlock1*>(pOldData);
         const Int32 numElts = refType->SubElementCount();
         for (Int32 j = 0; j < numElts; ++j) {
@@ -962,7 +962,7 @@ VIREO_FUNCTION_SIGNATUREV(RegisterForEvents, RegisterForEventsParamBlock)
                 regInfo->_entry.emplace_back(eSource, eventType, pDataCopy, regRefType);
             }
         }
-        const LVError err = RegisterForEventsCore(qID, regInfo, refInput, regRefType, eSource, eventType,
+        LVError err = RegisterForEventsCore(qID, regInfo, refInput, regRefType, eSource, eventType,
                                             pDataCopy, isRereg ? oldRef : nullptr);
         if (err) {
             if (!isRereg && !regRefType->IsRefnum()) {
@@ -1025,7 +1025,7 @@ VIREO_FUNCTION_SIGNATUREV(WaitForEventsAndDispatch, WaitForEventsParamBlock)
     }
     RefNumVal* eventRegRefnumPtr = static_cast<RefNumVal*>(regRefArg[0]._pData);
 
-    const Int32 eventStructIndex = _Param(eventStructIndex);
+    Int32 eventStructIndex = _Param(eventStructIndex);
     const Int32 numberOfFixedArgs = 4;
     const Int32 numArgsPerTuple = 4;  // <evemtSpecIndex, data, branchTarget>; data is StaticTypeAndData so counts as two args
     const Int32 numTuples = (_ParamVarArgCount() - numberOfFixedArgs) / numArgsPerTuple;
@@ -1057,7 +1057,7 @@ VIREO_FUNCTION_SIGNATUREV(WaitForEventsAndDispatch, WaitForEventsParamBlock)
     TypeRef eventSpecType = eventStructSpecsRef->ElementType()->GetSubElement(eventStructIndex);
     const UInt32 esCount = UInt32(eventSpecType->SubElementCount());
     AQBlock1 *eventSpecClustPtr = eventStructSpecsRef->RawBegin() + eventSpecType->ElementOffset();
-    const auto eventSpecRef = reinterpret_cast<EventSpecRef>(eventSpecClustPtr);
+    auto eventSpecRef = reinterpret_cast<EventSpecRef>(eventSpecClustPtr);
     {
         Int32 &staticCount = eventInfo->eventStructInfo[eventStructIndex].setCount;
 
@@ -1066,7 +1066,7 @@ VIREO_FUNCTION_SIGNATUREV(WaitForEventsAndDispatch, WaitForEventsParamBlock)
         if (!occ.HasOccurred(staticCount, false)) {
             Observer* pObserver = clump->GetObservationStates(2);
             if (!pObserver) {
-                const PlatformTickType future = msTimeout > 0 ? gPlatform.Timer.MillisecondsFromNowToTickCount(msTimeout) : 0;
+                PlatformTickType future = msTimeout > 0 ? gPlatform.Timer.MillisecondsFromNowToTickCount(msTimeout) : 0;
                 pObserver = clump->ReserveObservationStatesWithTimeout(2, future);
                 occ.InsertObserver(pObserver+1, occ.Count()+1);
                 return clump->WaitOnObservableObject(_this);
@@ -1080,7 +1080,7 @@ VIREO_FUNCTION_SIGNATUREV(WaitForEventsAndDispatch, WaitForEventsParamBlock)
 
     // If regRefCount > 0 (cluster of reg refnums passed), find queue with earliest event timestamp
     Int32 dynIndex = 0;
-    const Int32 regRefIndex = EventOracle::TheEventOracle().GetPendingEventInfo(&eventQID, regRefCount, eventRegRefnumPtr, &dynIndex);
+    Int32 regRefIndex = EventOracle::TheEventOracle().GetPendingEventInfo(&eventQID, regRefCount, eventRegRefnumPtr, &dynIndex);
     DynamicEventRegInfo *regInfo = nullptr;
     if (regRefIndex > 0 && eventRegRefnumPtr
         && EventRegistrationRefNumManager::RefNumStorage().GetRefNumData(eventRegRefnumPtr[regRefIndex-1].GetRefNum(), &regInfo) == kNIError_Success) {
@@ -1098,7 +1098,7 @@ VIREO_FUNCTION_SIGNATUREV(WaitForEventsAndDispatch, WaitForEventsParamBlock)
         dynIndex += regInfo->DynamicEventMatch(eventData.common, eventRegRefType->GetSubElement(0));
     }
     for (Int32 inputTuple = 0; inputTuple < numTuples; ++inputTuple) {
-        const UInt32 eventSpecIndex = *arguments[inputTuple].eventSpecIndex;
+        UInt32 eventSpecIndex = *arguments[inputTuple].eventSpecIndex;
         if (eventSpecIndex >= esCount) {
             THREAD_EXEC()->LogEvent(EventLog::kHardDataError, "Invalid Event Spec Index");
             return THREAD_EXEC()->Stop();
@@ -1177,7 +1177,7 @@ VIREO_FUNCTION_SIGNATUREV(WaitForEventsAndDispatch, WaitForEventsParamBlock)
 
 void OccurEvent(UInt32 eventOracleIndex, UInt32 controlID, UInt32 eventType, UInt32 ref, TypeRef eventDataType, void *eventData)
 {
-    const EventSource eventSource = GetEventSourceForEventType(eventType);
+    EventSource eventSource = GetEventSourceForEventType(eventType);
     EventData eData;
     eData.Init(eventSource, eventType, RefNumVal(ref), eventDataType, eventData);
     eData.controlUID = controlID;
@@ -1204,13 +1204,13 @@ VIREO_EXPORT void OccurEvent(TypeManagerRef tm, UInt32 eventOracleIndex, UInt32 
 VIREO_FUNCTION_SIGNATURE3(_OccurEvent, RefNumVal, UInt32, UInt32)
 {
     RefNumVal controlRefVal = _Param(0);
-    const UInt32 eventSource = _Param(1);
-    const UInt32 eventType = _Param(2);
+    UInt32 eventSource = _Param(1);
+    UInt32 eventType = _Param(2);
     VirtualInstrument *owningVI = THREAD_CLUMP()->OwningVI();
     EventInfo *eventInfo = owningVI->GetEventInfo();
     EventOracleIndex eventOracleIdx = kNotAnEventOracleIdx;
     EventControlUID controlID = 0;
-    const RefNum ref = controlRefVal.GetRefNum();
+    RefNum ref = controlRefVal.GetRefNum();
     if (eventInfo) {
         EventControlInfo *ecInfo = &eventInfo->controlIDInfoMap[ref];
         eventOracleIdx = ecInfo->eventOracleIndex;
@@ -1227,9 +1227,9 @@ VIREO_FUNCTION_SIGNATURE3(_OccurEvent, RefNumVal, UInt32, UInt32)
 
 VIREO_FUNCTION_SIGNATURE3(ConfigureEventSpecJSRef, Int32, Int32, JavaScriptRefNum)
 {
-    const Int32 eventStructIndex = _Param(0);
-    const Int32 eventSpecIndex = _Param(1);
-    const JavaScriptRefNum jsRefNum = _Param(2);
+    Int32 eventStructIndex = _Param(0);
+    Int32 eventSpecIndex = _Param(1);
+    JavaScriptRefNum jsRefNum = _Param(2);
     if (jsRefNum == 0) {
         THREAD_EXEC()->LogEvent(EventLog::kSoftDataError, "JavaScriptRefNum must not be null");
         return THREAD_EXEC()->Stop();
@@ -1242,7 +1242,7 @@ VIREO_FUNCTION_SIGNATURE3(ConfigureEventSpecJSRef, Int32, Int32, JavaScriptRefNu
 
 VIREO_FUNCTION_SIGNATURE2(RegisterForJSEvent, JavaScriptRefNum, UInt32)
 {
-    const JavaScriptRefNum jsRefNum = _Param(0);
+    JavaScriptRefNum jsRefNum = _Param(0);
     if (jsRefNum == 0) {
         THREAD_EXEC()->LogEvent(EventLog::kSoftDataError, "JavaScriptRefNum must not be null");
         return THREAD_EXEC()->Stop();

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -428,9 +428,7 @@ class DynamicEventRegInfo {
         if (regRefType->IsRefnum() && pData && (static_cast<RefNumVal*>(pData)->GetRefNum() == refnum)) {
             dynIndex = *dynIndexBase;
             return dynIndex;
-        }
-
-        if (regRefType->IsArray() && regRefType->Rank() == 1 && regRefType->GetSubElement(0)->IsRefnum()) {
+        } else if (regRefType->IsArray() && regRefType->Rank() == 1 && regRefType->GetSubElement(0)->IsRefnum()) {
             TypedArray1D<RefNumVal> *aRef = *static_cast<TypedArray1D<RefNumVal>**>(pData);
             RefNumVal *aPtr = aRef->BeginAt(0);
             for (Int32 i = 0; i < aRef->Length(); ++i) {
@@ -443,7 +441,7 @@ class DynamicEventRegInfo {
         } else if (regRefType->IsCluster()) {
             AQBlock1 *refClustPtr = static_cast<AQBlock1*>(pData);
             const Int32 numElts = regRefType->SubElementCount();
-            ++*dynIndexBase;  // the whole cluster counts as one, matching the rules for unbundler recursive indexes
+            ++*dynIndexBase;  // the whole cluster counts as one, matching the rules for un undler recursive indexes
             for (Int32 j = 0; j < numElts; ++j) {
                 TypeRef eltType = regRefType->GetSubElement(j);
                 AQBlock1* eltPtr = refClustPtr + eltType->ElementOffset();
@@ -550,7 +548,7 @@ struct EventSpec {  // Specifier for Event structure configuration data
 typedef EventSpec *EventSpecRef;
 
 // GetEventSourceForEventType -- return the EventSource associated with an event type
-static EventSource GetEventSourceForEventType(EventType eType) {
+inline static EventSource GetEventSourceForEventType(EventType eType) {
     EventSource eSource = kEventSourceLVUserInt;
     if (eType == kEventTypeUserEvent)
         eSource = kEventSourceUserEvent;

--- a/source/include/EventLog.h
+++ b/source/include/EventLog.h
@@ -14,7 +14,7 @@ SDG
 #ifndef EventLog_h
 #define EventLog_h
 
-#include <stdarg.h>
+#include <cstdarg>
 #include "TypeAndDataManager.h"
 
 namespace Vireo {
@@ -45,9 +45,9 @@ class EventLog {
     };
 
     explicit EventLog(StringRef str);
-    Int32 TotalErrorCount()                 { return _softErrorCount + _hardErrorCount; }
-    Int32 HardErrorCount()                  { return  _hardErrorCount; }
-    Int32 WarningCount()                    { return _warningCount; }
+    Int32 TotalErrorCount() const { return _softErrorCount + _hardErrorCount; }
+    Int32 HardErrorCount() const { return  _hardErrorCount; }
+    Int32 WarningCount() const { return _warningCount; }
     void LogEventV(EventSeverity severity, Int32 lineNumber, ConstCStr message, va_list args);
     void LogEvent(EventSeverity severity, Int32 lineNumber, ConstCStr message, ...);
     void LogEventCore(EventSeverity severity, Int32 lineNumber, ConstCStr message);

--- a/source/include/Events.h
+++ b/source/include/Events.h
@@ -78,17 +78,17 @@ struct EventCommonData {
 
     void InitEventTime() { eventTime = UInt32(gPlatform.Timer.TickCountToMilliseconds(gPlatform.Timer.TickCount())); }
 
-    EventCommonData(const UInt32 source, const UInt32 type) : eventSource(source), eventType(type), eventSeqIndex(0) {
+    EventCommonData(UInt32 source, UInt32 type) : eventSource(source), eventType(type), eventSeqIndex(0) {
         InitEventTime();
     }
 
-    EventCommonData(const UInt32 source, UInt32 type, const RefNumVal &ref) : eventSource(source), eventType(type), eventSeqIndex(0), eventRef(ref) {
+    EventCommonData(UInt32 source, UInt32 type, const RefNumVal &ref) : eventSource(source), eventType(type), eventSeqIndex(0), eventRef(ref) {
         InitEventTime();
     }
 };
 
 // Compare two event time stamps or sequence numbers, allowing for wrapping
-inline Int32 EventTimeSeqCompare(const UInt32 t1, const UInt32 t2) {
+inline Int32 EventTimeSeqCompare(UInt32 t1, UInt32 t2) {
     return Int32(t1 - t2);
 }
 
@@ -106,11 +106,11 @@ struct EventData {
     void *pEventData;
 
     EventData() : common(0, 0, RefNumVal()), controlUID(kNotAnEventControlUID), eventDataType(nullptr), pEventData(nullptr) { }
-    EventData(const EventSource source, const EventType type, const RefNumVal &ref, TypeRef edtype = nullptr, void *pData = nullptr) :
+    EventData(EventSource source, EventType type, const RefNumVal &ref, TypeRef edtype = nullptr, void *pData = nullptr) :
         common(source, type, ref), controlUID(kNotAnEventControlUID), eventDataType(edtype), pEventData(pData) { }
     EventData(EventSource source, EventType type, EventControlUID uid, TypeRef edtype = nullptr, void *pData = nullptr) :
         common(source, type), controlUID(0), eventDataType(edtype), pEventData(pData) { }
-    EventData &Init(EventSource source, const EventType type, const RefNumVal &ref, TypeRef edtype = nullptr, void *pData = nullptr) {
+    EventData &Init(EventSource source, EventType type, const RefNumVal &ref, TypeRef edtype = nullptr, void *pData = nullptr) {
         common.eventSource = source;
         common.eventType = type;
         common.eventSeqIndex = 0;

--- a/source/include/Events.h
+++ b/source/include/Events.h
@@ -77,21 +77,23 @@ struct EventCommonData {
     static UInt32 GetNumberOfCommonElements() { return 5; }  // change if fields are added above
 
     void InitEventTime() { eventTime = UInt32(gPlatform.Timer.TickCountToMilliseconds(gPlatform.Timer.TickCount())); }
-    EventCommonData(UInt32 source, UInt32 type) : eventSource(source), eventType(type), eventSeqIndex(0) {
+
+    EventCommonData(const UInt32 source, const UInt32 type) : eventSource(source), eventType(type), eventSeqIndex(0) {
         InitEventTime();
     }
-    EventCommonData(UInt32 source, UInt32 type, const RefNumVal &ref) : eventSource(source), eventType(type), eventSeqIndex(0), eventRef(ref) {
+
+    EventCommonData(const UInt32 source, UInt32 type, const RefNumVal &ref) : eventSource(source), eventType(type), eventSeqIndex(0), eventRef(ref) {
         InitEventTime();
     }
 };
 
 // Compare two event time stamps or sequence numbers, allowing for wrapping
-inline Int32 EventTimeSeqCompare(UInt32 t1, UInt32 t2) {
+inline Int32 EventTimeSeqCompare(const UInt32 t1, const UInt32 t2) {
     return Int32(t1 - t2);
 }
 
 inline UInt32 *EventIndexFieldPtr(void *rawEventDataPtr) {
-    EventCommonData *eventDataPtr = (EventCommonData*)rawEventDataPtr;
+    auto eventDataPtr = static_cast<EventCommonData*>(rawEventDataPtr);
     return &eventDataPtr->eventSeqIndex;
 }
 
@@ -104,11 +106,11 @@ struct EventData {
     void *pEventData;
 
     EventData() : common(0, 0, RefNumVal()), controlUID(kNotAnEventControlUID), eventDataType(nullptr), pEventData(nullptr) { }
-    EventData(EventSource source, EventType type, const RefNumVal &ref, TypeRef edtype = nullptr, void *pData = nullptr) :
+    EventData(const EventSource source, const EventType type, const RefNumVal &ref, TypeRef edtype = nullptr, void *pData = nullptr) :
         common(source, type, ref), controlUID(kNotAnEventControlUID), eventDataType(edtype), pEventData(pData) { }
     EventData(EventSource source, EventType type, EventControlUID uid, TypeRef edtype = nullptr, void *pData = nullptr) :
         common(source, type), controlUID(0), eventDataType(edtype), pEventData(pData) { }
-    EventData &Init(EventSource source, EventType type, const RefNumVal &ref, TypeRef edtype = nullptr, void *pData = nullptr) {
+    EventData &Init(EventSource source, const EventType type, const RefNumVal &ref, TypeRef edtype = nullptr, void *pData = nullptr) {
         common.eventSource = source;
         common.eventType = type;
         common.eventSeqIndex = 0;
@@ -119,12 +121,14 @@ struct EventData {
         pEventData = pData;
         return *this;
     }
+
     void Destroy() {
         if (eventDataType && pEventData) {
             eventDataType->ClearData(pEventData);
             THREAD_TADM()->Free(pEventData);
         }
     }
+
     static UInt32 GetNextEventSequenceNumber() { return ++_s_eventSequenceNumber; }
     static UInt32 _s_eventSequenceNumber;
 };

--- a/source/include/Thread.h
+++ b/source/include/Thread.h
@@ -8,7 +8,7 @@ SDG
 */
 
 /*! \file
-    \brief Tools for working in a multi threaded process.
+    \brief Tools for working in a multi-threaded process.
  */
 
 #ifndef Thread_h

--- a/source/include/Thread.h
+++ b/source/include/Thread.h
@@ -8,7 +8,7 @@ SDG
 */
 
 /*! \file
-    \brief Tools for working in a multithreaded process.
+    \brief Tools for working in a multi threaded process.
  */
 
 #ifndef Thread_h

--- a/source/include/TypeDefiner.h
+++ b/source/include/TypeDefiner.h
@@ -132,28 +132,28 @@ class TypeDefiner
 
 #if defined(VIREO_INSTRUCTION_REFLECTION)
     #define DEFINE_VIREO_FUNCTION(_name_, _typeTypeString_) \
-      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)(_name_), _typeTypeString_, \
+      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)(_name_), (_typeTypeString_), \
         kPTInstructionFunction, #_name_));
 
     #define DEFINE_VIREO_FUNCTION_CUSTOM(_name_, _cfunction_, _typeTypeString_) \
-      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)(_cfunction_), _typeTypeString_, \
+      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)(_cfunction_), (_typeTypeString_), \
         kPTInstructionFunction, #_cfunction_));
 
     #define DEFINE_VIREO_GENERIC(_name_, _typeTypeString_, _genericEmitProc_) \
-      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)(_genericEmitProc_), _typeTypeString_, \
+      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)(_genericEmitProc_), (_typeTypeString_), \
         kPTGenericFunctionCodeGen, #_name_));
 
 #else
     #define DEFINE_VIREO_FUNCTION(_name_, _typeTypeString_) \
-      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)_name_, _typeTypeString_, \
+      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)(_name_), (_typeTypeString_), \
         kPTInstructionFunction));
 
     #define DEFINE_VIREO_FUNCTION_CUSTOM(_name_, _cfunction_, _typeTypeString_) \
-      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)_cfunction_, _typeTypeString_, \
+      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)(_cfunction_), (_typeTypeString_), \
         kPTInstructionFunction));
 
     #define DEFINE_VIREO_GENERIC(_name_, _typeTypeString_, _genericEmitProc_) \
-      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)_genericEmitProc_, _typeTypeString_, \
+      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)(_genericEmitProc_), (_typeTypeString_), \
         kPTGenericFunctionCodeGen));
 
 #endif  // defined(VIREO_INSTRUCTION_REFLECTION)

--- a/source/include/TypeDefiner.h
+++ b/source/include/TypeDefiner.h
@@ -132,15 +132,15 @@ class TypeDefiner
 
 #if defined(VIREO_INSTRUCTION_REFLECTION)
     #define DEFINE_VIREO_FUNCTION(_name_, _typeTypeString_) \
-      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)_name_, _typeTypeString_, \
+      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)(_name_), _typeTypeString_, \
         kPTInstructionFunction, #_name_));
 
     #define DEFINE_VIREO_FUNCTION_CUSTOM(_name_, _cfunction_, _typeTypeString_) \
-      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)_cfunction_, _typeTypeString_, \
+      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)(_cfunction_), _typeTypeString_, \
         kPTInstructionFunction, #_cfunction_));
 
     #define DEFINE_VIREO_GENERIC(_name_, _typeTypeString_, _genericEmitProc_) \
-      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)_genericEmitProc_, _typeTypeString_, \
+      (TypeDefiner::DefineCustomPointerTypeWithValue(tm, #_name_, (void*)(_genericEmitProc_), _typeTypeString_, \
         kPTGenericFunctionCodeGen, #_name_));
 
 #else


### PR DESCRIPTION
From Resharper C++. Rules used:

local variable may be const
public base class access specifier is redundant
c style cast used instead of a c++ cast
Use auto
Inclusion of deprecated c header 'x'
member function may be const
macro argument should be enclosed in parentheses
use =delete to prohibit calling of a special member function
the empty method should be used to check for emptiness instead of size
result of a postfix operator is discarded, consider replacing it with a prefix operator.
member function may be static
redundant else keyword
use range-based for loop instead
inline specifier is redundant on a global static function
use emplace_back instead of push_back