### PR TITLE
Fix IsA type comparison for arrays

### DIFF
--- a/source/core/TypeAndDataManager.cpp
+++ b/source/core/TypeAndDataManager.cpp
@@ -785,7 +785,7 @@ Boolean TypeCommon::IsA(TypeRef otherType, Boolean compatibleStructure)
         EncodingEnum thisEncoding = BitEncoding();
         EncodingEnum otherEncoding = otherType->BitEncoding();
 
-        if (thisEncoding == kEncoding_Array && otherEncoding == kEncoding_Array && this->Rank() == otherType->Rank()) {
+        if (thisEncoding == kEncoding_Array && otherEncoding == kEncoding_Array) {
             if (this->Rank() != otherType->Rank()) {
                 bMatch = false;
                 return bMatch;


### PR DESCRIPTION
This is a change that I missed in my previous submission.