### PR TITLE
Enable AnalogWaveform allocation tests and implement deleteVariantAttribute

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,7 +96,7 @@ module.exports = {
         'func-names': ['error', 'never'],
         'func-style': 'error',
         'id-blacklist': 'error',
-        'id-length': ['error',  { 'exceptions': ['e', 'i', 'j'] }],
+        'id-length': ['error',  { 'exceptions': ['e', 'i', 'j', 'Y'] }],
         'id-match': 'error',
         'indent': 'error',
         'jsx-quotes': 'error',

--- a/source/core/CEntryPoints.cpp
+++ b/source/core/CEntryPoints.cpp
@@ -386,6 +386,28 @@ VIREO_EXPORT EggShellResult EggShell_SetVariantAttribute(TypeManagerRef tm, cons
     return kEggShellResult_Success;
 }
 //------------------------------------------------------------
+//! Deletes a variant attribute of a given type and data pointer
+VIREO_EXPORT EggShellResult EggShell_DeleteVariantAttribute(TypeManagerRef tm, const TypeRef typeRef, void* pData, const char* attributeNameCStr)
+{
+    TypeManagerScope scope(tm);
+    if (typeRef == nullptr || !typeRef->IsValid() || !typeRef->IsVariant())
+        return kEggShellResult_InvalidTypeRef;
+
+    if (pData == nullptr)
+        return kEggShellResult_InvalidDataPointer;
+
+    STACK_VAR(String, attributeSV);
+    StringRef attributeName = attributeSV.Value;
+    attributeName->AppendCStr(attributeNameCStr);
+
+    VariantDataRef variant = *(static_cast<const VariantDataRef*>(pData));
+    Boolean found = variant->DeleteAttribute(&attributeName);
+    if (!found)
+        return kEggShellResult_ObjectNotFoundAtPath;
+
+    return kEggShellResult_Success;
+}
+//------------------------------------------------------------
 VIREO_EXPORT void* Data_GetStringBegin(StringRef stringObject)
 {
     VIREO_ASSERT(String::ValidateHandle(stringObject));

--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -886,10 +886,18 @@ Int32 TDViaParser::ParseVariantData(VariantDataRef pData)
     LVError err = kLVError_NoError;
     VIREO_ASSERT(pData != nullptr);
 
-    if (!_string.EatChar('(')) {
-        err = kLVError_ArgError;
-    } else if (!_string.EatChar(')')) {
-        err = kLVError_ArgError;
+    // For JSON encodings skip variant parsing altogether
+    // Not possible until we include type information in FormatVariant
+    if (Fmt().QuoteFieldNames()) {
+        if (!EatJSONItem(&_string)) {
+            err = kLVError_ArgError;
+        }
+    } else {
+        if (!_string.EatChar('(')) {
+            err = kLVError_ArgError;
+        } else if (!_string.EatChar(')')) {
+            err = kLVError_ArgError;
+        }
     }
     if (err == kLVError_ArgError) {
         LOG_EVENT(kHardDataError, "default value for variant must be empty");
@@ -1030,7 +1038,7 @@ Int32 TDViaParser::ParseArrayData(TypedArrayCoreRef pArray, void* pFirstEltInSli
 
 //------------------------------------------------------------
 //! Skip over a JSON item.  TODO(PaulAustin): merge with ReadSubexpression
-Boolean EatJSONItem(SubString* input)
+Boolean TDViaParser::EatJSONItem(SubString* input)
 {
     SubString token;
 

--- a/source/include/CEntryPoints.h
+++ b/source/include/CEntryPoints.h
@@ -57,6 +57,7 @@ VIREO_EXPORT EggShellResult EggShell_GetVariantAttribute(TypeManagerRef tm, cons
                                                         TypeRef* typeRefLocation, void** dataRefLocation);
 VIREO_EXPORT EggShellResult EggShell_SetVariantAttribute(TypeManagerRef tm, const TypeRef typeRef, void* pData, const char* attributeNameCStr,
                                                         TypeRef attributeTypeRef, void* attributeDataRef);
+VIREO_EXPORT EggShellResult EggShell_DeleteVariantAttribute(TypeManagerRef tm, const TypeRef typeRef, void* pData, const char* attributeNameCStr);
 VIREO_EXPORT void* Data_GetStringBegin(StringRef stringObject);
 VIREO_EXPORT Int32 Data_GetStringLength(StringRef stringObject);
 VIREO_EXPORT void* Data_GetArrayBegin(const void* pData);

--- a/source/include/TDCodecVia.h
+++ b/source/include/TDCodecVia.h
@@ -156,6 +156,7 @@ class TDViaParser
     TypeRef ParseControlReference(void *pData = nullptr);
     TypeRef ParseEnumType(SubString *token);
     static EncodingEnum ParseEncoding(SubString* str);
+    static Boolean EatJSONItem(SubString* input);
 };
 
 #if defined (VIREO_VIA_FORMATTER)

--- a/source/io/module_eggShell.js
+++ b/source/io/module_eggShell.js
@@ -572,6 +572,23 @@ var assignEggShell;
             Module.eggShell.deallocateData(attributeValueRef);
         };
 
+        Module.eggShell.deleteVariantAttribute = publicAPI.eggShell.deleteVariantAttribute = function (valueRef, attributeName) {
+            var stack = Module.stackSave();
+
+            var attributeNameStackPointer = Module.coreHelpers.writeJSStringToStack(attributeName);
+            var eggShellResult = Module._EggShell_DeleteVariantAttribute(Module.eggShell.v_userShell, valueRef.typeRef, valueRef.dataRef, attributeNameStackPointer);
+            if (eggShellResult !== EGGSHELL_RESULT.SUCCESS && eggShellResult !== EGGSHELL_RESULT.OBJECT_NOT_FOUND_AT_PATH) {
+                throw new Error('Could not delete variant attribute for the following reason: ' + eggShellResultEnum[eggShellResult] +
+                    ' (error code: ' + eggShellResult + ')' +
+                    ' (type name: ' + Module.typeHelpers.typeName(valueRef.typeRef) + ')' +
+                    ' (subpath: ' + attributeName + ')');
+            }
+            var found = eggShellResult !== EGGSHELL_RESULT.OBJECT_NOT_FOUND_AT_PATH;
+
+            Module.stackRestore(stack);
+            return found;
+        };
+
         // **DEPRECATED**
         Module.eggShell.dataReadString = function (stringPointer) {
             var begin = Module._Data_GetStringBegin(stringPointer);

--- a/test-it/karma/publicapi/AllocateTypes.Test.js
+++ b/test-it/karma/publicapi/AllocateTypes.Test.js
@@ -41,13 +41,6 @@ describe('Vireo public API allows', function () {
         return JSON.parse(vireo.eggShell.readJSON(valueRef));
     };
 
-    // Vireo does not yet support writeJSON on Variant data types.
-    var allocateWaveformTest = function (viName, path) {
-        var dataValueRef = allocateData(viName, path);
-        expectValidValueRef(dataValueRef);
-        internalEggShell.deallocateData(dataValueRef);
-    };
-
     var allocateTest = function (viName, path, value) {
         var dataValueRef = allocateData(viName, path);
         expectValidValueRef(dataValueRef);
@@ -207,59 +200,89 @@ describe('Vireo public API allows', function () {
             });
         });
 
-        it('local variables in a VI', function () {
-            allocateTest(viName, 'booleans', [true, false, true, false]);
-            allocateTest(viName, 'strings', [
-                'everyone you know',
-                'everyone you ever heard of',
-                'every human being who ever was',
-                'lived out their lives'
-            ]);
-            allocateTest(viName, 'doubles', [1.2, 3.4, 5.6, 7.89, 1234.5678]);
-            allocateTest(viName, 'int32s', [-1000, -10, 42, 9876543, 123]);
-            allocateTest(viName, 'int64s', [
-                '-8989',
-                '9090',
-                '36028797018963968',
-                '-72057594037927936'
-            ]);
-            allocateTest(viName, 'uint64s', [
-                '9223372041149743104',
-                '0',
-                '9223376434901286912'
-            ]);
-            allocateTest(viName, 'complexes', [
-                {
-                    real: 0,
-                    imaginary: 0
-                }, {
-                    real: 10,
-                    imaginary: -10
-                }, {
-                    real: 5.045,
-                    imaginary: -5.67
-                }
-            ]);
-            allocateTest(viName, 'times', [
-                {
-                    seconds: '3564057536',
-                    fraction: '7811758927381448193'
-                }, {
-                    seconds: '3564057542',
-                    fraction: '16691056759750171331'
-                }
-            ]);
-
-            allocateTest(viName, 'fixedBooleans', [
-                [true, false],
-                [false, true]
-            ]);
-            allocateWaveformTest(viName, 'wave_Double');
-            allocateTest(viName, 'nipath', {
-                type: 'ABSOLUTE',
-                components: ['C', 'Windows', 'System32']
+        describe('local variables in a VI of type', function () {
+            it('Boolean', function () {
+                allocateTest(viName, 'booleans', [true, false, true, false]);
             });
-            allocateTest(viName, 'enum16numbers', 1);
+
+            it('String', function () {
+                allocateTest(viName, 'strings', [
+                    'everyone you know',
+                    'everyone you ever heard of',
+                    'every human being who ever was',
+                    'lived out their lives'
+                ]);
+            });
+
+            it('Numeric', function () {
+                allocateTest(viName, 'doubles', [1.2, 3.4, 5.6, 7.89, 1234.5678]);
+                allocateTest(viName, 'int32s', [-1000, -10, 42, 9876543, 123]);
+                allocateTest(viName, 'int64s', [
+                    '-8989',
+                    '9090',
+                    '36028797018963968',
+                    '-72057594037927936'
+                ]);
+                allocateTest(viName, 'uint64s', [
+                    '9223372041149743104',
+                    '0',
+                    '9223376434901286912'
+                ]);
+                allocateTest(viName, 'complexes', [
+                    {
+                        real: 0,
+                        imaginary: 0
+                    }, {
+                        real: 10,
+                        imaginary: -10
+                    }, {
+                        real: 5.045,
+                        imaginary: -5.67
+                    }
+                ]);
+            });
+
+            it('Timestamp', function () {
+                allocateTest(viName, 'times', [
+                    {
+                        seconds: '3564057536',
+                        fraction: '7811758927381448193'
+                    }, {
+                        seconds: '3564057542',
+                        fraction: '16691056759750171331'
+                    }
+                ]);
+            });
+
+            it('FixedBoolean', function () {
+                allocateTest(viName, 'fixedBooleans', [
+                    [true, false],
+                    [false, true]
+                ]);
+            });
+
+            it('AnalogWaveform', function () {
+                allocateTest(viName, 'wave_Double', {
+                    t0: {
+                        seconds: '50000',
+                        fraction: '456'
+                    },
+                    dt: 10.5,
+                    Y: [5, 25, 'NaN', '-Infinity', 'Infinity'],
+                    attributes: {_data: null, _attributes: null}
+                });
+            });
+
+            it('Path', function () {
+                allocateTest(viName, 'nipath', {
+                    type: 'ABSOLUTE',
+                    components: ['C', 'Windows', 'System32']
+                });
+            });
+
+            it('Enum', function () {
+                allocateTest(viName, 'enum16numbers', 1);
+            });
         });
 
         it('local constants in a VI', function () {

--- a/test-it/karma/publicapi/ReadJson.Test.js
+++ b/test-it/karma/publicapi/ReadJson.Test.js
@@ -609,7 +609,7 @@ describe('The Vireo EggShell readJSON api can read', function () {
                     fraction: '123'
                 },
                 dt: 8.8,
-                Y: [5.5, 6.6, 7.7, 8.8], // eslint-disable-line id-length
+                Y: [5.5, 6.6, 7.7, 8.8],
                 attributes: {_data: null, _attributes: {key1: {_data: 'hello', _attributes: null}, key2: {_data: 'hi', _attributes: null}}}
             });
         });

--- a/test-it/karma/publicapi/TypeWaveform.Test.js
+++ b/test-it/karma/publicapi/TypeWaveform.Test.js
@@ -35,7 +35,7 @@ describe('Peek/Poke different datatypes', function () {
                 fraction: '123'
             },
             dt: 5.8,
-            Y: [1.2, 1.3, 1, -0.5], // eslint-disable-line id-length
+            Y: [1.2, 1.3, 1, -0.5],
             attributes: {_data: null, _attributes: null}
         });
 
@@ -45,7 +45,7 @@ describe('Peek/Poke different datatypes', function () {
                 fraction: '0'
             },
             dt: 0,
-            Y: [], // eslint-disable-line id-length
+            Y: [],
             attributes: {_data: null, _attributes: null}
         });
 
@@ -55,7 +55,7 @@ describe('Peek/Poke different datatypes', function () {
                 fraction: '656'
             },
             dt: 20.5,
-            Y: [45, 55], // eslint-disable-line id-length
+            Y: [45, 55],
             attributes: {_data: null, _attributes: null}
         };
         viPathWriter('wave_i32_1.t0', newValue2.t0);
@@ -70,15 +70,15 @@ describe('Peek/Poke different datatypes', function () {
                     fraction: '123'
                 },
                 dt: 6.8,
-                Y: [10, 20, 30], // eslint-disable-line id-length
+                Y: [10, 20, 30],
                 attributes: {_data: null, _attributes: null}
             });
             done();
         });
     });
 
-    // Vireo does not yet support writeJSON on Variant data types.
-    xit('peeks and pokes on analog waveform type with write attribute values', function () {
+    // Vireo does not yet support writeJSON on Variant data types so any provided attributes value will be ignored on write
+    it('peeks and pokes on analog waveform type with write attribute values', function () {
         var viName = 'MyVI';
 
         vireoRunner.rebootAndLoadVia(vireo, publicApiWaveformSimpleViaUrl);
@@ -91,7 +91,7 @@ describe('Peek/Poke different datatypes', function () {
                 fraction: '456'
             },
             dt: 10.5,
-            Y: [5, 25], // eslint-disable-line id-length
+            Y: [5, 25],
             attributes: {_data: null, _attributes: null}
         };
         viPathWriter('wave_i32_1', newValue);

--- a/test-it/karma/publicapi/Variant.Test.js
+++ b/test-it/karma/publicapi/Variant.Test.js
@@ -101,4 +101,34 @@ describe('The Vireo EggShell api', function () {
             expect(result).toBe('new updated value');
         });
     });
+
+    describe('can use deleteVariantAttribute', function () {
+        it('to throw for none variant types', function () {
+            const valueRef = vireo.eggShell.findValueRef(viName, 'utf8string');
+            expect(() => vireo.eggShell.deleteVariantAttribute(valueRef, 'nonexistant')).toThrowError(/InvalidTypeRef/);
+        });
+
+        it('to not find an attribute in an empty variant without attributes', function () {
+            const valueRef = vireo.eggShell.findValueRef(viName, 'emptyAttributesVariant');
+            const found = vireo.eggShell.deleteVariantAttribute(valueRef, 'nonexistant');
+            expect(found).toBeFalse();
+        });
+
+        it('to find a string attribute in an empty variant with attribute key1:value1', function () {
+            const valueRef = vireo.eggShell.findValueRef(viName, 'stringAttributeVariant');
+            const attributeValueRefBefore = vireo.eggShell.getVariantAttribute(valueRef, 'key1');
+            const value = vireo.eggShell.readString(attributeValueRefBefore);
+            expect(attributeValueRefBefore).toBeObject();
+            expect(value).toBe('value1');
+
+            const found = vireo.eggShell.deleteVariantAttribute(valueRef, 'key1');
+            expect(found).toBe(true);
+
+            const attributeValueRefAfter = vireo.eggShell.getVariantAttribute(valueRef, 'key1');
+            expect(attributeValueRefAfter).toBeUndefined();
+
+            const foundAfter = vireo.eggShell.deleteVariantAttribute(valueRef, 'key1');
+            expect(foundAfter).toBe(false);
+        });
+    });
 });

--- a/test-it/karma/publicapi/WriteJson.Test.js
+++ b/test-it/karma/publicapi/WriteJson.Test.js
@@ -1049,16 +1049,16 @@ describe('The Vireo EggShell writeJSON api can write', function () {
             writeTest('dataItem_ClusterOfArrays', original, lessVals);
         });
 
-        // Vireo does not yet support writeJSON on Variant data types.
-        xit('analog waveform of double', function () {
+        // Vireo does not yet support writeJSON on Variant data types so any provided attributes value will be ignored on write
+        it('analog waveform of double', function () {
             var original = {
                 t0: {
                     seconds: '300',
                     fraction: '123'
                 },
                 dt: 8.8,
-                Y: [5.5, 6.6, 7.7, 8.8], // eslint-disable-line id-length
-                attributes: {value: null, attributes: null}
+                Y: [5.5, 6.6, 7.7, 8.8],
+                attributes: {_data: null, _attributes: null}
             };
             var sameSize = {
                 t0: {
@@ -1066,8 +1066,8 @@ describe('The Vireo EggShell writeJSON api can write', function () {
                     fraction: '0'
                 },
                 dt: 1234.5678,
-                Y: ['NaN', 'Infinity', '-Infinity', -0], // eslint-disable-line id-length
-                attributes: {value: null, attributes: null}
+                Y: ['NaN', 'Infinity', '-Infinity', -0],
+                attributes: {_data: null, _attributes: null}
             };
             var moreVals = {
                 t0: {
@@ -1075,8 +1075,8 @@ describe('The Vireo EggShell writeJSON api can write', function () {
                     fraction: '1231'
                 },
                 dt: 8.89,
-                Y: [5.5, 6.6, 7.7, 8.8, 9.9, 10.1, 11], // eslint-disable-line id-length
-                attributes: {value: null, attributes: null}
+                Y: [5.5, 6.6, 7.7, 8.8, 9.9, 10.1, 11],
+                attributes: {_data: null, _attributes: null}
             };
             var lessVals = {
                 t0: {
@@ -1084,8 +1084,8 @@ describe('The Vireo EggShell writeJSON api can write', function () {
                     fraction: '2'
                 },
                 dt: 3,
-                Y: [4], // eslint-disable-line id-length
-                attributes: {value: null, attributes: null}
+                Y: [4],
+                attributes: {_data: null, _attributes: null}
             };
 
             writeTest('wave_Double', original, sameSize);


### PR DESCRIPTION
This PR implements a workaround in `vireo.eggShell.writeJSON` so that when writing JSON values for variants that those parts of the JSON are ignored. This allows enabling the previously disabled waveform tests and the waveform allocate tests.

This PR also implements `vireo.eggShell.deleteVariantAttribute` for deleting an attribute on a variant from the JS context.