### PR TITLE
Update windows build platform toolset version

### DIFF
--- a/Vireo_VS/VireoCommandLine.vcxproj
+++ b/Vireo_VS/VireoCommandLine.vcxproj
@@ -110,19 +110,19 @@
     <ProjectGuid>{113F876C-CB35-4D2F-A3EF-C72215B288F7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>VireoCommandLine</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>

--- a/Vireo_VS/VireoCommandLine.vcxproj
+++ b/Vireo_VS/VireoCommandLine.vcxproj
@@ -110,7 +110,7 @@
     <ProjectGuid>{113F876C-CB35-4D2F-A3EF-C72215B288F7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>VireoCommandLine</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/Vireo_VS/VireoCommandLine.vcxproj
+++ b/Vireo_VS/VireoCommandLine.vcxproj
@@ -110,7 +110,7 @@
     <ProjectGuid>{113F876C-CB35-4D2F-A3EF-C72215B288F7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>VireoCommandLine</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.22000.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -92,7 +92,7 @@ Notice that vireo.js is created in the `dist` folder based on the `BUILD` type. 
 
 - Visual Studio 2022 with C++ support, specifically:
   - Windows 10 SDK (10.0.20348.0)
-  - MSVC v141 - VS 2017 C++ x64/x86 build tools (v14.16)
+  - MSVC v142 - VS 2019 C++ x64/x86 build tools (v14.29)
 
 ### Building Vireo Windows Native
 


### PR DESCRIPTION
Looks like the [windows build agents updated recently](https://github.com/actions/runner-images/releases/tag/win22%2F20240624.1) and now platform toolset v141 did not resolve anymore giving error:

```
MSBuild version 17.10.4+10fbfbf2e for .NET Framework
Build started 7/3/2024 9:22:16 PM.

     1>Project "D:\a\VireoSDK\VireoSDK\Vireo_VS\VireoCommandLine.sln" on node 1 (default targets).
     1>ValidateSolutionConfiguration:
         Building solution configuration "Debug|Win32".
     1>Project "D:\a\VireoSDK\VireoSDK\Vireo_VS\VireoCommandLine.sln" (1) is building "D:\a\VireoSDK\VireoSDK\Vireo_VS\VireoCommandLine.vcxproj" (2) on node 1 (default targets).
     2>C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.Cpp.WindowsSDK.targets(49,5): error MSB[8](https://github.com/rajsite/VireoSDK/actions/runs/9784974527/job/27017023226#step:6:9)037: The Windows SDK version 10.0.20348.0 for Desktop C++ Win32 Apps was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution".  [D:\a\VireoSDK\VireoSDK\Vireo_VS\VireoCommandLine.vcxproj]
     2>Done Building Project "D:\a\VireoSDK\VireoSDK\Vireo_VS\VireoCommandLine.vcxproj" (default targets) -- FAILED.
     1>Done Building Project "D:\a\VireoSDK\VireoSDK\Vireo_VS\VireoCommandLine.sln" (default targets) -- FAILED.

Build FAILED.

       "D:\a\VireoSDK\VireoSDK\Vireo_VS\VireoCommandLine.sln" (default target) (1) ->
       "D:\a\VireoSDK\VireoSDK\Vireo_VS\VireoCommandLine.vcxproj" (default target) (2) ->
       (_CheckWindowsSDKInstalled target) -> 
         C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.Cpp.WindowsSDK.targets(4[9](https://github.com/rajsite/VireoSDK/actions/runs/9784974527/job/27017023226#step:6:10),5): error MSB8037: The Windows SDK version [10](https://github.com/rajsite/VireoSDK/actions/runs/9784974527/job/27017023226#step:6:11).0.20348.0 for Desktop C++ Win32 Apps was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution".  [D:\a\VireoSDK\VireoSDK\Vireo_VS\VireoCommandLine.vcxproj]

    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:[13](https://github.com/rajsite/VireoSDK/actions/runs/9784974527/job/27017023226#step:6:14).42
```

Which is a not great error because Windows SDK version 10.0.20348.0 is installed but I guess PlatformToolset v141 wasn't. The [installed software list](https://github.com/actions/runner-images/blob/releases/win22/20240624/images/windows/Windows2022-Readme.md) shows a couple things VC++ related at v142 so just went with that