### PR TITLE
VariantToData:Fix float to integral conversion

### DIFF
--- a/source/core/DualTypeConversion.cpp
+++ b/source/core/DualTypeConversion.cpp
@@ -98,11 +98,7 @@ namespace Vireo
     {
         src = src >= 0 ? src : 0;
         auto destEnumCount = static_cast<TDest>(destTypeRef->GetEnumItemCount());
-#pragma warning(push)
-#pragma warning(disable : 4018)  // Warning C4018 '>=': signed / unsigned mismatch
-        // It is safe to disable this warning because 'src' should be >= 0 here.
-        TDest dest = (src >= destEnumCount) ? destEnumCount - 1 : static_cast<TDest>(src);
-#pragma warning(pop)
+        TDest dest = (static_cast<UInt32>(src) >= static_cast<UInt32>(destEnumCount)) ? destEnumCount - 1 : static_cast<TDest>(src);
         return dest;
     }
 

--- a/source/core/Math.cpp
+++ b/source/core/Math.cpp
@@ -412,18 +412,7 @@ DECLARE_SCALE2X_INTN_HELPER(Single)
 #define DECLARE_VIREO_FLOAT_TO_INT_CONVERSION_PRIMITIVE(DEST, SOURCE) \
     VIREO_FUNCTION_SIGNATURE2(SOURCE##Convert##DEST, SOURCE, DEST) \
     { \
-        SOURCE src = _Param(0); \
-        if (std::isnan(src)) { \
-            _Param(1) = numeric_limits<DEST>::max(); \
-        } else if (std::isinf(src)) { \
-            _Param(1) = src < 0 ? numeric_limits<DEST>::min() : numeric_limits<DEST>::max(); \
-        } else if (src < numeric_limits<DEST>::min()) { \
-            _Param(1) = numeric_limits<DEST>::min(); \
-        } else if (src > numeric_limits<DEST>::max()) { \
-            _Param(1) = numeric_limits<DEST>::max(); \
-        } else { \
-            _Param(1) = (DEST) RoundToEven(src); \
-        } \
+        _Param(1) = ConvertFloatToInt<SOURCE, DEST>(_Param(0)); \
         return _NextInstruction(); \
     }
 

--- a/source/core/TypeAndDataManager.cpp
+++ b/source/core/TypeAndDataManager.cpp
@@ -785,6 +785,8 @@ Boolean TypeCommon::IsA(TypeRef otherType, Boolean compatibleStructure)
         EncodingEnum thisEncoding = BitEncoding();
         EncodingEnum otherEncoding = otherType->BitEncoding();
 
+        if ((thisEncoding == kEncoding_Enum) != (otherEncoding == kEncoding_Enum))
+            return false;
         if (thisEncoding == kEncoding_Array && otherEncoding == kEncoding_Array) {
             if (this->Rank() != otherType->Rank()) {
                 bMatch = false;

--- a/source/include/TypeAndDataManager.h
+++ b/source/include/TypeAndDataManager.h
@@ -31,6 +31,7 @@ SDG
 #include <cstdlib>  // abs()
 #include <cmath>
 #include <new>       // for new placement
+#include <limits>
 
 #ifdef STL_MAP
     #include <map>
@@ -365,6 +366,24 @@ inline EMSCRIPTEN_NOOPT Single RoundToEven(Single value)
 #else
     return rintf(value);
 #endif
+}
+
+template <typename TSource, typename TDest>
+TDest ConvertFloatToInt(TSource src)
+{
+    TDest dest;
+    if (std::isnan(src)) {
+        dest = std::numeric_limits<TDest>::max();
+    } else if (std::isinf(src)) {
+        dest = src < 0 ? std::numeric_limits<TDest>::min() : std::numeric_limits<TDest>::max();
+    } else if (src < std::numeric_limits<TDest>::min()) {
+        dest = std::numeric_limits<TDest>::min();
+    } else if (src > std::numeric_limits<TDest>::max()) {
+        dest = std::numeric_limits<TDest>::max();
+    } else {
+        dest = static_cast<TDest>(RoundToEven(src));
+    }
+    return dest;
 }
 
 //------------------------------------------------------------

--- a/test-it/ExpectedResults/ConvertFloatToIntegral.vtr
+++ b/test-it/ExpectedResults/ConvertFloatToIntegral.vtr
@@ -1,0 +1,6 @@
+myUInt8=255, error=(false 0)
+myUInt16=65535, error=(false 0)
+myEnum8=7(h), error=(false 0)
+myUInt8=255
+myUInt16=65535
+myEnum8=h

--- a/test-it/ExpectedResults/ConvertFloatToIntegral.vtr
+++ b/test-it/ExpectedResults/ConvertFloatToIntegral.vtr
@@ -1,6 +1,14 @@
-myUInt8=255, error=(false 0)
-myUInt16=65535, error=(false 0)
-myEnum8=7(h), error=(false 0)
-myUInt8=255
-myUInt16=65535
-myEnum8=h
+1: myUInt8=255, error=(false 0)
+2: myInt16=32767, error=(false 0)
+3: myEnum8=7(h), error=(false 0)
+4: myUInt8=255
+5: myInt16=32767
+6: myEnum8=7(h)
+7: myEnum16=258(a258)
+8: myUInt8=2
+9: myDouble=258
+10: myUInt8=0
+11: myUInt8=1
+12: myUInt8=2
+13: myUInt8=1
+14: myEnum16=258(a258)

--- a/test-it/ViaTests/ConvertFloatToIntegral.via
+++ b/test-it/ViaTests/ConvertFloatToIntegral.via
@@ -1,0 +1,43 @@
+define(videf1 dv(.VirtualInstrument (
+    c(
+        e(dv(.Double 258) myDouble)
+        e(.Variant myVar)
+        e(dv(.UInt8 23) myUInt8)
+        e(dv(.UInt8 0) myUInt8Type)
+
+        e(.Variant myVar2)
+        e(dv(.Double 65538) myDouble2)
+        e(dv(.UInt16 23) myUInt16)
+        e(dv(.UInt16 0) myUInt16Type)
+
+        e(dv(Enum8 (a b c d e f g h) 1) myEnum8)
+        e(.ErrorCluster error)
+    )
+    clump(1
+    DataToVariant(myDouble myVar)
+    VariantToData(myVar error myUInt8Type myUInt8)
+    Printf("myUInt8=%z, error=(%z %z)\n" myUInt8 error.status error.code)
+
+    DataToVariant(myDouble2 myVar2)
+    VariantToData(myVar2 error myUInt16Type myUInt16)
+    Printf("myUInt16=%z, error=(%z %z)\n" myUInt16 error.status error.code)
+
+    VariantToData(myVar error myEnum8 myEnum8)
+    Printf("myEnum8=%d(%z), error=(%z %z)\n" myEnum8 myEnum8 error.status error.code)
+
+    Convert(23 myUInt8)
+    Convert(myDouble myUInt8)
+    Printf("myUInt8=%z\n" myUInt8)
+
+    Convert(23 myUInt16)
+    Convert(myDouble2 myUInt16)
+    Printf("myUInt16=%z\n" myUInt16)
+
+    Convert(1 myEnum8)
+    Convert(myDouble myEnum8)
+    Printf("myEnum8=%z\n" myEnum8)
+
+//--- end of vi
+    )
+)))
+enqueue(videf1)

--- a/test-it/ViaTests/ConvertFloatToIntegral.via
+++ b/test-it/ViaTests/ConvertFloatToIntegral.via
@@ -10,32 +10,71 @@ define(videf1 dv(.VirtualInstrument (
         e(dv(.UInt16 23) myUInt16)
         e(dv(.UInt16 0) myUInt16Type)
 
+        e(dv(.Int16 23) myInt16)
+        e(dv(.Int16 0) myInt16Type)
+
         e(dv(Enum8 (a b c d e f g h) 1) myEnum8)
+        e(dv(Enum16 (a0 a1  a2  a3  a4  a5  a6  a7  a8  a9  a10  a11  a12  a13  a14  a15  a16  a17  a18  a19  a20  a21  a22  a23  a24  a25  a26  a27  a28  a29  a30  a31  a32  a33  a34  a35  a36  a37  a38  a39  a40  a41  a42  a43  a44  a45  a46  a47  a48  a49  a50  a51  a52  a53  a54  a55  a56  a57  a58  a59  a60  a61  a62  a63  a64  a65  a66  a67  a68  a69  a70  a71  a72  a73  a74  a75  a76  a77  a78  a79  a80  a81  a82  a83  a84  a85  a86  a87  a88  a89  a90  a91  a92  a93  a94  a95  a96  a97  a98  a99  a100  a101  a102  a103  a104  a105  a106  a107  a108  a109  a110  a111  a112  a113  a114  a115  a116  a117  a118  a119  a120  a121  a122  a123  a124  a125  a126  a127  a128  a129  a130  a131  a132  a133  a134  a135  a136  a137  a138  a139  a140  a141  a142  a143  a144  a145  a146  a147  a148  a149  a150  a151  a152  a153  a154  a155  a156  a157  a158  a159  a160  a161  a162  a163  a164  a165  a166  a167  a168  a169  a170  a171  a172  a173  a174  a175  a176  a177  a178  a179  a180  a181  a182  a183  a184  a185  a186  a187  a188  a189  a190  a191  a192  a193  a194  a195  a196  a197  a198  a199  a200  a201  a202  a203  a204  a205  a206  a207  a208  a209  a210  a211  a212  a213  a214  a215  a216  a217  a218  a219  a220  a221  a222  a223  a224  a225  a226  a227  a228  a229  a230  a231  a232  a233  a234  a235  a236  a237  a238  a239  a240  a241  a242  a243  a244  a245  a246  a247  a248  a249  a250  a251  a252  a253  a254  a255  a256  a257  a258) 1) myEnum16)
         e(.ErrorCluster error)
     )
     clump(1
     DataToVariant(myDouble myVar)
     VariantToData(myVar error myUInt8Type myUInt8)
-    Printf("myUInt8=%z, error=(%z %z)\n" myUInt8 error.status error.code)
+    Printf("1: myUInt8=%z, error=(%z %z)\n" myUInt8 error.status error.code)
 
     DataToVariant(myDouble2 myVar2)
-    VariantToData(myVar2 error myUInt16Type myUInt16)
-    Printf("myUInt16=%z, error=(%z %z)\n" myUInt16 error.status error.code)
+    VariantToData(myVar2 error myInt16Type myInt16)
+    Printf("2: myInt16=%z, error=(%z %z)\n" myInt16 error.status error.code)
 
     VariantToData(myVar error myEnum8 myEnum8)
-    Printf("myEnum8=%d(%z), error=(%z %z)\n" myEnum8 myEnum8 error.status error.code)
+    Printf("3: myEnum8=%u(%z), error=(%z %z)\n" myEnum8 myEnum8 error.status error.code)
 
     Convert(23 myUInt8)
     Convert(myDouble myUInt8)
-    Printf("myUInt8=%z\n" myUInt8)
+    Printf("4: myUInt8=%z\n" myUInt8)
 
-    Convert(23 myUInt16)
-    Convert(myDouble2 myUInt16)
-    Printf("myUInt16=%z\n" myUInt16)
+    Convert(23 myInt16)
+    Convert(myDouble2 myInt16)
+    Printf("5: myInt16=%z\n" myInt16)
 
     Convert(1 myEnum8)
     Convert(myDouble myEnum8)
-    Printf("myEnum8=%z\n" myEnum8)
+    Printf("6: myEnum8=%u(%z)\n" myEnum8 myEnum8)
+
+    Convert(265 myUInt16)
+    Convert(myUInt16 myEnum16)
+    Printf("7: myEnum16=%u(%z)\n" myEnum16 myEnum16)
+
+    Convert(myEnum16 myUInt8)
+    Printf("8: myUInt8=%z\n" myUInt8)
+
+    Convert(myEnum16 myDouble)
+    Printf("9: myDouble=%z\n" myDouble)
+
+    Convert(0 myEnum16)
+    DataToVariant(myEnum16 myVar)
+    VariantToData(myVar error myUInt8Type myUInt8)
+    Printf("10: myUInt8=%z\n" myUInt8)
+
+    Convert(1 myEnum16)
+    DataToVariant(myEnum16 myVar)
+    VariantToData(myVar error myUInt8Type myUInt8)
+    Printf("11: myUInt8=%z\n" myUInt8)
+
+    Convert(2 myEnum16)
+    DataToVariant(myEnum16 myVar)
+    VariantToData(myVar error myUInt8Type myUInt8)
+    Printf("12: myUInt8=%z\n" myUInt8)
+
+    Convert(257 myEnum16)
+    DataToVariant(myEnum16 myVar)
+    VariantToData(myVar error myUInt8Type myUInt8)
+    Printf("13: myUInt8=%z\n" myUInt8)
+
+    Convert(260 myUInt16)
+    DataToVariant(myUInt16 myVar)
+    VariantToData(myVar error myEnum16 myEnum16)
+    Printf("14: myEnum16=%u(%z)\n" myEnum16 myEnum16)
 
 //--- end of vi
     )

--- a/test-it/testList.json
+++ b/test-it/testList.json
@@ -155,6 +155,7 @@
                 "ConstLocalMutabilityErrors.via",
                 "ControlRefBasic.via",
                 "ConvertStringNumber.via",
+                "ConvertFloatToIntegral.via",
                 "CopyAlignmentError.via",
                 "CopyAndReset.via",
                 "CopyingVIs.via",


### PR DESCRIPTION
When VariantToData is used to convert a variant of float to integer, it was not following G's general coercion rules. Fixing it to match the coercion rules and added some tests.