### PR TITLE
Expose private http client manager

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,15 @@
+# Pinned versions using pip freeze by temporarily modifying
+# the tox.ini to run the pip freeze command and copying the output
+
+click==8.1.3
+colorama==0.4.4
+decorator==5.1.1
+Flask==2.1.2
 httpbin==0.5.0
+importlib-metadata==4.11.4
+itsdangerous==2.1.2
+Jinja2==3.1.2
+MarkupSafe==2.1.1
+six==1.16.0
+Werkzeug==2.0.3
+zipp==3.8.0

--- a/source/io/module_httpClient.js
+++ b/source/io/module_httpClient.js
@@ -535,6 +535,10 @@ var assignHttpClient;
             httpClientManager.setXMLHttpRequestImplementation(fn);
         };
 
+        // Make httpClientManager available as a private API
+        // These are internal APIs subject to change: USE AT YOUR OWN RISK
+        Module.httpClient.httpClientManager = httpClientManager;
+
         // NOTE: All of the Module.js* functions  in this file should be called from Vireo only if there is not an existing error
         // unless otherwise stated in the function below
         Module.httpClient.jsHttpClientOpen = function (

--- a/test-it/karma/fixtures/http/OpenHandleCredentialsAdd.via
+++ b/test-it/karma/fixtures/http/OpenHandleCredentialsAdd.via
@@ -1,0 +1,32 @@
+// Copyright (c) 2020 National Instruments
+// SPDX-License-Identifier: MIT
+
+define(MyVI dv(VirtualInstrument (
+    Locals: c(
+        // Shared
+        e(dv(.UInt32 0) handle)
+        e(c(
+            e(.Boolean status)
+            e(.Int32 code)
+            e(.String source)
+        ) error)
+
+        // OpenHandle parameters
+        e('' cookieFile)
+        e('' username)
+        e('' password)
+        e(dv(.UInt32 1) verifyServer)
+        e(dv(.UInt32 1) withCredentials)
+
+        // AddHeader parameters
+        e('' header)
+        e('' value)
+    )
+    clump (
+        HttpClientOpen(cookieFile username password verifyServer handle error)
+        HttpClientConfigCORS(handle withCredentials error)
+        HttpClientAddHeader(handle header value error)
+    )
+) ) )
+
+enqueue(MyVI)

--- a/test-it/karma/publicapi/HttpClient.Test.js
+++ b/test-it/karma/publicapi/HttpClient.Test.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2020 National Instruments
+// SPDX-License-Identifier: MIT
+
+describe('The Vireo HttpClient', function () {
+    'use strict';
+
+    const vireoHelpers = window.vireoHelpers;
+    const vireoRunner = window.testHelpers.vireoRunner;
+    const fixtures = window.testHelpers.fixtures;
+    const httpOpenHandleCredentialsAddViaUrl = fixtures.convertToAbsoluteFromFixturesDir('http/OpenHandleCredentialsAdd.via');
+    let vireo;
+
+    beforeAll(function (done) {
+        fixtures.preloadAbsoluteUrls([
+            httpOpenHandleCredentialsAddViaUrl
+        ], done);
+    });
+
+    beforeAll(async function () {
+        vireo = await vireoHelpers.createInstance();
+    });
+
+    afterAll(function () {
+        vireo = undefined;
+    });
+
+    it('exposes the private http client mananger', async function () {
+        const vireoHelpers = window.vireoHelpers;
+        const vireo = await vireoHelpers.createInstance();
+        const httpClientManager = vireo.eggShell.internal_module_do_not_use_or_you_will_be_fired.httpClient.httpClientManager;
+        expect(httpClientManager).toBeDefined();
+    });
+
+    it('exposes the private http client to read header values', async function () {
+        const runSlicesAsync = vireoRunner.rebootAndLoadVia(vireo, httpOpenHandleCredentialsAddViaUrl);
+        const viPathParser = vireoRunner.createVIPathParser(vireo, 'MyVI');
+        const viPathWriter = vireoRunner.createVIPathWriter(vireo, 'MyVI');
+        const username = 'myuser';
+        const password = 'mypassword';
+        const header = 'birdperson';
+        const value = 'in bird culture this is considered a dick move';
+        const withCredentials = 1; // which is boolean true
+        viPathWriter('username', username);
+        viPathWriter('password', password);
+        viPathWriter('header', header);
+        viPathWriter('value', value);
+        viPathWriter('withCredentials', withCredentials);
+
+        const {rawPrint, rawPrintError} = await runSlicesAsync();
+        expect(rawPrint).toBeEmptyString();
+        expect(rawPrintError).toBeEmptyString();
+
+        // handle
+        const handle = viPathParser('handle');
+        expect(handle).toBeGreaterThan(0);
+
+        // error
+        expect(viPathParser('error.status')).toBeFalse();
+        expect(viPathParser('error.code')).toBe(0);
+        expect(viPathParser('error.source')).toBeEmptyString();
+
+        // Get current http client
+        const httpClientManager = vireo.eggShell.internal_module_do_not_use_or_you_will_be_fired.httpClient.httpClientManager;
+        expect(httpClientManager).toBeDefined();
+        const httpClient = httpClientManager.get(handle);
+        expect(httpClient).toBeDefined();
+
+        // A user accessing the internal http client api may be trying to access configured properties
+        // such as username, password, withCredentials, and headers
+        expect(httpClient._username).toBe(username);
+        expect(httpClient._password).toBe(password);
+        expect(httpClient._includeCredentialsDuringCORS).toBe(true);
+        expect(httpClient._headers.get(header)).toBe(value);
+    });
+});


### PR DESCRIPTION
# Description

This PR makes a trivial change of making it possible to access the internal HttpClientManger instance associated with Vireo. It does not make it part of the public API for Vireo but instead makes it possible to access via Vireo's private API.

The intention is to make it feasible to access the state of an HttpClient instance (the configured CORS state, username, password, headers) so that libraries written with the JSLI could access that information (at their own risk) to extend the HttpClient with new nodes (Post Multipart, Patch, Get - Binary, etc).

In addition, this PR pins the httpbin dependencies so that the httpbin server can be installed reliably for testing.

## Testing

The PR includes a test showing how the internal private HttpClientManager and HttpClient can be accessed and validates that the configured states of the HttpClient instance can be observed from the JS context given access to the vireo instance.

I did not run the full ASW test suite for this PR because the change has no functional changes, it only exposes a new property on the vireo private api.