### PR TITLE
Fix ByteArrayNode WebVI error code to match Desktop

### DIFF
--- a/source/core/NumericString.cpp
+++ b/source/core/NumericString.cpp
@@ -23,7 +23,7 @@
 namespace Vireo {
 
 // Encoding error codes
-enum { kInvalidUTF8CharErr = 1, kByteArrayTypeErr = 1, kCannotConvertErr = 1396 };
+enum { kInvalidUTF8CharErr = 1, kCannotConvertErr = 1396 };
 
 //------------------------------------------------------------
 struct FormatOptions {

--- a/source/core/NumericString.cpp
+++ b/source/core/NumericString.cpp
@@ -2090,7 +2090,7 @@ struct ByteArrayToStringParamBlock : InstructionCore
 static bool CheckUnsupportedEncodingError(ErrorCluster* errorCluster, UInt16 stringEncoding, TypedArrayCoreRef outputArray) {
     if (stringEncoding != 0) {
         if (errorCluster != nullptr) {
-            errorCluster->SetErrorAndAppendCallChain(true, 1, "Encoding type not supported");
+            errorCluster->SetErrorAndAppendCallChain(true, 1396, "Encoding type not supported");
         }
         if (outputArray != nullptr)
             outputArray->Resize1D(0);

--- a/test-it/ExpectedResults/ByteArrayString.vtr
+++ b/test-it/ExpectedResults/ByteArrayString.vtr
@@ -8,9 +8,9 @@ Invalid UTF-8 characters found')>
 5: array = <(255)>
 6: array = <(65 66 67 97 98 99)>, string = <ABCabc>, err = <(false 0 '')>
 7: array = <(65 66 67 97 98 99)>, string = <ABCabc>, err = <(false 0 '')>, isSame=<true>
-8: array = <(65 66 67 97 98 99)>, string = <>, err = <(true 1396 'String To Byte Array in HelloWorld<APPEND>
+8: array = <(65 66 67 97 98 99)>, string = <>, err = <(true 1396 'Byte Array To String in HelloWorld<APPEND>
 Encoding type not supported')>
-9: array = <(65 66 67 97 98 99)>, err = <(true 1396 'String To Byte Array in HelloWorld<APPEND>
+9: array = <(65 66 67 97 98 99)>, err = <(true 1396 'Byte Array To String in HelloWorld<APPEND>
 Encoding type not supported')>
 10: array = <()>, string = <ABCabc>, err = <(true 1396 'String To Byte Array in HelloWorld<APPEND>
 Encoding type not supported')>

--- a/test-it/ExpectedResults/ByteArrayString.vtr
+++ b/test-it/ExpectedResults/ByteArrayString.vtr
@@ -1,13 +1,20 @@
-1: array = <(192)>, string = <>, err = <(true 1 'Invalid UTF-8 characters found in HelloWorld')>
-2: array = <(193)>, string = <>, err = <(true 1 'Invalid UTF-8 characters found in HelloWorld')>
+1: array = <(192)>, string = <>, err = <(true 1 'Byte Array To String in HelloWorld<APPEND>
+Invalid UTF-8 characters found')>
+2: array = <(193)>, string = <>, err = <(true 1 'Byte Array To String in HelloWorld<APPEND>
+Invalid UTF-8 characters found')>
 3: array = <(245)>, string = <>
-4: array = <(246)>, err = <(true 1 'Invalid UTF-8 characters found in HelloWorld')>
+4: array = <(246)>, err = <(true 1 'Byte Array To String in HelloWorld<APPEND>
+Invalid UTF-8 characters found')>
 5: array = <(255)>
 6: array = <(65 66 67 97 98 99)>, string = <ABCabc>, err = <(false 0 '')>
 7: array = <(65 66 67 97 98 99)>, string = <ABCabc>, err = <(false 0 '')>, isSame=<true>
-8: array = <(65 66 67 97 98 99)>, string = <>, err = <(true 1396 'Encoding type not supported in HelloWorld')>
-9: array = <(65 66 67 97 98 99)>, err = <(true 1396 'Encoding type not supported in HelloWorld')>
-10: array = <()>, string = <ABCabc>, err = <(true 1396 'Encoding type not supported in HelloWorld')>
-11: string = <ABCabc>, err = <(true 1396 'Encoding type not supported in HelloWorld')>
+8: array = <(65 66 67 97 98 99)>, string = <>, err = <(true 1396 'String To Byte Array in HelloWorld<APPEND>
+Encoding type not supported')>
+9: array = <(65 66 67 97 98 99)>, err = <(true 1396 'String To Byte Array in HelloWorld<APPEND>
+Encoding type not supported')>
+10: array = <()>, string = <ABCabc>, err = <(true 1396 'String To Byte Array in HelloWorld<APPEND>
+Encoding type not supported')>
+11: string = <ABCabc>, err = <(true 1396 'String To Byte Array in HelloWorld<APPEND>
+Encoding type not supported')>
 12: string = <ABCabc>
 13: array = <(65 66 67 97 98 99)>, string = <ABCabc>

--- a/test-it/ExpectedResults/ByteArrayString.vtr
+++ b/test-it/ExpectedResults/ByteArrayString.vtr
@@ -5,9 +5,9 @@
 5: array = <(255)>
 6: array = <(65 66 67 97 98 99)>, string = <ABCabc>, err = <(false 0 '')>
 7: array = <(65 66 67 97 98 99)>, string = <ABCabc>, err = <(false 0 '')>, isSame=<true>
-8: array = <(65 66 67 97 98 99)>, string = <>, err = <(true 1 'Encoding type not supported in HelloWorld')>
-9: array = <(65 66 67 97 98 99)>, err = <(true 1 'Encoding type not supported in HelloWorld')>
-10: array = <()>, string = <ABCabc>, err = <(true 1 'Encoding type not supported in HelloWorld')>
-11: string = <ABCabc>, err = <(true 1 'Encoding type not supported in HelloWorld')>
+8: array = <(65 66 67 97 98 99)>, string = <>, err = <(true 1396 'Encoding type not supported in HelloWorld')>
+9: array = <(65 66 67 97 98 99)>, err = <(true 1396 'Encoding type not supported in HelloWorld')>
+10: array = <()>, string = <ABCabc>, err = <(true 1396 'Encoding type not supported in HelloWorld')>
+11: string = <ABCabc>, err = <(true 1396 'Encoding type not supported in HelloWorld')>
 12: string = <ABCabc>
 13: array = <(65 66 67 97 98 99)>, string = <ABCabc>


### PR DESCRIPTION
A developer noticed that the error code for the Web ByteArray node was 1 while desktop is 1396 (AzDo bug 1068756).
This change switches the error code and updates the tests.