### PR TITLE
Minor fix for readJSON for the data of variant types

### DIFF
--- a/source/core/TDCodecVia.cpp
+++ b/source/core/TDCodecVia.cpp
@@ -2400,7 +2400,7 @@ void TDViaFormatter::FormatVariant(TypeRef type, void *pData)
 
     TypeRef innerType = variantData->GetInnerType();
     if (innerType) {
-        FormatData(innerType, innerType->Begin(kPARead));
+        FormatData(innerType, variantData->GetInnerData());
     } else {
         _string->AppendCStr("null");
     }

--- a/test-it/karma/fixtures/publicapi/MultipleTypes.via
+++ b/test-it/karma/fixtures/publicapi/MultipleTypes.via
@@ -189,8 +189,12 @@ define (MyVI dv(.VirtualInstrument (
         e(dv(.String 'hi') utf8string)
         e(dv(.String 'key1') key1)
         e(dv(.String 'key2') key2)
+
+        e(dv(.String 'hello world!') variantOfStringData)
+        e(.Variant variantOfString)
     )
     clump(
+        Convert(variantOfStringData variantOfString)
         SetVariantAttribute(wave_Double.attributes key1 attributeValueSimple * *)
         SetVariantAttribute(wave_Double.attributes key2 utf8string * *)
     )

--- a/test-it/karma/publicapi/ReadJson.Test.js
+++ b/test-it/karma/publicapi/ReadJson.Test.js
@@ -620,4 +620,10 @@ describe('The Vireo EggShell readJSON api can read', function () {
             readTest('dataItem_Empty3DArray', [[[]]]);
         });
     });
+
+    describe('variants of type', function () {
+        it('string', function () {
+            readTest('variantOfString', {_data: 'hello world!', _attributes: null});
+        });
+    });
 });


### PR DESCRIPTION
The readJSON implementation for variants did not correctly format the innerData of the variant. This minor change fixes the behavior so the inner value is serialized