### PR TITLE
Refactor Arrays files

### DIFF
--- a/source/CommandLine/main.cpp
+++ b/source/CommandLine/main.cpp
@@ -28,7 +28,7 @@ void RunExec();
 }  // namespace Vireo
 
 //------------------------------------------------------------
-int VIREO_MAIN(int argc, const char * argv[])
+int VIREO_MAIN(const int argc, const char * argv[])
 {
     using namespace Vireo;  // NOLINT(build/namespaces)
 
@@ -47,7 +47,7 @@ int VIREO_MAIN(int argc, const char * argv[])
     if (argc >= 2) {
         gShells._pRootShell = TypeManager::New(nullptr);
 
-        for (Int32 arg = 1; arg < argc; ++arg) {
+        for (auto arg = 1; arg < argc; ++arg) {
             if (strcmp(argv[arg], "-D") == 0) {
                 gShells._pRootShell->DumpPrimitiveDictionary();
                 continue;
@@ -123,8 +123,8 @@ void Vireo::RunExec() {
     TypeManagerScope scope(tm);
     // These numbers may need further tuning (numSlices and millisecondsToRun).
     // They should match the values for VJS in io/module_eggShell.js
-    Int32 state = tm->TheExecutionContext()->ExecuteSlices(10000, 4);
-    Int32 delay = state > 0 ? state : 0;
+    const Int32 state = tm->TheExecutionContext()->ExecuteSlices(10000, 4);
+    const Int32 delay = state > 0 ? state : 0;
     gShells._keepRunning = (state != kExecSlices_ClumpsFinished);
     if (delay)
         gPlatform.Timer.SleepMilliseconds(delay);

--- a/source/core/Assert.cpp
+++ b/source/core/Assert.cpp
@@ -11,14 +11,14 @@ SDG
 /*! \file
  */
 
-#include <stdlib.h>         // exit()
+#include <cstdlib>         // exit()
 #include "DataTypes.h"
 
 namespace Vireo
 {
 
 #ifdef VIREO_USING_ASSERTS
-void VireoAssert_Hidden(Boolean test, ConstCStr message, ConstCStr file, int line)
+void VireoAssert_Hidden(Boolean test, ConstCStr message, ConstCStr file, const int line)
 {
     if (!test) {
         ConstCStr filename = (strrchr(file, '/') ? strrchr(file, '/') + 1 : strrchr(file, '\\') ? strrchr(file, '\\') + 1 : file);

--- a/source/core/Events.cpp
+++ b/source/core/Events.cpp
@@ -116,13 +116,15 @@ class EventQueueObject {
         ClearQueue();
         SetStatus(kQIDFree);
     }
-    const bool GetPendingEventSequenceNumber(UInt32 *eventSeq) {
+
+    bool GetPendingEventSequenceNumber(UInt32 *eventSeq) {
         if (size() > 0) {
             *eventSeq = _eventQueue.front().common.eventSeqIndex;
             return true;
         }
         return false;
     }
+
     const EventData &GetEventData() {
         if (size() > 0) {
             _eventLock = true;
@@ -130,6 +132,7 @@ class EventQueueObject {
         }
         return _timeOutEvent.Init(kEventSourceLVUserInt, kEventTypeTimeout, RefNumVal());
     }
+
     void SetObserver(OccurrenceCore *occ) {
         if (_wakeUpOccur != occ && occ) {
             size_t i = _eventQueue.size();

--- a/source/include/Array.h
+++ b/source/include/Array.h
@@ -25,7 +25,6 @@ class ArrayIterator
     IntIndex*  _dimensionLengths;
     ArrayDimensionVector _indexes;
 
- private:
     void ResetIndexes() {
         for (IntIndex i = 0; i < _rank; i++) {
             _indexes[i] = 0;
@@ -43,7 +42,7 @@ class ArrayIterator
     // Intended to be used only in special cases where the iterator is walked for the subset of arrays (for instance,
     // polymorphic binary operations). Thus, debug mode asserts that passed in rank and dimensionlengths are smaller
     // than that of the passed in array.
-    explicit ArrayIterator(TypedArrayCoreRef array, IntIndex rank, IntIndex* dimensionLengths) {
+    explicit ArrayIterator(TypedArrayCoreRef array, const IntIndex rank, IntIndex* dimensionLengths) {
         _array = array;
         if (array != nullptr) {
             VIREO_ASSERT(rank == array->Rank());

--- a/source/io/HttpClient.cpp
+++ b/source/io/HttpClient.cpp
@@ -7,7 +7,7 @@ This software is subject to the terms described in the LICENSE.TXT file
 SDG
 */
 
-#include <stdio.h>
+#include <cstdio>
 
 #include "TypeDefiner.h"
 #include "ExecutionContext.h"

--- a/source/io/JavaScriptInvoke.cpp
+++ b/source/io/JavaScriptInvoke.cpp
@@ -15,7 +15,7 @@ SDG
 #include "ExecutionContext.h"
 #include "StringUtilities.h"
 #include "TDCodecVia.h"
-#include <stdio.h>
+#include <cstdio>
 #include "VirtualInstrument.h"
 
 #if defined(VIREO_TYPE_JavaScriptInvoke)
@@ -31,13 +31,13 @@ extern "C" {
 
 //------------------------------------------------------------
 //! Return dataRef of the parameter that is at the given index in the parameters array
-VIREO_EXPORT void* JavaScriptInvoke_GetParameterDataRef(StaticTypeAndData *parameters, Int32 index)
+VIREO_EXPORT void* JavaScriptInvoke_GetParameterDataRef(StaticTypeAndData *parameters, const Int32 index)
 {
     return parameters[index]._pData;
 }
 
 //! Return typeRef of the parameter that is at the given index in the parameters array
-VIREO_EXPORT void* JavaScriptInvoke_GetParameterTypeRef(StaticTypeAndData *parameters, Int32 index)
+VIREO_EXPORT void* JavaScriptInvoke_GetParameterTypeRef(StaticTypeAndData *parameters, const Int32 index)
 {
     return parameters[index]._paramType;
 }

--- a/source/io/PropertyNode.cpp
+++ b/source/io/PropertyNode.cpp
@@ -17,7 +17,7 @@ SDG
 #include "TDCodecVia.h"
 #include "VirtualInstrument.h"
 #include "ControlRef.h"
-#include <stdio.h>
+#include <cstdio>
 
 #define VIREO_MODULE_PropertyNode 1
 
@@ -106,7 +106,7 @@ VIREO_FUNCTION_SIGNATUREV(PropertyNodeWrite, PropertyNodeWriteParamBlock)
 }
 
 //------------------------------------------------------------
-struct PropertyNodeReadParamBlock : public VarArgInstruction
+struct PropertyNodeReadParamBlock : VarArgInstruction
 {
     _ParamDef(RefNumVal, refNum);
     _ParamDef(StringRef, propertyName);


### PR DESCRIPTION
From Resharper C++. Rules used:

local variable may be const
public base class access specifier is redundant
c style cast used instead of a c++ cast
local variable 'x' is reassigned in all paths before being read.
inline specifier is redundant on a function declared entirely inside a struct definition.
Use auto
Inclusion of deprecated c header 'x'