### PR TITLE
Fix bug in the IsA checking code

### DIFF
--- a/source/core/TypeAndDataManager.cpp
+++ b/source/core/TypeAndDataManager.cpp
@@ -739,8 +739,11 @@ Boolean TypeCommon::CompareType(TypeRef otherType)
     if (this == otherType) {
         return true;
     } else if (thisEncoding == kEncoding_Array && otherEncoding == kEncoding_Array) {
-        if (this->Rank() == otherType->Rank())
+        if (this->Rank() != otherType->Rank()) {
+            return false;
+        } else {
             return this->GetSubElement(0)->CompareType(otherType->GetSubElement(0));
+        }
     } else if (thisEncoding == kEncoding_Cluster && otherEncoding == kEncoding_Cluster) {
         SubString thisTypeName, otherTypeName;
         Boolean isThisIntrinsicClusterType = this->IsIntrinsicClusterDataType(&thisTypeName);
@@ -783,8 +786,13 @@ Boolean TypeCommon::IsA(TypeRef otherType, Boolean compatibleStructure)
         EncodingEnum otherEncoding = otherType->BitEncoding();
 
         if (thisEncoding == kEncoding_Array && otherEncoding == kEncoding_Array && this->Rank() == otherType->Rank()) {
-            bMatch = this->GetSubElement(0)->IsA(otherType->GetSubElement(0), compatibleStructure);
-            return bMatch;
+            if (this->Rank() != otherType->Rank()) {
+                bMatch = false;
+                return bMatch;
+            } else {
+                bMatch = this->GetSubElement(0)->IsA(otherType->GetSubElement(0), compatibleStructure);
+                return bMatch;
+            }
         } else if (thisEncoding == kEncoding_UInt || thisEncoding == kEncoding_S2CInt ||
                    thisEncoding == kEncoding_Ascii || thisEncoding == kEncoding_Unicode) {
             if (otherEncoding == kEncoding_UInt || otherEncoding == kEncoding_S2CInt ||


### PR DESCRIPTION
Bug in the IsA check allowed Arrays of different ranks to fall through to a name-based comparison, incorrectly reporting that they are the same. I'm guessing this was likely not too big of an issue pre-variants, because compile time checks would've protected us from hitting it.

This change was reviewed in [PR](https://github.com/ni/VireoSDK/pull/591/files) initially, moving it to a separate PR for history tracking purposes on @sanmut's request.