### PR TITLE
Refactor TypeAndDataManager.h

### DIFF
--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -1151,7 +1151,7 @@ class TypedArrayCore
     Boolean Reserve(IntIndex length) const { return length <= Capacity(); }
 
     //! Calculate the length of a contiguous chunk of elements
-    IntIndex AQBlockLength(IntIndex count) const { return ElementType()->TopAQSize() * count; }
+    IntIndex AQBlockLength(IntIndex count) { return ElementType()->TopAQSize() * count; }
 
     //! Resize for multi dim arrays
     Boolean ResizeDimensions(Int32 rank, IntIndex *dimensionLengths, Boolean preserveElements, Boolean noInit = false);

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -476,7 +476,7 @@ class TypeCommon
     // Internal to the TypeManager, but this is hard to specify in C++
     virtual ~TypeCommon() = default;
 
-protected:
+ protected:
     /// @name Storage for core property
     /// Members use a common type (UInt16) to maximize packing.
 
@@ -1092,7 +1092,7 @@ class TypedArrayCore
 
     virtual ~TypedArrayCore() = default;
 
-protected:
+ protected:
     static size_t   StructSize(Int32 rank)  { return sizeof(TypedArrayCore) + ((rank-1) * sizeof(IntIndex) * 2); }
     explicit TypedArrayCore(TypeRef type);
  public:

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -1328,17 +1328,13 @@ struct StringRefCmp {
         Int32 cmp = memcmp(a->Begin(), b->Begin(), Min(a->Length(), b->Length()));
         if (cmp < 0) {
             return true;
-        }
-
-        if (cmp > 0) {
+        } else if (cmp > 0) {
+            return false;
+        } else if (a->Length() < b->Length()) {
+            return true;
+        } else {
             return false;
         }
-
-        if (a->Length() < b->Length()) {
-            return true;
-        }
-
-        return false;
     }
 };
 

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -263,7 +263,7 @@ class TypeManager
     explicit TypeManager(TypeManagerRef parentTm);
     NamedTypeRef NewNamedType(const SubString* typeName, TypeRef type, NamedTypeRef existingOverload);
  public:
-    ExecutionContextRef TheExecutionContext() const { return _executionContext; }
+    ExecutionContextRef TheExecutionContext() { return _executionContext; }
     void    SetExecutionContext(ExecutionContextRef exec) { _executionContext = exec; }
     void    DeleteTypes(Boolean finalTime);
     void    TrackType(TypeCommon* type);
@@ -271,10 +271,10 @@ class TypeManager
 
     void    UntrackLastType(TypeCommon* type);
     void    GetTypes(TypedArray1D<TypeRef>*);
-    TypeRef TypeList() const { return _typeList; }
+    TypeRef TypeList() { return _typeList; }
     void    PrintMemoryStat(ConstCStr, Boolean bLast);
 
-    TypeManagerRef BaseTypeManager() const { return _baseTypeManager; }
+    TypeManagerRef BaseTypeManager() { return _baseTypeManager; }
     TypeRef Define(const SubString* typeName, TypeRef type);
 
     TypeRef FindType(ConstCStr name);
@@ -470,8 +470,8 @@ class TypeCommon
     static const SubString TypeStaticTypeAndData;
 
     explicit TypeCommon(TypeManagerRef typeManager);
-    TypeManagerRef TheTypeManager() const { return _typeManager; }
-    TypeRef Next() const { return _next; }
+    TypeManagerRef TheTypeManager() { return _typeManager; }
+    TypeRef Next() { return _next; }
 
     // Internal to the TypeManager, but this is hard to specify in C++
     virtual ~TypeCommon() = default;
@@ -698,7 +698,7 @@ class NamedType : public WrappedType
         { return sizeof(NamedType) + InlineArray<Utf8Char>::ExtraStructSize(name->Length()); }
     static NamedType* New(TypeManagerRef typeManager, const SubString* name, TypeRef wrappedType, NamedTypeRef nextOverload);
 
-    NamedTypeRef    NextOverload() const { return _nextOverload; }
+    NamedTypeRef    NextOverload() { return _nextOverload; }
     void    Accept(TypeVisitor *tv) override { tv->VisitNamed(this); }
     SubString Name() override { return {_name.Begin(), _name.End()}; }
     SubString ElementName() override { return {nullptr, nullptr}; }
@@ -1100,7 +1100,7 @@ protected:
     static void Delete(TypedArrayCoreRef);
 
  public:
-    AQBlock1* BeginAt(IntIndex index) const
+    AQBlock1* BeginAt(IntIndex index)
     {
         VIREO_ASSERT(index >= 0)
         VIREO_ASSERT(ElementType() != nullptr)
@@ -1110,16 +1110,16 @@ protected:
     AQBlock1* BeginAtND(Int32, IntIndex*);
     AQBlock1* BeginAtNDIndirect(Int32 rank, IntIndex* ppDimIndexes[]);
 
-    void* RawObj() const { VIREO_ASSERT(Rank() == 0); return RawBegin(); }  // some extra asserts fo  ZDAs
-    AQBlock1* RawBegin() const { return _pRawBufferBegin; }
+    void* RawObj() { VIREO_ASSERT(Rank() == 0); return RawBegin(); }  // some extra asserts fo  ZDAs
+    AQBlock1* RawBegin() { return _pRawBufferBegin; }
     template<typename CT> CT BeginAtAQ(IntIndex index) { return reinterpret_cast<CT>(RawBegin() + index); }
     BlockItr RawItr()               { return BlockItr(RawBegin(), ElementType()->TopAQSize(), Length()); }
 
     //! Array's type.
-    TypeRef Type() const { return _typeRef; }
+    TypeRef Type() { return _typeRef; }
 
     //! The element type of this array instance. This type may be more specific than the element in Array's Type.
-    TypeRef ElementType() const { return _eltTypeRef; }
+    TypeRef ElementType() { return _eltTypeRef; }
     Boolean SetElementType(TypeRef, Boolean preserveElements);
 
  protected:
@@ -1263,8 +1263,8 @@ struct ErrorCluster {
     ErrorCluster() : status(false), code(0), source(nullptr) { }
     void SetError(Boolean s, Int32 c, ConstCStr str, Boolean appendCallChain = true);
     void SetError(ErrorCluster error);
-    void AddAppendixPreamble() const { source->AppendCStr("<APPEND>\n"); }
-    void AddAppendixPostamble() const { }  // no postamble
+    void AddAppendixPreamble() { source->AppendCStr("<APPEND>\n"); }
+    void AddAppendixPostamble() { }  // no postamble
     Boolean hasError() const { return status; }
     Boolean hasWarning() const { return !status && code != 0; }
 };

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -285,7 +285,7 @@ class TypeManager
     Int32   AQAlignment(Int32 size);
     static Int32   AlignAQOffset(Int32 offset, Int32 size) {
         if (size != 0) {
-            const Int32 remainder  = offset % size;
+            Int32 remainder  = offset % size;
             if (remainder)
                 offset += size - remainder;
         }
@@ -1223,26 +1223,26 @@ AQBlock1* ArrayToArrayCopyHelper(TypeRef elementType, AQBlock1* pDest, IntIndex*
 class String : public TypedArray1D< Utf8Char >
 {
  public:
-    SubString MakeSubStringAlias()              { return SubString(Begin(), End()); }
+    SubString MakeSubStringAlias()              { return {Begin(), End()}; }
     void CopyFromSubString(const SubString* str)   {
         if (str->Length())
             CopyFrom(str->Length(), str->Begin());
         else
             Resize1D(0);
     }
-    void AppendCStr(ConstCStr cstr)             { Append((IntIndex)strlen(cstr), (Utf8Char*)cstr); }
+    void AppendCStr(ConstCStr cstr)             { Append(static_cast<IntIndex>(strlen(cstr)), (Utf8Char*)cstr); }
     void AppendUtf8Str(Utf8Char* begin, IntIndex length) { Append(length, begin); }
-    void AppendSubString(SubString* str)     { Append((IntIndex)str->Length(), (Utf8Char*)str->Begin()); }
+    void AppendSubString(SubString* str)     { Append(static_cast<IntIndex>(str->Length()), str->Begin()); }
     void AppendStringRef(StringRef stringRef)           {
-        Append((IntIndex)stringRef->Length(), (Utf8Char*)stringRef->Begin());
+        Append(static_cast<IntIndex>(stringRef->Length()), stringRef->Begin());
     }
     void InsertCStr(IntIndex position, ConstCStr cstr)
-         { Insert(position, (IntIndex)strlen(cstr), (Utf8Char*)cstr); }
+         { Insert(position, static_cast<IntIndex>(strlen(cstr)), (Utf8Char*)cstr); }
     void AppendViaDecoded(SubString *str);
     void AppendEscapeEncoded(const Utf8Char* source, IntIndex len);
 
     void InsertSubString(IntIndex position, SubString* str) {
-        Insert(position, static_cast<IntIndex>(str->Length()), const_cast<Utf8Char*>(str->Begin()));
+        Insert(position, static_cast<IntIndex>(str->Length()), str->Begin());
     }
     Boolean IsEqual(String *rhs) {
         return Length() == rhs->Length() && memcmp(Begin(), rhs->Begin(), Length()) == 0;
@@ -1325,7 +1325,7 @@ class StackVar
 
 struct StringRefCmp {
     bool operator()(const StringRef& a, const StringRef &b) const {
-        const Int32 cmp = memcmp(a->Begin(), b->Begin(), Min(a->Length(), b->Length()));
+        Int32 cmp = memcmp(a->Begin(), b->Begin(), Min(a->Length(), b->Length()));
         if (cmp < 0) {
             return true;
         }


### PR DESCRIPTION
From Resharper C++. Rules used:

local variable may be const
public base class access specifier is redundant
c style cast used instead of a c++ cast
Use auto
Inclusion of deprecated c header 'x'
member function may be const
macro argument should be enclosed in parentheses
redundant else keyword
use emplace_back instead of push_back
use =default to define a trivial constructor
avoid repeating the return type from the declaration, use a braced initializer instead
