### PR TITLE
Example VIA in documentation does not run

### DIFF
--- a/docs/Intro.md
+++ b/docs/Intro.md
@@ -34,7 +34,7 @@ define (HelloWorld dv(.VirtualInstrument (
         e(dv(String 'hello, world') variable1)
     )
     clump(1
-        Print(variable1)
+        Println(variable1)
     )
 ) ) )
 enqueue (HelloWorld)

--- a/docs/IntroArrayExamples.md
+++ b/docs/IntroArrayExamples.md
@@ -16,23 +16,23 @@ define (ArrayDemo, dv(.VirtualInstrument, (
         e(a(Int32 *)     variableArray1d)
         e(a(Int32 5)     fixedArray1d)
         e(a(Int32 -5)    boundedArray1d)
-    
+
         // Variable size arrays size to fit initializer list
         e(dv(a(Int32 *) (1 2 3 4))  variableArray1dwithDefaults)
-    
+
         // Extra initializers added as needed
         e(dv(a(Int32 5) (1 2 3 4))  fixedArray1dwithDefaults)
-    
+
         // Size set by number of initializers
         e(dv(a(Int32 -5) (1 2 3 4)) boundedArray1dwithDefaults)
     )
     clump(
-        Print(variableArray1d)
-        Print(fixedArray1d)
-        Print(boundedArray1d)        
-        Print(variableArray1dwithDefaults)
-        Print(fixedArray1dwithDefaults)
-        Print(boundedArray1dwithDefaults)
+        Println(variableArray1d)
+        Println(fixedArray1d)
+        Println(boundedArray1d)        
+        Println(variableArray1dwithDefaults)
+        Println(fixedArray1dwithDefaults)
+        Println(boundedArray1dwithDefaults)
    )
 ) ) )
 enqueue (ArrayDemo)

--- a/docs/IntroParallelClumpExamples.md
+++ b/docs/IntroParallelClumpExamples.md
@@ -18,7 +18,7 @@ define (Parallel dv(.VirtualInstrument (
         e(v(Int32 500)  fiveHundred)
         e(v(String 'Pat you head.') sHead)
         e(v(String 'Rub your tummy.') sTummy)
-    ) 
+    )
     clump(              // Clump 0 (the root clump)
          Trigger(1)     // Trigger Clump #1        
          WaitMilliseconds(fiveHundred)
@@ -28,13 +28,13 @@ define (Parallel dv(.VirtualInstrument (
     )
     clump(              // Clump 1
         Perch(0)        // Labels are scoped to a clump, this is Label 0
-        Print(sHead)
+        Println(sHead)
         WaitMilliseconds(oneThousand)
         Branch(0)       // Branch to Perch 0
-    ) 
+    )
     clump(              // Clump 2
         Perch(0)
-        Print(sTummy)
+        Println(sTummy)
         WaitMilliseconds(oneThousand)
         Branch(0)
     )

--- a/docs/IntroTypeExamples.md
+++ b/docs/IntroTypeExamples.md
@@ -19,7 +19,7 @@ define (CalcUsingIntegers  dv(.VirtualInstrument  (
     )
     clump(1
         MulInt32(i j k)
-        Print(k)
+        Println(k)
     )
 ) ) )
 
@@ -31,7 +31,7 @@ define (CalcUsingDoubles  dv(.VirtualInstrument  (
     )
     clump(1
         MulDouble(x y z)
-        Print(z)
+        Println(z)
    )
 ) ) )
 
@@ -64,9 +64,9 @@ define (Calc  dv(.VirtualInstrument  (
     )
     clump(1
         Mul(i j k)   // Will resolve to MulInt32 at load time
-        Print(k)
+        Println(k)
         Mul(x y z)    // Will resolve to MulDouble at load time
-        Print(k)
+        Println(k)
    )
 ) ) )
 ```
@@ -74,5 +74,5 @@ define (Calc  dv(.VirtualInstrument  (
 ```console
 $esh Calculate.via
 42
-42.000000 
+42.000000
 ```

--- a/docs/TypeManager.md
+++ b/docs/TypeManager.md
@@ -26,12 +26,12 @@ define (Calc  dv(.VirtualInstrument  (
 
     // Specify a clump of instructions. Clumps are raw data used in the VIs definition.
     // They are not types.
-    clump(1 
-        // However, the functions they reference are types . 
+    clump(1
+        // However, the functions they reference are types .
         Mul(i j k)   
-        Print(k)
+        Println(k)
         Mul(x y z)
-        Print(k)
+        Println(k)
     )
 ) ) )
 ```
@@ -68,11 +68,11 @@ Its common to think of an _Equivalence_ as a C union, however, for an Equivalenc
 define(DoubleAtomic     c(e(bb(64 IEEE754B))) )
 
 // A definition that is more detailed
-define(DoubleCluster 
+define(DoubleCluster
     // This cluster contains a BitCluster, a packed set of BitBlock fields.
     c(e(bc(
         // Clusters or BitCluster elements can have field names.
-        e(bb(1  Boolean)      sign) 
+        e(bb(1  Boolean)      sign)
         e(bb(11 BiasedInt)   exponent)
         e(bb(52 Q1)          fraction)
     )))
@@ -89,7 +89,7 @@ Vireo includes built-in definitions for the floating point types _Single_, _Doub
 Internal types used in Vireo also have type definitions. Though the details are not going to be covered here, at the heart of a VirtualInstrument is a cluster of fields.
 
 ```cpp
-define (VirtualInstrument 
+define (VirtualInstrument
     a(c(                               
         e(.ExecutionContext Context)   
         e(a(*) Params)             
@@ -125,11 +125,11 @@ The signatures for internal functions are also defined as standard types. The ty
 // The print function takes one parameter, This is the raw parameter block definition
 //
 //            p(i(StaticTypeAndData))
-// 
+//
 // To bind the type to an actual function it will be part of the following:
 
 DEFINE_VIREO_BEGIN(FileSystem)
-    ... 
+    ...
     DEFINE_VIREO_FUNCTION(Print, "p(i(StaticTypeAndData))");
     ...
 DEFINE_VIREO_END()
@@ -150,10 +150,10 @@ DEFINE_VIREO_BEGIN(IEEE754Math)
     DEFINE_VIREO_GENERIC(Mul, ".GenericBinOp", EmitGenericBinOpInstruction);
     ...
     // The reference runtime does not generate cutoms code on the fly, it relies on
-    // predefined primtitves. So the generic Mul function ends up binding to functions 
+    // predefined primtitves. So the generic Mul function ends up binding to functions
     // like the following:
-    DEFINE_VIREO_FUNCTION(MulInt32,     ".BinOpInt32") 
-    DEFINE_VIREO_FUNCTION(MulDouble,    ".BinOpDouble") 
+    DEFINE_VIREO_FUNCTION(MulInt32,     ".BinOpInt32")
+    DEFINE_VIREO_FUNCTION(MulDouble,    ".BinOpDouble")
 
 DEFINE_VIREO_END()
 ```


### PR DESCRIPTION
Fixes #686 - Example VIA in documentation does not run

Replace deprecated Print() command with Println() in all the example VIA in the documentation

PS - I hope this pull request meets the contributor guidelines. I tried :)