### PR TITLE
Update unicode character encoding

### DIFF
--- a/source/core/vireo.loader.staticHelpers.js
+++ b/source/core/vireo.loader.staticHelpers.js
@@ -8,7 +8,7 @@ const encodeIdentifier = function (str) {
         ch = str.charAt(0);
 
     // First character must be encoded if is not a letter [A-Za-z]
-    if (!(codePoint >= 0x41 && codePoint <= 0x5A) && !(codePoint >= 0x61 && codePoint <= 0x7A)) {
+    if (!(codePoint >= 0x41 && codePoint <= 0x5A) && !(codePoint >= 0x61 && codePoint <= 0x7A) && !(codePoint > 0x7F)) {
         encoded += '%' + codePoint.toString(16).toUpperCase();
     } else {
         encoded += ch;

--- a/source/core/vireo.loader.staticHelpers.js
+++ b/source/core/vireo.loader.staticHelpers.js
@@ -1,3 +1,7 @@
+var isCharacterAlphabetOrNonAscii = function (codePoint) {
+    return ((codePoint >= 0x41 && codePoint <= 0x5A) || (codePoint >= 0x61 && codePoint <= 0x7A) || (codePoint > 0x7F));
+};
+
 const encodeIdentifier = function (str) {
     if (typeof str !== 'string' || str === '') {
         throw new Error('Identifier must be a non-empty string. Found: ' + str);
@@ -7,8 +11,8 @@ const encodeIdentifier = function (str) {
         codePoint = str.charCodeAt(0),
         ch = str.charAt(0);
 
-    // First character must be encoded if is not a letter [A-Za-z]
-    if (!(codePoint >= 0x41 && codePoint <= 0x5A) && !(codePoint >= 0x61 && codePoint <= 0x7A) && !(codePoint > 0x7F)) {
+    // First character must be encoded if is not a letter [A-Za-z] or a non-ascii character
+    if (!isCharacterAlphabetOrNonAscii(codePoint)) {
         encoded += '%' + codePoint.toString(16).toUpperCase();
     } else {
         encoded += ch;

--- a/source/core/vireo.loader.staticHelpers.js
+++ b/source/core/vireo.loader.staticHelpers.js
@@ -11,7 +11,6 @@ const encodeIdentifier = function (str) {
         codePoint = str.charCodeAt(0),
         ch = str.charAt(0);
 
-    // First character must be encoded if is not a letter [A-Za-z] or a non-ascii character
     if (!isCharacterAlphabetOrNonAscii(codePoint)) {
         encoded += '%' + codePoint.toString(16).toUpperCase();
     } else {

--- a/source/core/vireo.loader.staticHelpers.js
+++ b/source/core/vireo.loader.staticHelpers.js
@@ -1,4 +1,4 @@
-var isCharacterAlphabetOrNonAscii = function (codePoint) {
+const isCharacterAlphabetOrNonAscii = function (codePoint) {
     return ((codePoint >= 0x41 && codePoint <= 0x5A) || (codePoint >= 0x61 && codePoint <= 0x7A) || (codePoint > 0x7F));
 };
 

--- a/test-it/karma/static/VireoCodec.Test.js
+++ b/test-it/karma/static/VireoCodec.Test.js
@@ -45,6 +45,16 @@ describe('Vireo', function () {
             expect(encoded).toBe('Iñtërnâtiônàlizætiøn☃💩');
         });
 
+        it('does not encode CJK first character', function () {
+            var encoded = staticHelpers.encodeIdentifier('アプリケーション');
+            expect(encoded).toBe('アプリケーション');
+        });
+
+        it('does not encode SMP unicode plane first character', function () {
+            var encoded = staticHelpers.encodeIdentifier('💩💩Iñtërnâtiônàlizætiøn☃💩💩');
+            expect(encoded).toBe('💩💩Iñtërnâtiônàlizætiøn☃💩💩');
+        });
+
         it('url-encodes all other characters', function () {
             var encoded = staticHelpers.encodeIdentifier(' !"#%&\'(),./:;<=>?@[\\]^`{|}~');
             expect(encoded).toBe('%20%21%22%23%25%26%27%28%29%2C%2E%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E%60%7B%7C%7D%7E');


### PR DESCRIPTION
There seems to be a mismatch between the encoding algorithms used by NXG and Vireo. This change makes them behave identically.

Specifically, the first character of a VI's name was being encoded for all non alphanumeric characters. This isn't done on the NXG side. This mismatch causes errors in the peeker/poker code while trying to read values. (see NXG equivalent [here](https://ngsourcebrowser:4110/#NationalInstruments.LabVIEW.VireoTarget/Compiler/Emit/DataBuilder.cs,396))

Relying on existing tests on the Vireo side since to catch regressions. Adding integration test on the ASW side to assert that the issue is fixed.