### PR TITLE
Update to emscripten 1.39.5

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,9 +17,9 @@ install:
   - pip install tox
   - ps: Start-Process npm "run httpbin" -PassThru
   - git clone https://github.com/juj/emsdk.git
-  - cd emsdk && git checkout 1b1f08f356d3f10d91e50c09dda6d44372ca908c && cd ..
-  - ps: emsdk\emsdk install sdk-1.38.30-64bit
-  - ps: emsdk\emsdk activate sdk-1.38.30-64bit
+  - cd emsdk && git checkout 369013943283939412fb2807bb0d2ded8ebd5a9e && cd ..
+  - ps: emsdk\emsdk install 1.39.5-fastcomp
+  - ps: emsdk\emsdk activate 1.39.5-fastcomp
 platform:
   - Win32
 configuration:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ install:
 - nohup npm run httpbin &
 - gcc -v
 - git clone https://github.com/juj/emsdk.git
-- (cd emsdk && git checkout 1b1f08f356d3f10d91e50c09dda6d44372ca908c)
-- emsdk/emsdk install sdk-1.38.30-64bit
-- emsdk/emsdk activate sdk-1.38.30-64bit
+- (cd emsdk && git checkout 369013943283939412fb2807bb0d2ded8ebd5a9e)
+- emsdk/emsdk install 1.39.5-fastcomp
+- emsdk/emsdk activate 1.39.5-fastcomp
 - cat ~/.emscripten
 - (source emsdk/emsdk_env.sh && emcc -v)
 before_script:

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ The emsdk toolchain is used to cross-compile Vireo to Vireo.js to run in Node.js
 4. From either the extracted folder or the cloned emsdk repository run the following commands:
 
    ```console
-   emsdk install sdk-1.38.30-64bit
-   emsdk activate sdk-1.38.30-64bit
+   emsdk install 1.39.5-fastcomp
+   emsdk activate 1.39.5-fastcomp
    emcc -v # should match the sdk version
    ```
 

--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -69,7 +69,7 @@ EMCC= emcc
 EM_OPTFLAG = -O3
 
 ifeq ($(BUILD), debug)
-   EM_OPTFLAG = -g4 -s ASSERTIONS=2 -s SAFE_HEAP=1
+   EM_OPTFLAG = -g4 -s ASSERTIONS=2 -s SAFE_HEAP=1 -s USE_ES6_IMPORT_META=0
 endif
 
 ifeq ($(BUILD), profile)

--- a/make-it/EmMakefile
+++ b/make-it/EmMakefile
@@ -69,7 +69,7 @@ EMCC= emcc
 EM_OPTFLAG = -O3
 
 ifeq ($(BUILD), debug)
-   EM_OPTFLAG = -g4 -s ASSERTIONS=2 -s SAFE_HEAP=1 -s USE_ES6_IMPORT_META=0
+   EM_OPTFLAG = -g4 -s ASSERTIONS=2 -s SAFE_HEAP=1
 endif
 
 ifeq ($(BUILD), profile)
@@ -93,7 +93,7 @@ ifeq ($(TARGET), wasm32-unknown-emscripten)
 endif
 
 # NO_DYNAMIC_EXECUTION=1 Allows Vireo to be used in CSP environments where eval() is forbidden: https://github.com/kripken/emscripten/blob/master/src/settings.js#L563
-EM_OPT = $(EM_OPTFLAGS) $(TARGET_FLAG) -s NO_EXIT_RUNTIME=1 -std=c++14 -fno-exceptions -Werror --memory-init-file 0 -s NO_DYNAMIC_EXECUTION=1 -s MODULARIZE=1 -s EXPORT_NAME=VireoCreateCoreModule -s EXPORT_ES6=1 --minify 0 -s NO_FILESYSTEM=1 -s ABORTING_MALLOC=0
+EM_OPT = $(EM_OPTFLAGS) $(TARGET_FLAG) -s NO_EXIT_RUNTIME=1 -std=c++14 -fno-exceptions -Werror --memory-init-file 0 -s NO_DYNAMIC_EXECUTION=1 -s MODULARIZE=1 -s EXPORT_NAME=VireoCreateCoreModule -s EXPORT_ES6=1 -s USE_ES6_IMPORT_META=0 --minify 0 -s NO_FILESYSTEM=1 -s ABORTING_MALLOC=0
 EMFLAGS = -I$(INCDIR) -DkVireoOS_emscripten $(EM_OPT)
 EMLIBRARY = --js-library $(CORESOURCEDIR)/library_coreHelpers.js \
             --js-library $(CORESOURCEDIR)/library_eventHelpers.js \

--- a/source/io/FileIO.cpp
+++ b/source/io/FileIO.cpp
@@ -224,7 +224,7 @@ VIREO_FUNCTION_SIGNATURE3(StreamWrite, FileHandle, TypedArrayCoreRef, Int32)
     return _NextInstruction();
 }
 //------------------------------------------------------------
-VIREO_FUNCTION_SIGNATURE4(StreamSetPosition, FileHandle, IntIndex, IntIndex, Int32)
+/*VIREO_FUNCTION_SIGNATURE4(StreamSetPosition, FileHandle, IntIndex, IntIndex, Int32)
 {
     enum StartPositions
     {
@@ -254,6 +254,7 @@ VIREO_FUNCTION_SIGNATURE4(StreamSetPosition, FileHandle, IntIndex, IntIndex, Int
     _Param(3) = (Int32)POSIX_NAME(lseek)(fd, offset, startPosition);
     return _NextInstruction();
 }
+*/
 #ifdef VIREO_FILESYSTEM
 //------------------------------------------------------------
 VIREO_FUNCTION_SIGNATURE2(FileDelete, StringRef, Int32)
@@ -440,7 +441,7 @@ DEFINE_VIREO_BEGIN(FileSystem)
     DEFINE_VIREO_FUNCTION(StreamClose, "p(i(FileHandle)o(Int32))")
 #endif
     //--------
-    DEFINE_VIREO_FUNCTION(StreamSetPosition, "p(i(FileHandle)i(Int32)i(Int32)o(Int32))")
+//    DEFINE_VIREO_FUNCTION(StreamSetPosition, "p(i(FileHandle)i(Int32)i(Int32)o(Int32))")
     DEFINE_VIREO_FUNCTION(StreamRead, "p(i(FileHandle)o(String)o(Int32)o(Int32))")
     DEFINE_VIREO_FUNCTION(StreamWrite, "p(i(FileHandle)i(String)i(Int32)o(Int32))")
 

--- a/source/io/FileIO.cpp
+++ b/source/io/FileIO.cpp
@@ -224,7 +224,7 @@ VIREO_FUNCTION_SIGNATURE3(StreamWrite, FileHandle, TypedArrayCoreRef, Int32)
     return _NextInstruction();
 }
 //------------------------------------------------------------
-/*VIREO_FUNCTION_SIGNATURE4(StreamSetPosition, FileHandle, IntIndex, IntIndex, Int32)
+VIREO_FUNCTION_SIGNATURE4(StreamSetPosition, FileHandle, IntIndex, IntIndex, Int32)
 {
     enum StartPositions
     {
@@ -254,7 +254,7 @@ VIREO_FUNCTION_SIGNATURE3(StreamWrite, FileHandle, TypedArrayCoreRef, Int32)
     _Param(3) = (Int32)POSIX_NAME(lseek)(fd, offset, startPosition);
     return _NextInstruction();
 }
-*/
+
 #ifdef VIREO_FILESYSTEM
 //------------------------------------------------------------
 VIREO_FUNCTION_SIGNATURE2(FileDelete, StringRef, Int32)
@@ -441,7 +441,7 @@ DEFINE_VIREO_BEGIN(FileSystem)
     DEFINE_VIREO_FUNCTION(StreamClose, "p(i(FileHandle)o(Int32))")
 #endif
     //--------
-//    DEFINE_VIREO_FUNCTION(StreamSetPosition, "p(i(FileHandle)i(Int32)i(Int32)o(Int32))")
+    DEFINE_VIREO_FUNCTION(StreamSetPosition, "p(i(FileHandle)i(Int32)i(Int32)o(Int32))")
     DEFINE_VIREO_FUNCTION(StreamRead, "p(i(FileHandle)o(String)o(Int32)o(Int32))")
     DEFINE_VIREO_FUNCTION(StreamWrite, "p(i(FileHandle)i(String)i(Int32)o(Int32))")
 

--- a/source/io/FileIO.cpp
+++ b/source/io/FileIO.cpp
@@ -254,7 +254,6 @@ VIREO_FUNCTION_SIGNATURE4(StreamSetPosition, FileHandle, IntIndex, IntIndex, Int
     _Param(3) = (Int32)POSIX_NAME(lseek)(fd, offset, startPosition);
     return _NextInstruction();
 }
-
 #ifdef VIREO_FILESYSTEM
 //------------------------------------------------------------
 VIREO_FUNCTION_SIGNATURE2(FileDelete, StringRef, Int32)


### PR DESCRIPTION
In emscripten 1.39.0 the build infrastructure used by emscripten was changed which is seen from the name change from `sdk-<version>-64bit` to `<version>-fastcomp`.

In addition the `fastcomp` backend was changed from the default and while still supported has to be explicitly selected.

This change does not effect the underlying clang version 6.0.1 that is used but instead makes sure we are using emscripten versions released on the current infrastructure. The emscripten [changelog shows changes from 1.38.30 to 1.39.5](https://github.com/emscripten-core/emscripten/blob/incoming/ChangeLog.md).

Passing [ASW PR](https://ni.visualstudio.com/DevCentral/_build/results?buildId=272139&_a=summary&view=results).