### PR TITLE
Debugging toggles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ To create and release hotfixes, annotated git tags are used; no release branches
 * Fetch new branches and tags from remote.
 ```console
 git remote update -p
-```	
+```
 * Create a local branch (say 'myHotfix') using the same tag as the 'hotfix' ni/VireoSDK branch.
 ```console
 git checkout -b myHotfix v10.1.7
@@ -217,7 +217,7 @@ git cherry-pick ec64f3296e5ee858dbe088768f0ff4fb4afad221
 * Once your PR has been reviewed and approved, the Maintainer will merge your PR into the main hotfix release
 
 #### Maintainer will push a new annotated tag to create the hotfix release
-* If this is the first hotfix for the tag, we need to switch to prerelease first. 
+* If this is the first hotfix for the tag, we need to switch to prerelease first.
   * Manually update the package.json file, append '-hotfix' to the version (10.1.7 becomes 10.1.7-hotfix). Save the file.
   * Run 'npm install' to update the package-lock.json
   * Commit just this change with just package.json and package-lock.json updates.
@@ -336,3 +336,98 @@ The esh.exe build is packaged as a nuget package to make it consumeable in .NET 
     ```
 
 3. After the configuration is saved, when you have a C or C++ filetype open you should see an environment configuration in the bottom right of the status bar. Click the environment configuration to choose the newly added `Emscripten` configuration.
+
+# Debugging toggles
+
+Vireo has toggles that can be turned on to aid in debugging a problem. To turn on a toggle, look in the DebuggingToggles.h file for the toggle definition and change its value from 0 to 1 and then rebuild Vireo.
+
+## VIREO_DEBUG_EXEC_PRINT_INSTRS
+
+Turn on this toggle to print the name of the actual Vireo instructions being executed
+
+The following VIA program when run
+```text
+define (CheckEqual dv(.VirtualInstrument (
+   Locals: c(   // Data Space
+       ce(dv(.Int32 -56)c1)
+       ce(dv(.Int32 -56)c3)
+       e(.Boolean local5)
+   )
+   clump(1
+     IsEQ(c1 c3 local5)
+   )
+)))
+enqueue (CheckEqual)
+```
+
+Will produce output similar to this in the console:
+```console
+Exec: IsEQInt32
+Exec: Done
+```
+
+## VIREO_DEBUG_PARSING_PRINT_OVERLOADS
+
+Turn on this toggle to print the overloads available for an instruction and the overload being selected as the instruction is being parsed. This is helpful when debugging why Vireo is not properly parsing a new Vireo instruction.
+
+The following VIA program when run
+```text
+define (CheckEqual dv(.VirtualInstrument (
+   Locals: c(   // Data Space
+       ce(dv(.Int32 -56)c1)
+       ce(dv(.Int32 -56)c3)
+       e(.Boolean local5)
+   )
+   clump(1
+     IsEQ(c1 c3 local5)
+   )
+)))
+enqueue (CheckEqual)
+```
+
+Will produce output similar to this in the console:
+```console
+=========================================================
+Finding an appropriate overload for 'IsEQ'
+It currently has the following overloads:
+        IsEQBoolean (Boolean, Boolean, Boolean)
+        IsEQRefnum (EventRegRefNum, EventRegRefNum, Boolean)
+        IsEQRefnum (UserEventRefNum, UserEventRefNum, Boolean)
+        IsEQRefnum (ControlRefNum, ControlRefNum, Boolean)
+        IsEQRefnum (JavaScriptStaticRefNum, JavaScriptStaticRefNum, Boolean)
+        IsEQRefnum (JavaScriptDynamicRefNum, JavaScriptDynamicRefNum, Boolean)
+        GenericBinOp (*, *, *)
+                Generic loader
+        IsEQRefnum (QueueRefNum, QueueRefNum, Boolean)
+        IsEQUtf8Char (Utf8Char, Utf8Char, Boolean)
+        IsEQDouble (Double, Double, Boolean)
+        IsEQSingle (Single, Single, Boolean)
+        IsEQInt64 (Int64, Int64, Boolean)
+        IsEQInt32 (Int32, Int32, Boolean)
+        IsEQInt16 (Int16, Int16, Boolean)
+        IsEQInt8 (Int8, Int8, Boolean)
+        IsEQUInt64 (UInt64, UInt64, Boolean)
+        IsEQUInt32 (UInt32, UInt32, Boolean)
+        IsEQUInt16 (UInt16, UInt16, Boolean)
+        IsEQUInt8 (UInt8, UInt8, Boolean)
+
+        trying... IsEQBoolean (Boolean, Boolean, Boolean)
+        trying... IsEQRefnum (EventRegRefNum, EventRegRefNum, Boolean)
+        trying... IsEQRefnum (UserEventRefNum, UserEventRefNum, Boolean)
+        trying... IsEQRefnum (ControlRefNum, ControlRefNum, Boolean)
+        trying... IsEQRefnum (JavaScriptStaticRefNum, JavaScriptStaticRefNum, Boolean)
+        trying... IsEQRefnum (JavaScriptDynamicRefNum, JavaScriptDynamicRefNum, Boolean)
+        trying... IsEQRefnum (QueueRefNum, QueueRefNum, Boolean)
+        trying... IsEQUtf8Char (Utf8Char, Utf8Char, Boolean)
+        trying... IsEQDouble (Double, Double, Boolean)
+        trying... IsEQSingle (Single, Single, Boolean)
+        trying... IsEQInt64 (Int64, Int64, Boolean)
+        trying... IsEQInt32 (Int32, Int32, Boolean)
+        An overload was found.
+=========================================================
+Finding an appropriate overload for 'Done'
+It currently has the following overloads:
+        Done ()
+
+        trying... Done ()
+```

--- a/Vireo_VS/VireoCommandLine.vcxproj
+++ b/Vireo_VS/VireoCommandLine.vcxproj
@@ -80,6 +80,7 @@
     <ClInclude Include="..\source\include\DataReflectionVisitor.h" />
     <ClInclude Include="..\source\include\DataTypes.h" />
     <ClInclude Include="..\source\include\Date.h" />
+    <ClInclude Include="..\source\include\DebuggingToggles.h" />
     <ClInclude Include="..\source\include\DualTypeConversion.h" />
     <ClInclude Include="..\source\include\EventLog.h" />
     <ClInclude Include="..\source\include\Events.h" />

--- a/Vireo_VS/VireoCommandLine.vcxproj.filters
+++ b/Vireo_VS/VireoCommandLine.vcxproj.filters
@@ -286,5 +286,8 @@
     <ClInclude Include="..\source\include\DualTypeConversion.h">
       <Filter>VireoSource\Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\source\include\DebuggingToggles.h">
+      <Filter>VireoSource\Include</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/source/CommandLine/main.cpp
+++ b/source/CommandLine/main.cpp
@@ -10,6 +10,7 @@ SDG
 #include "ExecutionContext.h"
 #include "TDCodecVia.h"
 #include "UnitTest.h"
+#include "DebuggingToggles.h"
 
 #if kVireoOS_emscripten
     #include <emscripten.h>

--- a/source/core/ExecutionContext.cpp
+++ b/source/core/ExecutionContext.cpp
@@ -14,11 +14,11 @@ SDG
 #include "TypeDefiner.h"
 #include "ExecutionContext.h"
 #include "VirtualInstrument.h"
+#include "DebuggingToggles.h"
+
 #if kVireoOS_emscripten
 #include <emscripten.h>
 #endif
-
-#define VIREO_DEBUG_EXEC_PRINT_INSTRS 0  // Turn on to print each instruction as it is executed to console
 
 namespace Vireo {
 

--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -29,6 +29,7 @@ SDG
 #include "VirtualInstrument.h"  // TODO(PaulAustin): remove once it is all driven by the type system.
 #include "Variants.h"
 #include "StringUtilities.h"
+#include "DebuggingToggles.h"
 
 #if !kVireoOS_windows
     #include <math.h>
@@ -1821,12 +1822,11 @@ void TDViaParser::ParseClump(VIClump* viClump, InstructionAllocator* cia)
                 }
             }
             InstructionCore* instruction = state.EmitInstruction();
-#ifdef VIREO_DEBUG_PARSING_PRINT_OVERLOADS
+#if VIREO_DEBUG_PARSING_PRINT_OVERLOADS
             if (cia->IsCalculatePass()) {
                 if (instruction) {
                     gPlatform.IO.Printf("\tAn overload was found.\n");
-                }
-                else {
+                } else {
                     gPlatform.IO.Printf("\tAn overload wasn't found. Unable to generate instruction.\n");
                 }
             }

--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -28,6 +28,7 @@ SDG
 
 #include "VirtualInstrument.h"  // TODO(PaulAustin): remove once it is all driven by the type system.
 #include "Variants.h"
+#include "StringUtilities.h"
 
 #if !kVireoOS_windows
     #include <math.h>
@@ -1820,6 +1821,16 @@ void TDViaParser::ParseClump(VIClump* viClump, InstructionAllocator* cia)
                 }
             }
             InstructionCore* instruction = state.EmitInstruction();
+#ifdef VIREO_DEBUG_PARSING_PRINT_OVERLOADS
+            if (cia->IsCalculatePass()) {
+                if (instruction) {
+                    gPlatform.IO.Printf("\tAn overload was found.\n");
+                }
+                else {
+                    gPlatform.IO.Printf("\tAn overload wasn't found. Unable to generate instruction.\n");
+                }
+            }
+#endif
             if (!instruction) {
                 LOG_EVENTV(kSoftDataError, "Instruction not generated '%.*s'", FMT_LEN_BEGIN(&instructionNameToken));
             }

--- a/source/core/VirtualInstrument.cpp
+++ b/source/core/VirtualInstrument.cpp
@@ -15,6 +15,7 @@ SDG
 #include "ExecutionContext.h"
 #include "VirtualInstrument.h"
 #include "Events.h"
+#include "DebuggingToggles.h"
 
 namespace Vireo
 {
@@ -427,7 +428,7 @@ void ClumpParseState::SetClumpFireCount(Int32 fireCount) const
 //------------------------------------------------------------
 TypeRef ClumpParseState::ReresolveInstruction(SubString* opName)
 {
-#ifdef VIREO_DEBUG_PARSING_PRINT_OVERLOADS
+#if VIREO_DEBUG_PARSING_PRINT_OVERLOADS
     if (_cia->IsCalculatePass()) {
         gPlatform.IO.Printf("The instruction has been substituted with '%.*s'\n", FMT_LEN_BEGIN(opName));
     }
@@ -447,7 +448,7 @@ TypeRef ClumpParseState::ReresolveInstruction(SubString* opName)
 
     return _instructionType;
 }
-#ifdef VIREO_DEBUG_PARSING_PRINT_OVERLOADS
+#if VIREO_DEBUG_PARSING_PRINT_OVERLOADS
 //------------------------------------------------------------
 static void PrintOverload(ConstCStr outputPrefix, NamedTypeRef overload, TypeRef baseVIType, Boolean isCalculatePass)
 {
@@ -462,8 +463,7 @@ static void PrintOverload(ConstCStr outputPrefix, NamedTypeRef overload, TypeRef
             TypeRef instructionType = overload->GetSubElement(0);
             parameters = instructionType;
             gPlatform.IO.Printf("%.*s (", FMT_LEN_BEGIN(&instructionType->Name()));
-        }
-        else {
+        } else {
             InstructionFunction  instructionfunction;
             overload->InitData(&instructionfunction);
             SubString cName;
@@ -483,12 +483,9 @@ static void PrintOverload(ConstCStr outputPrefix, NamedTypeRef overload, TypeRef
             }
         }
         gPlatform.IO.Printf(")");
-
-    }
-    else if (overload->IsA(baseVIType)) {
+    } else if (overload->IsA(baseVIType)) {
         gPlatform.IO.Printf("%.*s - SubVI Call", FMT_LEN_BEGIN(&overload->Name()));
-    }
-    else if (overload->IsString()) {
+    } else if (overload->IsString()) {
         StringRef *str = static_cast<StringRef*>(overload->Begin(kPARead));
         if (str) {
             SubString subString = (*str)->MakeSubStringAlias();
@@ -566,7 +563,7 @@ TypeRef ClumpParseState::StartNextOverload()
             t = _clump->TheTypeManager()->FindTypeCore(&ss);
         }
     }
-#ifdef VIREO_DEBUG_PARSING_PRINT_OVERLOADS
+#if VIREO_DEBUG_PARSING_PRINT_OVERLOADS
     PrintOverload("\ttrying... ", t, _baseViType, _cia->IsCalculatePass());
 #endif
     return _instructionType;
@@ -585,7 +582,7 @@ TypeRef ClumpParseState::StartInstruction(SubString* opName)
         }
     }
     _hasMultipleDefinitions = _nextFunctionDefinition ? _nextFunctionDefinition->NextOverload() != nullptr : false;
-#ifdef VIREO_DEBUG_PARSING_PRINT_OVERLOADS
+#if VIREO_DEBUG_PARSING_PRINT_OVERLOADS
     PrintOverloads(opName, _clump->TheTypeManager(), _baseViType, _cia->IsCalculatePass());
 #endif
     return StartNextOverload();

--- a/source/core/VirtualInstrument.cpp
+++ b/source/core/VirtualInstrument.cpp
@@ -427,6 +427,11 @@ void ClumpParseState::SetClumpFireCount(Int32 fireCount) const
 //------------------------------------------------------------
 TypeRef ClumpParseState::ReresolveInstruction(SubString* opName)
 {
+#ifdef VIREO_DEBUG_PARSING_PRINT_OVERLOADS
+    if (_cia->IsCalculatePass()) {
+        gPlatform.IO.Printf("The instruction has been substituted with '%.*s'\n", FMT_LEN_BEGIN(opName));
+    }
+#endif
     // A new instruction function is being substituted for the
     // on original map (used for generics and SubVI calling)
     VIREO_ASSERT(_instructionType != nullptr)
@@ -442,6 +447,76 @@ TypeRef ClumpParseState::ReresolveInstruction(SubString* opName)
 
     return _instructionType;
 }
+#ifdef VIREO_DEBUG_PARSING_PRINT_OVERLOADS
+//------------------------------------------------------------
+static void PrintOverload(ConstCStr outputPrefix, NamedTypeRef overload, TypeRef baseVIType, Boolean isCalculatePass)
+{
+    if (!isCalculatePass)
+        return;
+
+    gPlatform.IO.Printf("%s", outputPrefix);
+    if (overload->BitEncoding() == kEncoding_Pointer) {
+        TypeRef parameters = nullptr;
+        // Native instruction
+        if (overload->PointerType() == kPTGenericFunctionCodeGen) {
+            TypeRef instructionType = overload->GetSubElement(0);
+            parameters = instructionType;
+            gPlatform.IO.Printf("%.*s (", FMT_LEN_BEGIN(&instructionType->Name()));
+        }
+        else {
+            InstructionFunction  instructionfunction;
+            overload->InitData(&instructionfunction);
+            SubString cName;
+            THREAD_TADM()->FindCustomPointerTypeFromValue(static_cast<void*>(instructionfunction), &cName);
+            gPlatform.IO.Printf("%.*s (", FMT_LEN_BEGIN(&cName));
+            parameters = overload->GetSubElement(0);
+        }
+        // Print parameters type
+        if (parameters) {
+            Int32 parametersCount = parameters->SubElementCount();
+            for (int i = 0; i < parametersCount; i++) {
+                TypeRef parameterType = parameters->GetSubElement(i);
+                gPlatform.IO.Printf("%.*s", FMT_LEN_BEGIN(&parameterType->Name()));
+                if (i != parametersCount - 1) {
+                    gPlatform.IO.Printf(", ");
+                }
+            }
+        }
+        gPlatform.IO.Printf(")");
+
+    }
+    else if (overload->IsA(baseVIType)) {
+        gPlatform.IO.Printf("%.*s - SubVI Call", FMT_LEN_BEGIN(&overload->Name()));
+    }
+    else if (overload->IsString()) {
+        StringRef *str = static_cast<StringRef*>(overload->Begin(kPARead));
+        if (str) {
+            SubString subString = (*str)->MakeSubStringAlias();
+            gPlatform.IO.Printf("String: %.*s : ", FMT_LEN_BEGIN(&subString));
+        }
+    }
+
+    if (overload->PointerType() == kPTGenericFunctionCodeGen) {
+        gPlatform.IO.Printf("\n\t\tGeneric loader");
+    }
+    gPlatform.IO.Printf("\n");
+}
+//------------------------------------------------------------
+static void PrintOverloads(SubString* opName, TypeManagerRef typeManagerRef, TypeRef baseVIType, Boolean isCalculatePass)
+{
+    if (!isCalculatePass)
+        return;
+
+    NamedTypeRef originalFunctionDefinition = typeManagerRef->FindTypeCore(opName, true);
+    gPlatform.IO.Printf("=========================================================\n");
+    gPlatform.IO.Printf("Finding an appropriate overload for '%.*s'\n", FMT_LEN_BEGIN(opName));
+    gPlatform.IO.Printf("It currently has the following overloads:\n");
+    for (NamedTypeRef overload = originalFunctionDefinition; overload; overload = overload->NextOverload()) {
+        PrintOverload("\t", overload, baseVIType, isCalculatePass);
+    }
+    gPlatform.IO.Printf("\n");
+}
+#endif  // VIREO_DEBUG_PARSING_PRINT_OVERLOADS
 //------------------------------------------------------------
 TypeRef ClumpParseState::StartNextOverload()
 {
@@ -491,6 +566,9 @@ TypeRef ClumpParseState::StartNextOverload()
             t = _clump->TheTypeManager()->FindTypeCore(&ss);
         }
     }
+#ifdef VIREO_DEBUG_PARSING_PRINT_OVERLOADS
+    PrintOverload("\ttrying... ", t, _baseViType, _cia->IsCalculatePass());
+#endif
     return _instructionType;
 }
 //------------------------------------------------------------
@@ -507,6 +585,9 @@ TypeRef ClumpParseState::StartInstruction(SubString* opName)
         }
     }
     _hasMultipleDefinitions = _nextFunctionDefinition ? _nextFunctionDefinition->NextOverload() != nullptr : false;
+#ifdef VIREO_DEBUG_PARSING_PRINT_OVERLOADS
+    PrintOverloads(opName, _clump->TheTypeManager(), _baseViType, _cia->IsCalculatePass());
+#endif
     return StartNextOverload();
 }
 //------------------------------------------------------------

--- a/source/include/DebuggingToggles.h
+++ b/source/include/DebuggingToggles.h
@@ -1,0 +1,20 @@
+/**
+
+Copyright (c) 2014-2019 National Instruments Corp.
+
+This software is subject to the terms described in the LICENSE.TXT file
+
+SDG
+*/
+
+/*! \file
+\brief Toggles to aid in debugging
+*/
+
+#ifndef DebuggingToggles_h
+#define DebuggingToggles_h
+
+#define VIREO_DEBUG_PARSING_PRINT_OVERLOADS 0  // Turn on to print overloads to console as VIA instructions are parsed
+#define VIREO_DEBUG_EXEC_PRINT_INSTRS 0  // Turn on to print each instruction as it is executed to console
+
+#endif  // DebuggingToggles_h

--- a/source/include/VirtualInstrument.h
+++ b/source/include/VirtualInstrument.h
@@ -21,7 +21,7 @@ SDG
 #include <vector>
 #include <map>
 
-#define VIREO_DEBUG_PARSING_PRINT_OVERLOADS 1  // Turn on to print overloads to console as VIA instructions are parsed
+#define VIREO_DEBUG_PARSING_PRINT_OVERLOADS 0  // Turn on to print overloads to console as VIA instructions are parsed
 
 namespace Vireo
 {

--- a/source/include/VirtualInstrument.h
+++ b/source/include/VirtualInstrument.h
@@ -21,8 +21,6 @@ SDG
 #include <vector>
 #include <map>
 
-#define VIREO_DEBUG_PARSING_PRINT_OVERLOADS 0  // Turn on to print overloads to console as VIA instructions are parsed
-
 namespace Vireo
 {
 

--- a/source/include/VirtualInstrument.h
+++ b/source/include/VirtualInstrument.h
@@ -21,6 +21,8 @@ SDG
 #include <vector>
 #include <map>
 
+#define VIREO_DEBUG_PARSING_PRINT_OVERLOADS 1  // Turn on to print overloads to console as VIA instructions are parsed
+
 namespace Vireo
 {
 


### PR DESCRIPTION
- Added debugging toggle for printing current overloads and selected overload for instructions being parsed
- Created debugging toggle file to consolidate toggles.
- Moved debugging toggle for printing Vireo instructions as they are executed to the new DebuggingToggles.h file
- Documented these toggles in a new section in the contributing document